### PR TITLE
Ref #28 network bgp authenticationKey is optional

### DIFF
--- a/docs/resources/network_bgp.md
+++ b/docs/resources/network_bgp.md
@@ -35,7 +35,7 @@ network device and remote service provider
 * `local_asn` - (Required) Local ASN number
 * `remote_ip_address` - (Required) IP address of remote peer
 * `remote_asn` - (Required) Remote ASN number
-* `authentication_key` - (Required) shared key used for BGP peer authentication
+* `authentication_key` - (Optional) shared key used for BGP peer authentication
 
 ## Attributes Reference
 

--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -132,3 +132,11 @@ func getFromEnv(varName string) (string, error) {
 	}
 	return "", fmt.Errorf("environmental variable '%s' is not set", varName)
 }
+
+func copyMap(source map[string]interface{}) map[string]interface{} {
+	target := make(map[string]interface{})
+	for k, v := range source {
+		target[k] = v
+	}
+	return target
+}

--- a/equinix/resource_network_bgp.go
+++ b/equinix/resource_network_bgp.go
@@ -76,8 +76,8 @@ func createNetworkBGPResourceSchema() map[string]*schema.Schema {
 		},
 		networkBGPSchemaNames["AuthenticationKey"]: {
 			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
+			Optional:     true,
+			ValidateFunc: validation.StringLenBetween(6, 60),
 		},
 		networkBGPSchemaNames["State"]: {
 			Type:     schema.TypeString,


### PR DESCRIPTION
@ocobleseqx I've made `authentication_key` field **optional** + updated acceptance test, so in first step it creates BGP peering config **without** `authentication_key`. I've also added second step that updates existing BGP peering with a new auth key.