### PR TITLE
Use Go 1.17 in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@v2.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 sudo: false
 
 go:
-  - 1.14.x
+  - 1.17.x
 
 script:
   - make test


### PR DESCRIPTION
Go 1.16 adds support for darwin-arm64 binaries, might as well go all the way to the latest version.

I believe this should fix #51, but I don't know if there's other parts of your release pipeline.

I've run the unit tests with Go 1.17 locally, and I've also run goreleaser with Go 1.17 and without changing the config it already created darwin-arm64 binaries.

I have not run the acceptance tests, since I don't have a test environment to run them against.