### PR TITLE
add support for running acceptance tests with sandbox/playground tokens

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Example [provider configuration](https://www.terraform.io/docs/configuration/pro
 in `main.tf` file:
 
 ```hcl
-provider equinix {
+provider "equinix" {
   client_id     = "someID"
   client_secret = "someSecret"
 }
@@ -36,20 +36,42 @@ export EQUINIX_API_CLIENTID=someID
 export EQUINIX_API_CLIENTSECRET=someSecret
 ```
 
+### Token Authentication
+
+Token's can be generated for the API Client using the OAuth2 Token features described in the
+[OAuth2 API](https://developer.equinix.com/catalog/accesstokenv1#operation/GetOAuth2AccessToken) documentation.
+
+API tokens can be provided using the `token` provider argument, or the `EQUINIX_API_TOKEN` evironment variable.
+The `client_id` and `client_secret` arguments will be ignored in the presence of a `token` argument.
+
+When testing against the [Equinix Sandbox API](https://developer.equinix.com/environment/sandbox), tokens must be used.
+
+```hcl
+provider "equinix" {
+  token         = "someToken"
+}
+```
+
 ## Argument Reference
 
-The Equinix provider requires a few basic parameters:
+The Equinix provider requires a few basic parameters. While the authentication arguments are
+individually optionally, either `token` or `client_id` and `client_secret` must be defined
+through arguments or environment settings.
 
-- `client_id` - (Required) API Consumer Key available under "My Apps" in
-  developer portal. Argument can be also specified by setting `EQUINIX_API_CLIENTID`
+- `client_id` - (Optional) API Consumer Key available under "My Apps" in
+  developer portal. This argument can also be specified with the `EQUINIX_API_CLIENTID`
   shell environment variable.
 
-- `client_secret` (Required) API Consumer secret available under "My Apps" in
-  developer portal. Argument can be also specified by setting `EQUINIX_API_CLIENTSECRET`
+- `client_secret` (Optional) API Consumer secret available under "My Apps" in
+  developer portal. This argument can also be specified with the `EQUINIX_API_CLIENTSECRET`
+  shell environment variable.
+
+- `token` (Optional) API tokens are generated from API Consumer clients using the [OAuth2 API](https://developer.equinix.com/docs/ecx-getting-started#requesting-access-and-refresh-tokens).
+  This argument can also be specified with the `EQUINIX_API_TOKEN`
   shell environment variable.
 
 - `endpoint` (Optional) The Equinix API base URL to point out desired environment.
-   Argument can be also specified by setting `EQUINIX_API_ENDPOINT`
+   This argument can also be specified with the `EQUINIX_API_ENDPOINT`
    shell environment variable. (Defaults to `https://api.equinix.com`)
 
 - `request_timeout` (Optional) The duration of time, in seconds, that the

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -20,6 +20,7 @@ const (
 	endpointEnvVar      = "EQUINIX_API_ENDPOINT"
 	clientIDEnvVar      = "EQUINIX_API_CLIENTID"
 	clientSecretEnvVar  = "EQUINIX_API_CLIENTSECRET"
+	clientTokenEnvVar   = "EQUINIX_API_TOKEN"
 	clientTimeoutEnvVar = "EQUINIX_API_TIMEOUT"
 )
 
@@ -44,18 +45,25 @@ func Provider() *schema.Provider {
 				Description:  "The Equinix API base URL to point out desired environment. Defaults to https://api.equinix.com",
 			},
 			"client_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				DefaultFunc:  schema.EnvDefaultFunc(clientIDEnvVar, nil),
-				ValidateFunc: validation.StringIsNotEmpty,
-				Description:  "API Consumer Key available under My Apps section in developer portal",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(clientIDEnvVar, nil),
+				// ValidateFunc: validation.StringIsNotEmpty,
+				Description: "API Consumer Key available under My Apps section in developer portal",
 			},
 			"client_secret": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				DefaultFunc:  schema.EnvDefaultFunc(clientSecretEnvVar, nil),
-				ValidateFunc: validation.StringIsNotEmpty,
-				Description:  "API Consumer secret available under My Apps section in developer portal",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(clientSecretEnvVar, nil),
+				// ValidateFunc: validation.StringIsNotEmpty,
+				Description: "API Consumer secret available under My Apps section in developer portal",
+			},
+			"token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(clientTokenEnvVar, nil),
+				// ValidateFunc: validation.StringIsNotEmpty,
+				Description: "API token from the developer sandbox",
 			},
 			"request_timeout": {
 				Type:         schema.TypeInt,
@@ -109,6 +117,9 @@ func configureProvider(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	}
 	if v, ok := d.GetOk("client_secret"); ok {
 		config.ClientSecret = v.(string)
+	}
+	if v, ok := d.GetOk("token"); ok {
+		config.Token = v.(string)
 	}
 	if v, ok := d.GetOk("request_timeout"); ok {
 		config.RequestTimeout = time.Duration(v.(int)) * time.Second

--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -316,6 +316,9 @@ func testAccPreCheck(t *testing.T) {
 	if _, err := getFromEnv(endpointEnvVar); err != nil {
 		t.Fatalf("%s", err)
 	}
+	if _, err := getFromEnv(clientTokenEnvVar); err == nil {
+		return
+	}
 	if _, err := getFromEnv(clientIDEnvVar); err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
 )
 
 require (
@@ -64,7 +65,6 @@ require (
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
-	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84 // indirect
 	golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79 // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/tools v0.1.0 // indirect


### PR DESCRIPTION
This PR investigates what it would look like to support API sandbox / playground tokens:

![image](https://user-images.githubusercontent.com/317653/132879113-92ee161d-304b-4544-ac6c-2caae3859ae4.png)

These can be found in the developer app dashboard: _developer.equinix.com/user/{your id}/apps?refresh_pg_token=true_

I'm not sure if the sandbox provides the necessary state consistency to allow for the acceptance tests to pass.

If _some_ acceptance tests can pass with the playground, we could introduce levels of acceptance testing, gated by environment variables, that cover what is possible.

To test:

```
export EQUINIX_API_ENDPOINT=https://playgroundapi.equinix.com
export EQUINIX_API_TOKEN=..........

make testacc
```


---

I ran into `unsupported state format version: expected "0.1", got "0.2"` and had to address that by updating the version of the TF SDK:

https://github.com/equinix/terraform-provider-metal/issues/155#issuecomment-883265481

---

## TODO

Several other acceptance test variables will need to be explored, such as `TF_ACC_NETWORK_DEVICE_METRO`. It may not be possible to set mock values for all of these (compatible with playground). 

These can be found with `git grep TF_ACC_`.

