### PR TITLE
Add Actions attribute on equinix_ecx_l2_connection

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,6 +70,8 @@ primary, Dot1Q encapsulated connections. Reflected by Fabric connection tests.
 secondary,Dot1Q encapsulated connections. Reflected by Fabric connection tests
 * `TF_ACC_FABRIC_AWS_L2_SP_NAME` alters default name of Equinix Fabric AWS seller
 profile. Reflected by Fabric connection tests
+* `TF_ACC_FABRIC_AWS_AUTH_KEY` alters default authentication key of Equinix Fabric
+AWS l2 connection. Reflected by Fabric connection tests
 * `TF_ACC_FABRIC_L2_AZURE_SP_NAME` alters default name of Equinix Fabric Azure seller
 profile. Reflected by Fabric connection tests.
 * `TF_ACC_FABRIC_GCP1_L2_SP_NAME` alters default name of Equinix Fabric GCP

--- a/equinix/resource_ecx_l2_connection_acc_test.go
+++ b/equinix/resource_ecx_l2_connection_acc_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 const (
-	priPortEnvVar  = "TF_ACC_FABRIC_PRI_PORT_NAME"
-	secPortEnvVar  = "TF_ACC_FABRIC_SEC_PORT_NAME"
-	awsSpEnvVar    = "TF_ACC_FABRIC_AWS_L2_SP_NAME"
-	azureSpEnvVar  = "TF_ACC_FABRIC_AZURE_L2_SP_NAME"
-	gcpOneSpEnvVar = "TF_ACC_FABRIC_GCP1_L2_SP_NAME"
-	gcpTwoSpEnvVar = "TF_ACC_FABRIC_GCP2_L2_SP_NAME"
+	priPortEnvVar    = "TF_ACC_FABRIC_PRI_PORT_NAME"
+	secPortEnvVar    = "TF_ACC_FABRIC_SEC_PORT_NAME"
+	awsSpEnvVar      = "TF_ACC_FABRIC_AWS_L2_SP_NAME"
+	awsAuthKeyEnvVar = "TF_ACC_FABRIC_AWS_AUTH_KEY"
+	azureSpEnvVar    = "TF_ACC_FABRIC_AZURE_L2_SP_NAME"
+	gcpOneSpEnvVar   = "TF_ACC_FABRIC_GCP1_L2_SP_NAME"
+	gcpTwoSpEnvVar   = "TF_ACC_FABRIC_GCP2_L2_SP_NAME"
 )
 
 func init() {
@@ -71,6 +72,7 @@ func TestAccFabricL2Connection_Port_Single_AWS(t *testing.T) {
 	t.Parallel()
 	portName, _ := schema.EnvDefaultFunc(priPortEnvVar, "sit-001-CX-SV1-NL-Dot1q-BO-10G-PRI-JUN-33")()
 	spName, _ := schema.EnvDefaultFunc(awsSpEnvVar, "AWS Direct Connect")()
+	authKey, _ := schema.EnvDefaultFunc(awsAuthKeyEnvVar, "123456789012")()
 	context := map[string]interface{}{
 		"port-resourceName":                "test",
 		"port-name":                        portName.(string),
@@ -82,12 +84,10 @@ func TestAccFabricL2Connection_Port_Single_AWS(t *testing.T) {
 		"connection-notifications":         []string{"marry@equinix.com", "john@equinix.com"},
 		"connection-purchase_order_number": randString(10),
 		"connection-vlan_stag":             randInt(2000),
-		"connection-seller_region":         "us-west-2",
+		"connection-seller_region":         "us-west-1",
 		"connection-seller_metro_code":     "SV",
-		"connection-authorization_key":     "123456789012",
+		"connection-authorization_key":     authKey.(string),
 	}
-	contextWithChanges := copyMap(context)
-	contextWithChanges["connection-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
 	resourceName := fmt.Sprintf("equinix_ecx_l2_connection.%s", context["connection-resourceName"].(string))
 	var testConn ecx.L2Connection
 	resource.Test(t, resource.TestCase{
@@ -102,16 +102,8 @@ func TestAccFabricL2Connection_Port_Single_AWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", ecx.ConnectionStatusProvisioned),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_status"),
 					resource.TestCheckResourceAttrSet(resourceName, "zside_port_uuid"),
-				),
-			},
-			{
-				Config: newTestAccConfig(contextWithChanges).withPort().withConnection().build(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccFabricL2ConnectionExists(resourceName, &testConn),
-					testAccFabricL2ConnectionAttributes(&testConn, contextWithChanges),
-					resource.TestCheckResourceAttr(resourceName, "status", ecx.ConnectionStatusProvisioned),
-					resource.TestCheckResourceAttrSet(resourceName, "provider_status"),
-					resource.TestCheckResourceAttrSet(resourceName, "zside_port_uuid"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.required_data.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.required_data.0.key", "awsConnectionId"),
 				),
 			},
 		},

--- a/equinix/resource_ecx_l2_connection_test.go
+++ b/equinix/resource_ecx_l2_connection_test.go
@@ -168,6 +168,7 @@ func TestFabricL2Connection_flattenSecondary(t *testing.T) {
 			ecxL2ConnectionSchemaNames["AuthorizationKey"]:  input.AuthorizationKey,
 			ecxL2ConnectionSchemaNames["RedundantUUID"]:     input.RedundantUUID,
 			ecxL2ConnectionSchemaNames["RedundancyType"]:    input.RedundancyType,
+			ecxL2ConnectionSchemaNames["Actions"]:           []interface{}{},
 		},
 	}
 

--- a/equinix/resource_ecx_l2_connection_test.go
+++ b/equinix/resource_ecx_l2_connection_test.go
@@ -267,6 +267,47 @@ func TestFabricL2Connection_expandAdditionalInfo(t *testing.T) {
 	assert.Equal(t, expected, out, "Output matches expected result")
 }
 
+func TestFabricL2Connection_flattenActions(t *testing.T) {
+	//given
+	input := []ecx.L2ConnectionAction{
+		{
+			Type:  ecx.String(randString(32)),
+			OperationID: ecx.String(randString(32)),
+			Message: ecx.String(randString(32)),
+			RequiredData:  []ecx.L2ConnectionActionData{
+				{
+					Key: ecx.String(randString(10)),
+					Label: ecx.String(randString(10)),
+					Value: ecx.String(randString(10)),
+					IsEditable: ecx.Bool(true),
+					ValidationPattern: ecx.String(randString(10)),
+				},
+			},
+		},
+	}
+	expected := []interface{}{
+		map[string]interface{}{
+			ecxL2ConnectionActionsSchemaNames["Type"]:  input[0].Type,
+			ecxL2ConnectionActionsSchemaNames["OperationID"]: input[0].OperationID,
+			ecxL2ConnectionActionsSchemaNames["Message"]: input[0].Message,
+			ecxL2ConnectionActionsSchemaNames["RequiredData"]: []interface{}{
+				map[string]interface{}{
+					ecxL2ConnectionActionDataSchemaNames["Key"]:  input[0].RequiredData[0].Key,
+					ecxL2ConnectionActionDataSchemaNames["Label"]: input[0].RequiredData[0].Label,
+					ecxL2ConnectionActionDataSchemaNames["Value"]: input[0].RequiredData[0].Value,
+					ecxL2ConnectionActionDataSchemaNames["IsEditable"]: input[0].RequiredData[0].IsEditable,
+					ecxL2ConnectionActionDataSchemaNames["ValidationPattern"]: input[0].RequiredData[0].ValidationPattern,
+				},
+			},
+		},
+	}
+	//when
+	out := flattenECXL2ConnectionActions(input)
+	//then
+	assert.NotNil(t, out, "Output is not empty")
+	assert.Equal(t, expected, out, "Output matches expected result")
+}
+
 type mockedL2ConnectionUpdateRequest struct {
 	name      string
 	speed     int


### PR DESCRIPTION
This change provides consistency between terraform provider and upstream API and push up https://github.com/equinix/terraform-provider-equinix/pull/64
- This PR includes: 
  - Actions attribute definition
  - Unit testing for TestFabricL2Connection_flattenActions function
  - Updated AWS connection Acceptance test 