### PR TITLE
Added waiter for secondary connection. resolves #84

### DIFF
--- a/equinix/config.go
+++ b/equinix/config.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 )
 
-//Config is the configuration structure used to instantiate the Equinix
-//provider.
+// Config is the configuration structure used to instantiate the Equinix
+// provider.
 type Config struct {
 	BaseURL        string
 	ClientID       string
@@ -24,8 +24,8 @@ type Config struct {
 	ne  ne.Client
 }
 
-//Load function validates configuration structure fields and configures
-//all required API clients.
+// Load function validates configuration structure fields and configures
+// all required API clients.
 func (c *Config) Load(ctx context.Context) error {
 	if c.BaseURL == "" {
 		return fmt.Errorf("baseURL cannot be empty")
@@ -39,7 +39,8 @@ func (c *Config) Load(ctx context.Context) error {
 	authConfig := oauth2.Config{
 		ClientID:     c.ClientID,
 		ClientSecret: c.ClientSecret,
-		BaseURL:      c.BaseURL}
+		BaseURL:      c.BaseURL,
+	}
 	authClient := authConfig.New(ctx)
 	authClient.Timeout = c.requestTimeout()
 	authClient.Transport = logging.NewTransport("Equinix", authClient.Transport)

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -22,8 +22,8 @@ const (
 	clientTimeoutEnvVar = "EQUINIX_API_TIMEOUT"
 )
 
-//resourceDataProvider provies interface to schema.ResourceData
-//for convenient mocking purposes
+// resourceDataProvider provies interface to schema.ResourceData
+// for convenient mocking purposes
 type resourceDataProvider interface {
 	Get(key string) interface{}
 	GetOk(key string) (interface{}, bool)
@@ -31,7 +31,7 @@ type resourceDataProvider interface {
 	GetChange(key string) (interface{}, interface{})
 }
 
-//Provider returns Equinix terraform *schema.Provider
+// Provider returns Equinix terraform *schema.Provider
 func Provider() *schema.Provider {
 	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{

--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testAccProviders map[string]*schema.Provider
-var testAccProvider *schema.Provider
+var (
+	testAccProviders map[string]*schema.Provider
+	testAccProvider  *schema.Provider
+)
 
 type mockedResourceDataProvider struct {
 	actual map[string]interface{}
@@ -61,7 +63,7 @@ func TestProvider(t *testing.T) {
 }
 
 func TestProvider_hasApplicationErrorCode(t *testing.T) {
-	//given
+	// given
 	code := "ERR-505"
 	errors := []rest.ApplicationError{
 		{
@@ -71,44 +73,44 @@ func TestProvider_hasApplicationErrorCode(t *testing.T) {
 			Code: randString(10),
 		},
 	}
-	//when
+	// when
 	result := hasApplicationErrorCode(errors, code)
-	//then
+	// then
 	assert.True(t, result, "Error list contains error with given code")
 }
 
 func TestProvider_stringsFound(t *testing.T) {
-	//given
+	// given
 	needles := []string{"key1", "key5"}
 	hay := []string{"key1", "key2", "Key3", "key4", "key5"}
-	//when
+	// when
 	result := stringsFound(needles, hay)
-	//then
+	// then
 	assert.True(t, result, "Given strings were found")
 }
 
 func TestProvider_atLeastOneStringFound(t *testing.T) {
-	//given
+	// given
 	needles := []string{"key4", "key2"}
 	hay := []string{"key1", "key2"}
-	//when
+	// when
 	result := atLeastOneStringFound(needles, hay)
-	//then
+	// then
 	assert.True(t, result, "Given strings were found")
 }
 
 func TestProvider_stringsFound_negative(t *testing.T) {
-	//given
+	// given
 	needles := []string{"key1", "key6"}
 	hay := []string{"key1", "key2", "Key3", "key4", "key5"}
-	//when
+	// when
 	result := stringsFound(needles, hay)
-	//then
+	// then
 	assert.False(t, result, "Given strings were found")
 }
 
 func TestProvider_resourceDataChangedKeys(t *testing.T) {
-	//given
+	// given
 	keys := []string{"key", "keyTwo", "keyThree"}
 	rd := mockedResourceDataProvider{
 		actual: map[string]interface{}{
@@ -123,14 +125,14 @@ func TestProvider_resourceDataChangedKeys(t *testing.T) {
 	expected := map[string]interface{}{
 		"keyTwo": "newValueTwo",
 	}
-	//when
+	// when
 	result := getResourceDataChangedKeys(keys, rd)
-	//then
+	// then
 	assert.Equal(t, expected, result, "Function returns valid key changes")
 }
 
 func TestProvider_resourceDataListElementChanges(t *testing.T) {
-	//given
+	// given
 	keys := []string{"key", "keyTwo", "keyThree"}
 	listKeyName := "myList"
 	rd := mockedResourceDataProvider{
@@ -157,14 +159,14 @@ func TestProvider_resourceDataListElementChanges(t *testing.T) {
 		"keyTwo":   "newValueTwo",
 		"keyThree": 100,
 	}
-	//when
+	// when
 	result := getResourceDataListElementChanges(keys, listKeyName, 0, rd)
-	//then
+	// then
 	assert.Equal(t, expected, result, "Function returns valid key changes")
 }
 
 func TestProvider_mapChanges(t *testing.T) {
-	//given
+	// given
 	keys := []string{"key", "keyTwo", "keyThree"}
 	old := map[string]interface{}{
 		"key":    "value",
@@ -177,14 +179,14 @@ func TestProvider_mapChanges(t *testing.T) {
 	expected := map[string]interface{}{
 		"key": "newValue",
 	}
-	//when
+	// when
 	result := getMapChangedKeys(keys, old, new)
-	//then
+	// then
 	assert.Equal(t, expected, result, "Function returns valid key changes")
 }
 
 func TestProvider_isEmpty(t *testing.T) {
-	//given
+	// given
 	input := []interface{}{
 		"test",
 		"",
@@ -202,32 +204,32 @@ func TestProvider_isEmpty(t *testing.T) {
 		false,
 		true,
 	}
-	//when then
+	// when then
 	for i := range input {
 		assert.Equal(t, expected[i], isEmpty(input[i]), "Input %v produces expected result %v", input[i], expected[i])
 	}
 }
 
 func TestProvider_setSchemaValueIfNotEmpty(t *testing.T) {
-	//given
+	// given
 	key := "test"
 	s := map[string]*schema.Schema{
 		key: {
 			Type:     schema.TypeString,
 			Optional: true,
-		}}
+		},
+	}
 	var b *int = nil
 	d := schema.TestResourceDataRaw(t, s, make(map[string]interface{}))
-	//when
+	// when
 	setSchemaValueIfNotEmpty(key, b, d)
-	//then
+	// then
 	_, ok := d.GetOk(key)
 	assert.False(t, ok, "Key was not set")
-
 }
 
 func TestProvider_slicesMatch(t *testing.T) {
-	//given
+	// given
 	input := [][][]string{
 		{
 			{"DC", "SV", "FR"},
@@ -251,19 +253,19 @@ func TestProvider_slicesMatch(t *testing.T) {
 		false,
 		true,
 	}
-	//when
+	// when
 	results := make([]bool, len(expected))
 	for i := range input {
 		results[i] = slicesMatch(input[i][0], input[i][1])
 	}
-	//then
+	// then
 	for i := range expected {
 		assert.Equal(t, expected[i], results[i])
 	}
 }
 
 func TestProvider_isRestNotFoundError(t *testing.T) {
-	//given
+	// given
 	input := []error{
 		rest.Error{HTTPCode: http.StatusNotFound, Message: "Not Found"},
 		rest.Error{HTTPCode: http.StatusInternalServerError, Message: "Internal Server Error"},
@@ -274,17 +276,17 @@ func TestProvider_isRestNotFoundError(t *testing.T) {
 		false,
 		false,
 	}
-	//when
+	// when
 	result := make([]bool, len(input))
 	for i := range input {
 		result[i] = isRestNotFoundError(input[i])
 	}
-	//then
+	// then
 	assert.Equal(t, expected, result, "Result matches expected output")
 }
 
 func TestProvider_schemaSetToMap(t *testing.T) {
-	//given
+	// given
 	type item struct {
 		id       string
 		valueOne int
@@ -300,9 +302,9 @@ func TestProvider_schemaSetToMap(t *testing.T) {
 		item{"id3", 0, 100},
 	}
 	set := schema.NewSet(setFunc, items)
-	//when
+	// when
 	list := schemaSetToMap(set)
-	//then
+	// then
 	assert.Equal(t, items[0], list[setFunc(items[0])])
 	assert.Equal(t, items[1], list[setFunc(items[1])])
 	assert.Equal(t, items[2], list[setFunc(items[2])])

--- a/equinix/resource_ecx_l2_connection.go
+++ b/equinix/resource_ecx_l2_connection.go
@@ -553,10 +553,10 @@ func resourceECXL2ConnectionCreate(ctx context.Context, d *schema.ResourceData, 
 	conf := m.(*Config)
 	var diags diag.Diagnostics
 	primary, secondary := createECXL2Connections(d)
-	var primaryID *string
+    var primaryID, secondaryID *string
 	var err error
 	if secondary != nil {
-		primaryID, _, err = conf.ecx.CreateL2RedundantConnection(*primary, *secondary)
+		primaryID, secondaryID, err = conf.ecx.CreateL2RedundantConnection(*primary, *secondary)
 	} else {
 		primaryID, err = conf.ecx.CreateL2Connection(*primary)
 	}
@@ -589,6 +589,19 @@ func resourceECXL2ConnectionCreate(ctx context.Context, d *schema.ResourceData, 
 	if _, err := createStateConf.WaitForStateContext(ctx); err != nil {
 		return diag.Errorf("error waiting for connection (%s) to be created: %s", d.Id(), err)
 	}
+	if ecx.StringValue(secondaryID) != "" {
+        createStateConf.Refresh = func() (interface{}, string, error) {
+            resp, err := conf.ecx.GetL2Connection(ecx.StringValue(secondaryID))
+            if err != nil {
+                return nil, "", err
+            }
+            return resp, ecx.StringValue(resp.Status), nil
+        }
+
+        if _, err := createStateConf.WaitForStateContext(ctx); err != nil {
+            return diag.Errorf("error waiting for secondary connection (%s) to be created: %s", d.Id(), err)
+        }
+    }
 	diags = append(diags, resourceECXL2ConnectionRead(ctx, d, m)...)
 	return diags
 }

--- a/equinix/resource_ecx_l2_connection.go
+++ b/equinix/resource_ecx_l2_connection.go
@@ -389,8 +389,10 @@ func createECXL2ConnectionResourceSchema() map[string]*schema.Schema {
 						ForceNew:     true,
 						Optional:     true,
 						ValidateFunc: validation.StringIsNotEmpty,
-						AtLeastOneOf: []string{ecxL2ConnectionSchemaNames["SecondaryConnection"] + ".0." + ecxL2ConnectionSchemaNames["PortUUID"],
-							ecxL2ConnectionSchemaNames["SecondaryConnection"] + ".0." + ecxL2ConnectionSchemaNames["DeviceUUID"]},
+						AtLeastOneOf: []string{
+							ecxL2ConnectionSchemaNames["SecondaryConnection"] + ".0." + ecxL2ConnectionSchemaNames["PortUUID"],
+							ecxL2ConnectionSchemaNames["SecondaryConnection"] + ".0." + ecxL2ConnectionSchemaNames["DeviceUUID"],
+						},
 						ConflictsWith: []string{ecxL2ConnectionSchemaNames["SecondaryConnection"] + ".0." + ecxL2ConnectionSchemaNames["DeviceUUID"]},
 						Description:   ecxL2ConnectionDescriptions["PortUUID"],
 					},
@@ -494,24 +496,24 @@ func createECXL2ConnectionResourceSchema() map[string]*schema.Schema {
 func createECXL2ConnectionActionsSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		ecxL2ConnectionActionsSchemaNames["Type"]: {
-			Type:         schema.TypeString,
-			Computed:     true,
-			Description:  ecxL2ConnectionActionsDescriptions["Type"],
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: ecxL2ConnectionActionsDescriptions["Type"],
 		},
 		ecxL2ConnectionActionsSchemaNames["OperationID"]: {
-			Type:         schema.TypeString,
-			Computed:     true,
-			Description:  ecxL2ConnectionActionsDescriptions["OperationID"],
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: ecxL2ConnectionActionsDescriptions["OperationID"],
 		},
 		ecxL2ConnectionActionsSchemaNames["Message"]: {
-			Type:         schema.TypeString,
-			Computed:     true,
-			Description:  ecxL2ConnectionActionsDescriptions["Message"],
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: ecxL2ConnectionActionsDescriptions["Message"],
 		},
 		ecxL2ConnectionActionsSchemaNames["RequiredData"]: {
-			Type:         schema.TypeSet,
-			Computed:     true,
-			Description:  ecxL2ConnectionActionsDescriptions["RequiredData"],
+			Type:        schema.TypeSet,
+			Computed:    true,
+			Description: ecxL2ConnectionActionsDescriptions["RequiredData"],
 			Elem: &schema.Resource{
 				Schema: createECXL2ConnectionActionsRequiredDataSchema(),
 			},
@@ -522,29 +524,29 @@ func createECXL2ConnectionActionsSchema() map[string]*schema.Schema {
 func createECXL2ConnectionActionsRequiredDataSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		ecxL2ConnectionActionDataSchemaNames["Key"]: {
-			Type:         schema.TypeString,
-			Computed:     true,
-			Description:  ecxL2ConnectionActionDataDescriptions["Key"],
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: ecxL2ConnectionActionDataDescriptions["Key"],
 		},
 		ecxL2ConnectionActionDataSchemaNames["Label"]: {
-			Type:         schema.TypeString,
-			Computed:     true,
-			Description:  ecxL2ConnectionActionDataDescriptions["Label"],
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: ecxL2ConnectionActionDataDescriptions["Label"],
 		},
 		ecxL2ConnectionActionDataSchemaNames["Value"]: {
-			Type:         schema.TypeString,
-			Computed:     true,
-			Description:  ecxL2ConnectionActionDataDescriptions["Value"],
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: ecxL2ConnectionActionDataDescriptions["Value"],
 		},
 		ecxL2ConnectionActionDataSchemaNames["IsEditable"]: {
-			Type:         schema.TypeBool,
-			Computed:     true,
-			Description:  ecxL2ConnectionActionDataDescriptions["IsEditable"],
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: ecxL2ConnectionActionDataDescriptions["IsEditable"],
 		},
 		ecxL2ConnectionActionDataSchemaNames["ValidationPattern"]: {
-			Type:         schema.TypeString,
-			Computed:     true,
-			Description:  ecxL2ConnectionActionDataDescriptions["ValidationPattern"],
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: ecxL2ConnectionActionDataDescriptions["ValidationPattern"],
 		},
 	}
 }
@@ -553,7 +555,7 @@ func resourceECXL2ConnectionCreate(ctx context.Context, d *schema.ResourceData, 
 	conf := m.(*Config)
 	var diags diag.Diagnostics
 	primary, secondary := createECXL2Connections(d)
-    var primaryID, secondaryID *string
+	var primaryID, secondaryID *string
 	var err error
 	if secondary != nil {
 		primaryID, secondaryID, err = conf.ecx.CreateL2RedundantConnection(*primary, *secondary)
@@ -590,18 +592,18 @@ func resourceECXL2ConnectionCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error waiting for connection (%s) to be created: %s", d.Id(), err)
 	}
 	if ecx.StringValue(secondaryID) != "" {
-        createStateConf.Refresh = func() (interface{}, string, error) {
-            resp, err := conf.ecx.GetL2Connection(ecx.StringValue(secondaryID))
-            if err != nil {
-                return nil, "", err
-            }
-            return resp, ecx.StringValue(resp.Status), nil
-        }
+		createStateConf.Refresh = func() (interface{}, string, error) {
+			resp, err := conf.ecx.GetL2Connection(ecx.StringValue(secondaryID))
+			if err != nil {
+				return nil, "", err
+			}
+			return resp, ecx.StringValue(resp.Status), nil
+		}
 
-        if _, err := createStateConf.WaitForStateContext(ctx); err != nil {
-            return diag.Errorf("error waiting for secondary connection (%s) to be created: %s", d.Id(), err)
-        }
-    }
+		if _, err := createStateConf.WaitForStateContext(ctx); err != nil {
+			return diag.Errorf("error waiting for secondary connection (%s) to be created: %s", d.Id(), err)
+		}
+	}
 	diags = append(diags, resourceECXL2ConnectionRead(ctx, d, m)...)
 	return diags
 }
@@ -641,9 +643,11 @@ func resourceECXL2ConnectionRead(ctx context.Context, d *schema.ResourceData, m 
 func resourceECXL2ConnectionUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	conf := m.(*Config)
 	var diags diag.Diagnostics
-	supportedChanges := []string{ecxL2ConnectionSchemaNames["Name"],
+	supportedChanges := []string{
+		ecxL2ConnectionSchemaNames["Name"],
 		ecxL2ConnectionSchemaNames["Speed"],
-		ecxL2ConnectionSchemaNames["SpeedUnit"]}
+		ecxL2ConnectionSchemaNames["SpeedUnit"],
+	}
 	primaryChanges := getResourceDataChangedKeys(supportedChanges, d)
 	primaryUpdateReq := conf.ecx.NewL2ConnectionUpdateRequest(d.Id())
 	if err := fillFabricL2ConnectionUpdateRequest(primaryUpdateReq, primaryChanges).Execute(); err != nil {
@@ -666,14 +670,14 @@ func resourceECXL2ConnectionDelete(ctx context.Context, d *schema.ResourceData, 
 	if err := conf.ecx.DeleteL2Connection(d.Id()); err != nil {
 		restErr, ok := err.(rest.Error)
 		if ok {
-			//IC-LAYER2-4021 = Connection already deleted
+			// IC-LAYER2-4021 = Connection already deleted
 			if hasApplicationErrorCode(restErr.ApplicationErrors, "IC-LAYER2-4021") {
 				return diags
 			}
 		}
 		return diag.FromErr(err)
 	}
-	//remove secondary connection, don't fail on error as there is no partial state on delete
+	// remove secondary connection, don't fail on error as there is no partial state on delete
 	if redID, ok := d.GetOk(ecxL2ConnectionSchemaNames["RedundantUUID"]); ok {
 		if err := conf.ecx.DeleteL2Connection(redID.(string)); err != nil {
 			diags = append(diags, diag.Diagnostic{
@@ -966,10 +970,10 @@ func flattenECXL2ConnectionActionData(actionData []ecx.L2ConnectionActionData) [
 	transformed := make([]interface{}, 0, len(actionData))
 	for _, data := range actionData {
 		transformed = append(transformed, map[string]interface{}{
-			ecxL2ConnectionActionDataSchemaNames["Key"]:  data.Key,
-			ecxL2ConnectionActionDataSchemaNames["Label"]: data.Label,
-			ecxL2ConnectionActionDataSchemaNames["Value"]: data.Value,
-			ecxL2ConnectionActionDataSchemaNames["IsEditable"]: data.IsEditable,
+			ecxL2ConnectionActionDataSchemaNames["Key"]:               data.Key,
+			ecxL2ConnectionActionDataSchemaNames["Label"]:             data.Label,
+			ecxL2ConnectionActionDataSchemaNames["Value"]:             data.Value,
+			ecxL2ConnectionActionDataSchemaNames["IsEditable"]:        data.IsEditable,
 			ecxL2ConnectionActionDataSchemaNames["ValidationPattern"]: data.ValidationPattern,
 		})
 	}

--- a/equinix/resource_ecx_l2_connection_accepter_test.go
+++ b/equinix/resource_ecx_l2_connection_accepter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRetrieveAWSCredentials_Basic(t *testing.T) {
-	//Given
+	// Given
 	key := "testKey"
 	secret := "testSecret"
 	profileName := "testProfile"
@@ -19,10 +19,10 @@ func TestRetrieveAWSCredentials_Basic(t *testing.T) {
 			ecxL2ConnectionAccepterSchemaNames["Profile"]:   profileName,
 		})
 
-	//when
+	// when
 	creds, err := retrieveAWSCredentials(d)
 
-	//then
+	// then
 	assert.Nil(t, err, "Error is not returned")
 	assert.NotNil(t, creds, "Credentials value is returned")
 	assert.Equal(t, key, creds.AccessKeyID, "AccessKeyID matches")

--- a/equinix/resource_ecx_l2_connection_test.go
+++ b/equinix/resource_ecx_l2_connection_test.go
@@ -52,17 +52,17 @@ func TestFabricL2Connection_createFromResourceData(t *testing.T) {
 		AuthorizationKey:    ecx.String(rawData[ecxL2ConnectionSchemaNames["AuthorizationKey"]].(string)),
 	}
 
-	//when
+	// when
 	primary, secondary := createECXL2Connections(d)
 
-	//then
+	// then
 	assert.NotNil(t, primary, "Primary connection is not nil")
 	assert.Nil(t, secondary, "Secondary connection is nil")
 	assert.Equal(t, expectedPrimary, primary, "Primary connection matches expected result")
 }
 
 func TestFabricL2Connection_updateResourceData(t *testing.T) {
-	//given
+	// given
 	d := schema.TestResourceDataRaw(t, createECXL2ConnectionResourceSchema(), make(map[string]interface{}))
 	input := &ecx.L2Connection{
 		UUID:                ecx.String(randString(36)),
@@ -89,10 +89,10 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 		RedundantUUID:       ecx.String(randString(36)),
 		RedundancyType:      ecx.String(randString(10)),
 	}
-	//when
+	// when
 	err := updateECXL2ConnectionResource(input, nil, d)
 
-	//then
+	// then
 	assert.Nil(t, err, "Update of resource data does not return error")
 	assert.Equal(t, ecx.StringValue(input.UUID), d.Get(ecxL2ConnectionSchemaNames["UUID"]), "UUID matches")
 	assert.Equal(t, ecx.StringValue(input.Name), d.Get(ecxL2ConnectionSchemaNames["Name"]), "Name matches")
@@ -121,7 +121,7 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 }
 
 func TestFabricL2Connection_flattenSecondary(t *testing.T) {
-	//given
+	// given
 	input := &ecx.L2Connection{
 		UUID:             ecx.String(randString(36)),
 		Name:             ecx.String(randString(36)),
@@ -172,16 +172,16 @@ func TestFabricL2Connection_flattenSecondary(t *testing.T) {
 		},
 	}
 
-	//when
+	// when
 	out := flattenECXL2ConnectionSecondary(previousInput, input)
 
-	//then
+	// then
 	assert.NotNil(t, out, "Output is not nil")
 	assert.Equal(t, expected, out, "Output matches expected result")
 }
 
 func TestFabricL2Connection_expandSecondary(t *testing.T) {
-	//given
+	// given
 	input := []interface{}{
 		map[string]interface{}{
 			ecxL2ConnectionSchemaNames["Name"]:              "testName",
@@ -213,16 +213,16 @@ func TestFabricL2Connection_expandSecondary(t *testing.T) {
 		AuthorizationKey:  ecx.String(input[0].(map[string]interface{})[ecxL2ConnectionSchemaNames["AuthorizationKey"]].(string)),
 	}
 
-	//when
+	// when
 	out := expandECXL2ConnectionSecondary(input)
 
-	//then
+	// then
 	assert.NotNil(t, out, "Output is not empty")
 	assert.Equal(t, expected, out, "Output matches expected result")
 }
 
 func TestFabricL2Connection_flattenAdditionalInfo(t *testing.T) {
-	//given
+	// given
 	input := []ecx.L2ConnectionAdditionalInfo{
 		{
 			Name:  ecx.String(randString(32)),
@@ -235,9 +235,9 @@ func TestFabricL2Connection_flattenAdditionalInfo(t *testing.T) {
 			ecxL2ConnectionAdditionalInfoSchemaNames["Value"]: input[0].Value,
 		},
 	}
-	//when
+	// when
 	out := flattenECXL2ConnectionAdditionalInfo(input)
-	//then
+	// then
 	assert.NotNil(t, out, "Output is not empty")
 	assert.Equal(t, expected, out, "Output matches expected result")
 }
@@ -247,7 +247,7 @@ func TestFabricL2Connection_expandAdditionalInfo(t *testing.T) {
 		str := fmt.Sprintf("%v", i)
 		return schema.HashString(str)
 	}
-	//given
+	// given
 	input := schema.NewSet(f, []interface{}{
 		map[string]interface{}{
 			ecxL2ConnectionAdditionalInfoSchemaNames["Name"]:  randString(36),
@@ -261,26 +261,26 @@ func TestFabricL2Connection_expandAdditionalInfo(t *testing.T) {
 			Value: ecx.String(inputList[0].(map[string]interface{})[ecxL2ConnectionAdditionalInfoSchemaNames["Value"]].(string)),
 		},
 	}
-	//when
+	// when
 	out := expandECXL2ConnectionAdditionalInfo(input)
-	//then
+	// then
 	assert.NotNil(t, out, "Output is not empty")
 	assert.Equal(t, expected, out, "Output matches expected result")
 }
 
 func TestFabricL2Connection_flattenActions(t *testing.T) {
-	//given
+	// given
 	input := []ecx.L2ConnectionAction{
 		{
-			Type:  ecx.String(randString(32)),
+			Type:        ecx.String(randString(32)),
 			OperationID: ecx.String(randString(32)),
-			Message: ecx.String(randString(32)),
-			RequiredData:  []ecx.L2ConnectionActionData{
+			Message:     ecx.String(randString(32)),
+			RequiredData: []ecx.L2ConnectionActionData{
 				{
-					Key: ecx.String(randString(10)),
-					Label: ecx.String(randString(10)),
-					Value: ecx.String(randString(10)),
-					IsEditable: ecx.Bool(true),
+					Key:               ecx.String(randString(10)),
+					Label:             ecx.String(randString(10)),
+					Value:             ecx.String(randString(10)),
+					IsEditable:        ecx.Bool(true),
 					ValidationPattern: ecx.String(randString(10)),
 				},
 			},
@@ -288,23 +288,23 @@ func TestFabricL2Connection_flattenActions(t *testing.T) {
 	}
 	expected := []interface{}{
 		map[string]interface{}{
-			ecxL2ConnectionActionsSchemaNames["Type"]:  input[0].Type,
+			ecxL2ConnectionActionsSchemaNames["Type"]:        input[0].Type,
 			ecxL2ConnectionActionsSchemaNames["OperationID"]: input[0].OperationID,
-			ecxL2ConnectionActionsSchemaNames["Message"]: input[0].Message,
+			ecxL2ConnectionActionsSchemaNames["Message"]:     input[0].Message,
 			ecxL2ConnectionActionsSchemaNames["RequiredData"]: []interface{}{
 				map[string]interface{}{
-					ecxL2ConnectionActionDataSchemaNames["Key"]:  input[0].RequiredData[0].Key,
-					ecxL2ConnectionActionDataSchemaNames["Label"]: input[0].RequiredData[0].Label,
-					ecxL2ConnectionActionDataSchemaNames["Value"]: input[0].RequiredData[0].Value,
-					ecxL2ConnectionActionDataSchemaNames["IsEditable"]: input[0].RequiredData[0].IsEditable,
+					ecxL2ConnectionActionDataSchemaNames["Key"]:               input[0].RequiredData[0].Key,
+					ecxL2ConnectionActionDataSchemaNames["Label"]:             input[0].RequiredData[0].Label,
+					ecxL2ConnectionActionDataSchemaNames["Value"]:             input[0].RequiredData[0].Value,
+					ecxL2ConnectionActionDataSchemaNames["IsEditable"]:        input[0].RequiredData[0].IsEditable,
 					ecxL2ConnectionActionDataSchemaNames["ValidationPattern"]: input[0].RequiredData[0].ValidationPattern,
 				},
 			},
 		},
 	}
-	//when
+	// when
 	out := flattenECXL2ConnectionActions(input)
-	//then
+	// then
 	assert.NotNil(t, out, "Output is not empty")
 	assert.Equal(t, expected, out, "Output matches expected result")
 }
@@ -341,16 +341,16 @@ func (m *mockedL2ConnectionUpdateRequest) Execute() error {
 }
 
 func TestFabricL2Connection_fillUpdateRequest(t *testing.T) {
-	//given
+	// given
 	updateReq := mockedL2ConnectionUpdateRequest{}
 	changes := map[string]interface{}{
 		ecxL2ConnectionSchemaNames["Name"]:      randString(32),
 		ecxL2ConnectionSchemaNames["Speed"]:     50,
 		ecxL2ConnectionSchemaNames["SpeedUnit"]: "MB",
 	}
-	//when
+	// when
 	fillFabricL2ConnectionUpdateRequest(&updateReq, changes)
-	//then
+	// then
 	assert.Equal(t, changes[ecxL2ConnectionSchemaNames["Name"]], updateReq.name, "Update request name matches")
 	assert.Equal(t, changes[ecxL2ConnectionSchemaNames["Speed"]], updateReq.speed, "Update request speed matches")
 	assert.Equal(t, changes[ecxL2ConnectionSchemaNames["SpeedUnit"]], updateReq.speedUnit, "Update speed unit matches")

--- a/equinix/resource_ecx_l2_serviceprofile.go
+++ b/equinix/resource_ecx_l2_serviceprofile.go
@@ -382,7 +382,7 @@ func resourceECXL2ServiceProfileDelete(ctx context.Context, d *schema.ResourceDa
 	if err := conf.ecx.DeleteL2ServiceProfile(d.Id()); err != nil {
 		restErr, ok := err.(rest.Error)
 		if ok {
-			//IC-PROFILE-004 =  profile does not exist
+			// IC-PROFILE-004 =  profile does not exist
 			if hasApplicationErrorCode(restErr.ApplicationErrors, "IC-PROFILE-004") {
 				return diags
 			}

--- a/equinix/resource_ecx_l2_serviceprofile_test.go
+++ b/equinix/resource_ecx_l2_serviceprofile_test.go
@@ -89,15 +89,15 @@ func TestFabricL2ServiceProfile_createFromResourceData(t *testing.T) {
 		Ports:                               expandECXL2ServiceProfilePorts(d.Get(ecxL2ServiceProfileSchemaNames["Port"]).(*schema.Set)),
 		SpeedBands:                          expandECXL2ServiceProfileSpeedBands(d.Get(ecxL2ServiceProfileSchemaNames["SpeedBand"]).(*schema.Set)),
 	}
-	//when
+	// when
 	result := createECXL2ServiceProfile(d)
-	//then
+	// then
 	assert.NotNil(t, result, "Result is not nil")
 	assert.Equal(t, expected, *result, "Result matches expected value")
 }
 
 func TestFabricL2ServiceProfile_updateResourceData(t *testing.T) {
-	//given
+	// given
 	d := schema.TestResourceDataRaw(t, createECXL2ServiceProfileResourceSchema(), make(map[string]interface{}))
 	input := ecx.L2ServiceProfile{
 		UUID:                                ecx.String("5d113752-996b-4b59-8e21-8927e7b98058"),
@@ -149,9 +149,9 @@ func TestFabricL2ServiceProfile_updateResourceData(t *testing.T) {
 			},
 		},
 	}
-	//when
+	// when
 	err := updateECXL2ServiceProfileResource(&input, d)
-	//then
+	// then
 	assert.Nil(t, err, "Update of resource data does not return error")
 	assert.Equal(t, ecx.StringValue(input.UUID), d.Get(ecxL2ServiceProfileSchemaNames["UUID"]), "UUID matches")
 	assert.Equal(t, ecx.StringValue(input.State), d.Get(ecxL2ServiceProfileSchemaNames["State"]), "State matches")

--- a/equinix/resource_network_acl_template.go
+++ b/equinix/resource_network_acl_template.go
@@ -359,7 +359,7 @@ func flattenACLTemplateInboundRules(existingRules []ne.ACLTemplateInboundRule, r
 }
 
 func getSubnet(existingRule ne.ACLTemplateInboundRule, rule ne.ACLTemplateInboundRule) *string {
-	var subnet = existingRule.Subnet
+	subnet := existingRule.Subnet
 	if existingRule.Subnet != nil && len(ne.StringValue(existingRule.Subnet)) > 0 {
 		subnet = rule.Subnet
 	}

--- a/equinix/resource_network_acl_template_test.go
+++ b/equinix/resource_network_acl_template_test.go
@@ -31,14 +31,13 @@ func TestNetworkACLTemplate_createFromResourceData(t *testing.T) {
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkACLTemplateSchema(), rawData)
 	d.Set(networkACLTemplateSchemaNames["InboundRules"], flattenACLTemplateInboundRules(expected.InboundRules, expected.InboundRules))
-	//when
+	// when
 	result := createACLTemplate(d)
-	//then
+	// then
 	assert.Equal(t, expected, result, "Created ACL Template matches expected result")
 }
 
 func TestNetworkACLTemplate_updateResourceData(t *testing.T) {
-
 	initial := ne.ACLTemplate{
 		Name:        ne.String("test"),
 		Description: ne.String("testTemplate"),
@@ -84,9 +83,9 @@ func TestNetworkACLTemplate_updateResourceData(t *testing.T) {
 			},
 		},
 	}
-	//when
+	// when
 	err := updateACLTemplateResource(input, d)
-	//then
+	// then
 	assert.Nil(t, err, "Update of resource data does not return error")
 	assert.Equal(t, ne.StringValue(input.Name), d.Get(networkACLTemplateSchemaNames["Name"]), "Name matches")
 	assert.Equal(t, ne.StringValue(input.Description), d.Get(networkACLTemplateSchemaNames["Description"]), "Description matches")
@@ -95,7 +94,7 @@ func TestNetworkACLTemplate_updateResourceData(t *testing.T) {
 }
 
 func TestNetworkACLTemplate_expandInboundRules(t *testing.T) {
-	//given
+	// given
 	input := []interface{}{
 		map[string]interface{}{
 			networkACLTemplateInboundRuleSchemaNames["Subnets"]:  []interface{}{"10.0.0.0/24", "1.1.1.1/32"},
@@ -132,14 +131,13 @@ func TestNetworkACLTemplate_expandInboundRules(t *testing.T) {
 			DstPort:  ne.String(input[1].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["DstPort"]].(string)),
 		},
 	}
-	//when
+	// when
 	result := expandACLTemplateInboundRules(input)
-	//then
+	// then
 	assert.Equal(t, expected, result, "Expanded ACL template inbound rules matches expected result")
 }
 
 func TestNetworkACLTemplate_flattenInboundRules(t *testing.T) {
-
 	input := []ne.ACLTemplateInboundRule{
 		{
 			SeqNo:    ne.Int(1),
@@ -181,9 +179,9 @@ func TestNetworkACLTemplate_flattenInboundRules(t *testing.T) {
 			networkACLTemplateInboundRuleSchemaNames["DstPort"]:  input[1].DstPort,
 		},
 	}
-	//when
+	// when
 	result := flattenACLTemplateInboundRules(initial, input)
-	//then
+	// then
 	assert.Equal(t, expected, result, "Flattened ACL template inbound rules match expected result")
 }
 
@@ -212,8 +210,8 @@ func TestNetworkACLTemplate_flattenDeviceDetails(t *testing.T) {
 			networkACLTemplateDeviceDetailSchemaNames["ACLStatus"]: input[1].ACLStatus,
 		},
 	}
-	//when
+	// when
 	result := flattenACLTemplateDeviceDetails(input)
-	//then
+	// then
 	assert.Equal(t, expected, result, "Flattened ACL template Device Details match expected result")
 }

--- a/equinix/resource_network_bgp.go
+++ b/equinix/resource_network_bgp.go
@@ -174,7 +174,7 @@ func resourceNetworkBGPUpdate(ctx context.Context, d *schema.ResourceData, m int
 }
 
 func resourceNetworkBGPDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	//BGP configuration removal is not possible with NE public APIs
+	// BGP configuration removal is not possible with NE public APIs
 	d.SetId("")
 	return nil
 }

--- a/equinix/resource_network_bgp_test.go
+++ b/equinix/resource_network_bgp_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNetworkBGP_createFromResourceData(t *testing.T) {
-	//given
+	// given
 	expected := ne.BGPConfiguration{
 		ConnectionUUID:    ne.String("6ca8d0df-c71a-4475-a835-53c2df1e6667"),
 		LocalIPAddress:    ne.String("1.1.1.1/32"),
@@ -29,14 +29,14 @@ func TestNetworkBGP_createFromResourceData(t *testing.T) {
 		networkBGPSchemaNames["AuthenticationKey"]: ne.StringValue(expected.AuthenticationKey),
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkBGPResourceSchema(), rawData)
-	//when
+	// when
 	result := createNetworkBGPConfiguration(d)
-	//then
+	// then
 	assert.Equal(t, expected, result, "Created BGP configuration matches expected result")
 }
 
 func TestNetworkBGP_updateResourceData(t *testing.T) {
-	//when
+	// when
 	input := ne.BGPConfiguration{
 		UUID:               ne.String("0cb9759d-58ab-44e6-9c10-6a3cfd18cefb"),
 		DeviceUUID:         ne.String("8895983f-00f9-42f1-a387-85248f2aab49"),
@@ -50,9 +50,9 @@ func TestNetworkBGP_updateResourceData(t *testing.T) {
 		ProvisioningStatus: ne.String(ne.BGPProvisioningStatusProvisioned),
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkBGPResourceSchema(), make(map[string]interface{}))
-	//when
+	// when
 	err := updateNetworkBGPResource(&input, d)
-	//then
+	// then
 	assert.Nil(t, err, "Update of resource data does not return error")
 	assert.Equal(t, ne.StringValue(input.UUID), d.Get(networkBGPSchemaNames["UUID"]), "UUID matches")
 	assert.Equal(t, ne.StringValue(input.DeviceUUID), d.Get(networkBGPSchemaNames["DeviceUUID"]), "DeviceUUID matches")
@@ -101,7 +101,7 @@ func (r *mockedBGPUpdateRequest) Execute() error {
 }
 
 func TestNetworkBGP_createUpdateRequest(t *testing.T) {
-	//given
+	// given
 	req := &mockedBGPUpdateRequest{data: make(map[string]interface{})}
 	f := func(uuid string) ne.BGPUpdateRequest {
 		req.uuid = uuid
@@ -114,9 +114,9 @@ func TestNetworkBGP_createUpdateRequest(t *testing.T) {
 		RemoteASN:         ne.Int(60421),
 		AuthenticationKey: ne.String("secret"),
 	}
-	//when
+	// when
 	createNetworkBGPUpdateRequest(f, &bgp)
-	//then
+	// then
 	assert.Equal(t, ne.StringValue(bgp.RemoteIPAddress), req.data["remoteIPAddress"], "RemoteIPAddress matches")
 	assert.Equal(t, ne.IntValue(bgp.RemoteASN), req.data["remoteASN"], "RemoteASN matches")
 	assert.Equal(t, ne.StringValue(bgp.LocalIPAddress), req.data["localIPAddress"], "LocalIPAddress matches")
@@ -125,7 +125,7 @@ func TestNetworkBGP_createUpdateRequest(t *testing.T) {
 }
 
 func TestNetworkBGP_statusProvisioningWaitConfiguration(t *testing.T) {
-	//given
+	// given
 	bgpID := "test"
 	var queriedID string
 	fetchFunc := func(uuid string) (*ne.BGPConfiguration, error) {
@@ -134,10 +134,10 @@ func TestNetworkBGP_statusProvisioningWaitConfiguration(t *testing.T) {
 	}
 	delay := 100 * time.Millisecond
 	timeout := 10 * time.Minute
-	//when
+	// when
 	waitConfig := createBGPConfigStatusProvisioningWaitConfiguration(fetchFunc, bgpID, delay, timeout)
 	_, err := waitConfig.WaitForStateContext(context.Background())
-	//then
+	// then
 	assert.Nil(t, err, "WaitForState does not return an error")
 	assert.Equal(t, bgpID, queriedID, "Queried device ID matches")
 	assert.Equal(t, timeout, waitConfig.Timeout, "Device status wait configuration timeout matches")

--- a/equinix/resource_network_device.go
+++ b/equinix/resource_network_device.go
@@ -715,9 +715,11 @@ func resourceNetworkDeviceRead(ctx context.Context, d *schema.ResourceData, m in
 func resourceNetworkDeviceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	conf := m.(*Config)
 	var diags diag.Diagnostics
-	supportedChanges := []string{networkDeviceSchemaNames["Name"], networkDeviceSchemaNames["TermLength"],
+	supportedChanges := []string{
+		networkDeviceSchemaNames["Name"], networkDeviceSchemaNames["TermLength"],
 		networkDeviceSchemaNames["Notifications"], networkDeviceSchemaNames["AdditionalBandwidth"],
-		networkDeviceSchemaNames["ACLTemplateUUID"]}
+		networkDeviceSchemaNames["ACLTemplateUUID"],
+	}
 	updateReq := conf.ne.NewDeviceUpdateRequest(d.Id())
 	primaryChanges := getResourceDataChangedKeys(supportedChanges, d)
 	if err := fillNetworkDeviceUpdateRequest(updateReq, primaryChanges).Execute(); err != nil {
@@ -1154,8 +1156,10 @@ func getNetworkDeviceStateChangeConfigs(c ne.Client, deviceID string, timeout ti
 	return configs
 }
 
-type openFile func(name string) (*os.File, error)
-type uploadLicenseFile func(metroCode, deviceTypeCode, deviceManagementMode, licenseMode, fileName string, reader io.Reader) (*string, error)
+type (
+	openFile          func(name string) (*os.File, error)
+	uploadLicenseFile func(metroCode, deviceTypeCode, deviceManagementMode, licenseMode, fileName string, reader io.Reader) (*string, error)
+)
 
 func uploadDeviceLicenseFile(openFunc openFile, uploadFunc uploadLicenseFile, typeCode string, device *ne.Device) error {
 	if device == nil || ne.StringValue(device.LicenseFile) == "" {
@@ -1179,9 +1183,11 @@ func uploadDeviceLicenseFile(openFunc openFile, uploadFunc uploadLicenseFile, ty
 	return nil
 }
 
-type getDevice func(uuid string) (*ne.Device, error)
-type getACL func(uuid string) (*ne.DeviceACLDetails, error)
-type getAdditionalBandwidthDetails func(uuid string) (*ne.DeviceAdditionalBandwidthDetails, error)
+type (
+	getDevice                     func(uuid string) (*ne.Device, error)
+	getACL                        func(uuid string) (*ne.DeviceACLDetails, error)
+	getAdditionalBandwidthDetails func(uuid string) (*ne.DeviceAdditionalBandwidthDetails, error)
+)
 
 func createNetworkDeviceStatusProvisioningWaitConfiguration(fetchFunc getDevice, id string, delay time.Duration, timeout time.Duration) *resource.StateChangeConf {
 	pending := []string{

--- a/equinix/resource_network_device_acc_test.go
+++ b/equinix/resource_network_device_acc_test.go
@@ -46,7 +46,8 @@ func testSweepNetworkDevice(region string) error {
 		ne.DeviceStateProvisioned,
 		ne.DeviceStateProvisioning,
 		ne.DeviceStateWaitingSecondary,
-		ne.DeviceStateFailed})
+		ne.DeviceStateFailed,
+	})
 	if err != nil {
 		log.Printf("[INFO][SWEEPER_LOG] error fetching NetworkDevice list: %s", err)
 		return err

--- a/equinix/resource_network_device_link_test.go
+++ b/equinix/resource_network_device_link_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNetworkDeviceLink_createFromResourceData(t *testing.T) {
-	//given
+	// given
 
 	expected := ne.DeviceLinkGroup{
 		Name:   ne.String("testGroup"),
@@ -45,15 +45,14 @@ func TestNetworkDeviceLink_createFromResourceData(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, createNetworkDeviceLinkResourceSchema(), rawData)
 	d.Set(networkDeviceLinkSchemaNames["Devices"], flattenNetworkDeviceLinkDevices(nil, expected.Devices))
 	d.Set(networkDeviceLinkSchemaNames["Links"], flattenNetworkDeviceLinkConnections(nil, expected.Links))
-	//when
+	// when
 	result := createNetworkDeviceLink(d)
-	//then
+	// then
 	assert.Equal(t, expected, result, "Created device link matches expected result")
-
 }
 
 func TestNetworkDeviceLink_updateResourceData(t *testing.T) {
-	//given
+	// given
 	input := ne.DeviceLinkGroup{
 		UUID:   ne.String("aae04283-10f9-4edb-9395-33681176592b"),
 		Name:   ne.String("testGroup"),
@@ -84,9 +83,9 @@ func TestNetworkDeviceLink_updateResourceData(t *testing.T) {
 		},
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkDeviceLinkResourceSchema(), make(map[string]interface{}))
-	//when
+	// when
 	err := updateNetworkDeviceLinkResource(&input, d)
-	//then
+	// then
 	assert.Nil(t, err, "Update of resource data does not return error")
 	assert.Equal(t, ne.StringValue(input.UUID), d.Get(networkDeviceLinkSchemaNames["UUID"]), "UUID matches")
 	assert.Equal(t, ne.StringValue(input.Name), d.Get(networkDeviceLinkSchemaNames["Name"]), "Name matches")

--- a/equinix/resource_network_device_test.go
+++ b/equinix/resource_network_device_test.go
@@ -76,17 +76,17 @@ func TestNetworkDevice_createFromResourceData(t *testing.T) {
 	d.Set(networkDeviceSchemaNames["UserPublicKey"], flattenNetworkDeviceUserKeys([]*ne.DeviceUserPublicKey{&expectedPrimaryUserKey}))
 	d.Set(networkDeviceSchemaNames["VendorConfiguration"], expectedPrimary.VendorConfiguration)
 
-	//when
+	// when
 	primary, secondary := createNetworkDevices(d)
 
-	//then
+	// then
 	assert.NotNil(t, primary, "Primary device is not nil")
 	assert.Nil(t, secondary, "Secondary device is nil")
 	assert.Equal(t, expectedPrimary, primary, "Primary device matches expected result")
 }
 
 func TestNetworkDevice_updateResourceData(t *testing.T) {
-	//given
+	// given
 	inputPrimary := &ne.Device{
 		Name:                ne.String("device"),
 		TypeCode:            ne.String("CSR1000V"),
@@ -125,10 +125,10 @@ func TestNetworkDevice_updateResourceData(t *testing.T) {
 	d.Set(networkDeviceSchemaNames["Secondary"], flattenNetworkDeviceSecondary(&ne.Device{
 		LicenseFile: ne.String(secondarySchemaLicenseFile),
 	}))
-	//when
+	// when
 	err := updateNetworkDeviceResource(inputPrimary, inputSecondary, d)
 
-	//then
+	// then
 	assert.Nil(t, err, "Update of resource data does not return error")
 	assert.Equal(t, ne.StringValue(inputPrimary.Name), d.Get(networkDeviceSchemaNames["Name"]), "Name matches")
 	assert.Equal(t, ne.StringValue(inputPrimary.TypeCode), d.Get(networkDeviceSchemaNames["TypeCode"]), "TypeCode matches")
@@ -159,7 +159,7 @@ func TestNetworkDevice_updateResourceData(t *testing.T) {
 }
 
 func TestNetworkDevice_flattenSecondary(t *testing.T) {
-	//given
+	// given
 	input := &ne.Device{
 		UUID:                ne.String("0452fa68-8246-48b1-a1b2-817fb4baddcb"),
 		Name:                ne.String("device"),
@@ -247,15 +247,15 @@ func TestNetworkDevice_flattenSecondary(t *testing.T) {
 			networkDeviceSchemaNames["ZoneCode"]: input.ZoneCode,
 		},
 	}
-	//when
+	// when
 	out := flattenNetworkDeviceSecondary(input)
-	//then
+	// then
 	assert.NotNil(t, out, "Output is not nil")
 	assert.Equal(t, expected, out, "Output matches expected result")
 }
 
 func TestNetworkDevice_expandSecondary(t *testing.T) {
-	//given
+	// given
 	f := func(i interface{}) int {
 		str := fmt.Sprintf("%v", i)
 		return schema.HashString(str)
@@ -299,15 +299,15 @@ func TestNetworkDevice_expandSecondary(t *testing.T) {
 		},
 		UserPublicKey: expandNetworkDeviceUserKeys(input[0].(map[string]interface{})[networkDeviceSchemaNames["UserPublicKey"]].(*schema.Set))[0],
 	}
-	//when
+	// when
 	out := expandNetworkDeviceSecondary(input)
-	//then
+	// then
 	assert.NotNil(t, out, "Output is not empty")
 	assert.Equal(t, expected, out, "Output matches expected result")
 }
 
 func TestNetworkDevice_uploadLicenseFile(t *testing.T) {
-	//given
+	// given
 	fileName := "test.lic"
 	licenseFileID := "someTestID"
 	device := &ne.Device{LicenseFile: ne.String("/path/to/" + fileName), MetroCode: ne.String("SV"), TypeCode: ne.String("VSRX")}
@@ -323,9 +323,9 @@ func TestNetworkDevice_uploadLicenseFile(t *testing.T) {
 	openFunc := func(name string) (*os.File, error) {
 		return &os.File{}, nil
 	}
-	//when
+	// when
 	err := uploadDeviceLicenseFile(openFunc, uploadFunc, ne.StringValue(device.TypeCode), device)
-	//then
+	// then
 	assert.Nil(t, err, "License upload function does not return any error")
 	assert.Equal(t, licenseFileID, ne.StringValue(device.LicenseFileID), "Device LicenseFileID matches")
 	assert.Equal(t, ne.StringValue(device.MetroCode), rxMetroCode, "Received metroCode matches")
@@ -336,7 +336,7 @@ func TestNetworkDevice_uploadLicenseFile(t *testing.T) {
 }
 
 func TestNetworkDevice_statusProvisioningWaitConfiguration(t *testing.T) {
-	//given
+	// given
 	deviceID := "test"
 	var queriedDeviceID string
 	fetchFunc := func(uuid string) (*ne.Device, error) {
@@ -345,10 +345,10 @@ func TestNetworkDevice_statusProvisioningWaitConfiguration(t *testing.T) {
 	}
 	delay := 100 * time.Millisecond
 	timeout := 10 * time.Minute
-	//when
+	// when
 	waitConfig := createNetworkDeviceStatusProvisioningWaitConfiguration(fetchFunc, deviceID, delay, timeout)
 	_, err := waitConfig.WaitForStateContext(context.Background())
-	//then
+	// then
 	assert.Nil(t, err, "WaitForState does not return an error")
 	assert.Equal(t, deviceID, queriedDeviceID, "Queried device ID matches")
 	assert.Equal(t, timeout, waitConfig.Timeout, "Device status wait configuration timeout matches")
@@ -356,7 +356,7 @@ func TestNetworkDevice_statusProvisioningWaitConfiguration(t *testing.T) {
 }
 
 func TestNetworkDevice_statusDeleteWaitConfiguration(t *testing.T) {
-	//given
+	// given
 	deviceID := "test"
 	var queriedDeviceID string
 	fetchFunc := func(uuid string) (*ne.Device, error) {
@@ -365,10 +365,10 @@ func TestNetworkDevice_statusDeleteWaitConfiguration(t *testing.T) {
 	}
 	delay := 100 * time.Millisecond
 	timeout := 10 * time.Minute
-	//when
+	// when
 	waitConfig := createNetworkDeviceStatusDeleteWaitConfiguration(fetchFunc, deviceID, delay, timeout)
 	_, err := waitConfig.WaitForStateContext(context.Background())
-	//then
+	// then
 	assert.Nil(t, err, "WaitForState does not return an error")
 	assert.Equal(t, deviceID, queriedDeviceID, "Queried device ID matches")
 	assert.Equal(t, timeout, waitConfig.Timeout, "Device status wait configuration timeout matches")
@@ -376,7 +376,7 @@ func TestNetworkDevice_statusDeleteWaitConfiguration(t *testing.T) {
 }
 
 func TestNetworkDevice_licenseStatusWaitConfiguration(t *testing.T) {
-	//given
+	// given
 	deviceID := "test"
 	var queriedDeviceID string
 	fetchFunc := func(uuid string) (*ne.Device, error) {
@@ -385,10 +385,10 @@ func TestNetworkDevice_licenseStatusWaitConfiguration(t *testing.T) {
 	}
 	delay := 100 * time.Millisecond
 	timeout := 10 * time.Minute
-	//when
+	// when
 	waitConfig := createNetworkDeviceLicenseStatusWaitConfiguration(fetchFunc, deviceID, delay, timeout)
 	_, err := waitConfig.WaitForStateContext(context.Background())
-	//then
+	// then
 	assert.Nil(t, err, "WaitForState does not return an error")
 	assert.Equal(t, deviceID, queriedDeviceID, "Queried device ID matches")
 	assert.Equal(t, timeout, waitConfig.Timeout, "Device status wait configuration timeout matches")
@@ -396,7 +396,7 @@ func TestNetworkDevice_licenseStatusWaitConfiguration(t *testing.T) {
 }
 
 func TestNetworkDevice_ACLStatusWaitConfiguration(t *testing.T) {
-	//given
+	// given
 	deviceUUID := "test"
 	var receivedDeviceUUID string
 	fetchFunc := func(uuid string) (*ne.DeviceACLDetails, error) {
@@ -405,10 +405,10 @@ func TestNetworkDevice_ACLStatusWaitConfiguration(t *testing.T) {
 	}
 	delay := 100 * time.Millisecond
 	timeout := 10 * time.Minute
-	//when
+	// when
 	waitConfig := createNetworkDeviceACLStatusWaitConfiguration(fetchFunc, deviceUUID, delay, timeout)
 	_, err := waitConfig.WaitForStateContext(context.Background())
-	//then
+	// then
 	assert.Nil(t, err, "WaitForState does not return an error")
 	assert.Equal(t, deviceUUID, receivedDeviceUUID, "Queried Device id matches")
 	assert.Equal(t, timeout, waitConfig.Timeout, "Device status wait configuration timeout matches")
@@ -416,7 +416,7 @@ func TestNetworkDevice_ACLStatusWaitConfiguration(t *testing.T) {
 }
 
 func TestNetworkDevice_AdditionalBandwidthStatusWaitConfiguration(t *testing.T) {
-	//given
+	// given
 	deviceID := "test"
 	var receivedID string
 	fetchFunc := func(uuid string) (*ne.DeviceAdditionalBandwidthDetails, error) {
@@ -425,10 +425,10 @@ func TestNetworkDevice_AdditionalBandwidthStatusWaitConfiguration(t *testing.T) 
 	}
 	delay := 100 * time.Millisecond
 	timeout := 10 * time.Minute
-	//when
+	// when
 	waitConfig := createNetworkDeviceAdditionalBandwidthStatusWaitConfiguration(fetchFunc, deviceID, delay, timeout)
 	_, err := waitConfig.WaitForStateContext(context.Background())
-	//then
+	// then
 	assert.Nil(t, err, "WaitForState does not return an error")
 	assert.Equal(t, deviceID, receivedID, "Queried Additional Bandwidth device id matches")
 	assert.Equal(t, timeout, waitConfig.Timeout, "Additional bandwidth status wait configuration timeout matches")

--- a/equinix/resource_network_ssh_key.go
+++ b/equinix/resource_network_ssh_key.go
@@ -64,6 +64,7 @@ func createNetworkSSHKeyResourceSchema() map[string]*schema.Schema {
 		},
 	}
 }
+
 func resourceNetworkSSHKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	conf := m.(*Config)
 	var diags diag.Diagnostics

--- a/equinix/resource_network_ssh_key_test.go
+++ b/equinix/resource_network_ssh_key_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNetworkSSHKey_createFromResourceData(t *testing.T) {
-	//given
+	// given
 	expected := ne.SSHPublicKey{
 		Name:  ne.String("testKey"),
 		Value: ne.String("testKeyValue"),
@@ -19,23 +19,23 @@ func TestNetworkSSHKey_createFromResourceData(t *testing.T) {
 		networkSSHKeySchemaNames["Value"]: ne.StringValue(expected.Value),
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkSSHKeyResourceSchema(), rawData)
-	//when
+	// when
 	key := createNetworkSSHKey(d)
-	//then
+	// then
 	assert.Equal(t, expected, key, "Created key matches expected result")
 }
 
 func TestNetworkSSHKey_updateResourceData(t *testing.T) {
-	//given
+	// given
 	input := &ne.SSHPublicKey{
 		UUID:  ne.String("059c3020-aec5-44ca-816c-235435f16df9"),
 		Name:  ne.String("testKey"),
 		Value: ne.String("testKeyValue"),
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkSSHKeyResourceSchema(), make(map[string]interface{}))
-	//when
+	// when
 	err := updateNetworkSSHKeyResource(input, d)
-	//then
+	// then
 	assert.Nil(t, err, "Update of resource data does not return error")
 	assert.Equal(t, ne.StringValue(input.UUID), d.Get(networkSSHKeySchemaNames["UUID"]), "UUID matches")
 	assert.Equal(t, ne.StringValue(input.Name), d.Get(networkSSHKeySchemaNames["Name"]), "Name matches")

--- a/equinix/resource_network_ssh_user_test.go
+++ b/equinix/resource_network_ssh_user_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNetworkSSHUser_resourceFromResourceData(t *testing.T) {
-	//given
+	// given
 	rawData := map[string]interface{}{
 		networkSSHUserSchemaNames["Username"]: "user",
 		networkSSHUserSchemaNames["Password"]: "secret",
@@ -23,24 +23,24 @@ func TestNetworkSSHUser_resourceFromResourceData(t *testing.T) {
 		DeviceUUIDs: deviceUUIDs,
 	}
 
-	//when
+	// when
 	result := createNetworkSSHUser(d)
 
-	//then
+	// then
 	assert.Equal(t, expected, result, "Result matches expected result")
 }
 
 func TestNetworkSSHUser_updateResourceData(t *testing.T) {
-	//given
+	// given
 	d := schema.TestResourceDataRaw(t, createNetworkSSHUserResourceSchema(), make(map[string]interface{}))
 	input := ne.SSHUser{
 		Username:    ne.String("user"),
 		Password:    ne.String("secret"),
 		DeviceUUIDs: []string{"52c00d7f-c310-458e-9426-1d7549e1f600", "5f1483f4-c479-424d-98c5-43a266aae25c"},
 	}
-	//when
+	// when
 	err := updateNetworkSSHUserResource(&input, d)
-	//then
+	// then
 	assert.Nil(t, err, "Update of resource data does not return error")
 	assert.Equal(t, ne.StringValue(input.Username), d.Get(networkSSHUserSchemaNames["Username"]), "Username matches")
 	assert.Equal(t, ne.StringValue(input.Password), d.Get(networkSSHUserSchemaNames["Password"]), "Password matches")


### PR DESCRIPTION
Fixes #84 

With the fix below it will check the status of the secondary connection for redundant connections. It usually sets the status of the primary and secondary connections at the same time, but there is no other way to make sure there is no race condition than to also check the status of the secondary connection.

https://github.com/equinix/terraform-provider-equinix/blob/3843c8408eeec9c536a440f947d50366b5745af7/equinix/resource_ecx_l2_connection.go#L488-L500

All other changes included are forced code style formatting