### PR TITLE
Fix resource_ecx_l2_serviceprofile detecting diff after refresh

### DIFF
--- a/docs/resources/ecx_l2_serviceprofile.md
+++ b/docs/resources/ecx_l2_serviceprofile.md
@@ -121,7 +121,7 @@ will receive notifications about connections approvals and rejections
 - `features` - (Required) Block of profile features configuration
   - `allow_remote_connections` - (Required) indicates whether or not connections
     to this profile can be created from remote metro locations
-  - `test_profile` - (Required) indicates whether or not this profile can be used
+  - `test_profile` - (Deprecated) indicates whether or not this profile can be used
     for test connections
 - `port` - (Required) One or more definitions of ports residing in locations,
   from which your customers will be able to access services using given profile

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"regexp"
 	"time"
+	"strings"
 
 	"github.com/equinix/ecx-go/v2"
 	"github.com/equinix/rest-go"
@@ -263,6 +264,30 @@ func slicesMatch(s1, s2 []string) bool {
 				continue
 			}
 			if s1[i] == s2[j] {
+				visited[j] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func slicesMatchCaseInsensitive(s1, s2 []string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	visited := make([]bool, len(s1))
+	for i := 0; i < len(s1); i++ {
+		found := false
+		for j := 0; j < len(s2); j++ {
+			if visited[j] {
+				continue
+			}
+			if strings.EqualFold(s1[i], s2[j]) {
 				visited[j] = true
 				found = true
 				break

--- a/equinix/resource_ecx_l2_serviceprofile_acc_test.go
+++ b/equinix/resource_ecx_l2_serviceprofile_acc_test.go
@@ -51,6 +51,7 @@ func TestAccFabricL2ServiceProfile_Private(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"private_user_emails"},
 			},
 		},
 	})
@@ -131,7 +132,7 @@ func testAccECXL2ServiceProfileAttributes(profile *ecx.L2ServiceProfile, ctx map
 		if v, ok := ctx["private"]; ok && ecx.BoolValue(profile.Private) != v.(bool) {
 			return fmt.Errorf("private does not match %v - %v", ecx.BoolValue(profile.Private), v)
 		}
-		if v, ok := ctx["private_user_emails"]; ok && !slicesMatch(profile.PrivateUserEmails, v.([]string)) {
+		if v, ok := ctx["private_user_emails"]; ok && !slicesMatchCaseInsensitive(profile.PrivateUserEmails, v.([]string)) {
 			return fmt.Errorf("private_user_emails does not match %v - %v", profile.PrivateUserEmails, v)
 		}
 		if v, ok := ctx["redundancy_required"]; ok && ecx.BoolValue(profile.RequiredRedundancy) != v.(bool) {
@@ -148,9 +149,6 @@ func testAccECXL2ServiceProfileAttributes(profile *ecx.L2ServiceProfile, ctx map
 		}
 		if v, ok := ctx["features_cloud_reach"]; ok && ecx.BoolValue(profile.Features.CloudReach) != v.(bool) {
 			return fmt.Errorf("features.cloud_reach does not match %v - %v", ecx.BoolValue(profile.Features.CloudReach), v)
-		}
-		if v, ok := ctx["features_test_profile"]; ok && ecx.BoolValue(profile.Features.TestProfile) != v.(bool) {
-			return fmt.Errorf("features.test_profile does not match %v - %v", ecx.BoolValue(profile.Features.TestProfile), v)
 		}
 		if len(profile.Ports) != 2 {
 			return fmt.Errorf("ports.# length does not match %v - %v", len(profile.Ports), 2)

--- a/equinix/resource_ecx_l2_serviceprofile_acc_test.go
+++ b/equinix/resource_ecx_l2_serviceprofile_acc_test.go
@@ -51,7 +51,7 @@ func TestAccFabricL2ServiceProfile_Private(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"private_user_emails"},
+				ImportStateVerifyIgnore: []string{"private_user_emails", "features.0.test_profile"},
 			},
 		},
 	})

--- a/equinix/resource_ecx_l2_serviceprofile_test.go
+++ b/equinix/resource_ecx_l2_serviceprofile_test.go
@@ -38,7 +38,7 @@ func TestFabricL2ServiceProfile_createFromResourceData(t *testing.T) {
 	d.Set(ecxL2ServiceProfileSchemaNames["OnVcApprovalRejectionNotification"], testEmails)
 	d.Set(ecxL2ServiceProfileSchemaNames["PrivateUserEmails"], testEmails)
 	d.Set(ecxL2ServiceProfileSchemaNames["Features"], flattenECXL2ServiceProfileFeatures(
-		ecx.L2ServiceProfileFeatures{CloudReach: ecx.Bool(true), TestProfile: ecx.Bool(true)},
+		&ecx.L2ServiceProfileFeatures{CloudReach: ecx.Bool(true), TestProfile: ecx.Bool(true)},
 		ecx.L2ServiceProfileFeatures{CloudReach: ecx.Bool(true), TestProfile: ecx.Bool(false)},
 	))
 	d.Set(ecxL2ServiceProfileSchemaNames["Port"], flattenECXL2ServiceProfilePorts([]ecx.L2ServiceProfilePort{
@@ -127,7 +127,6 @@ func TestFabricL2ServiceProfile_updateResourceData(t *testing.T) {
 		Description:                         ecx.String("testDescription"),
 		Features: ecx.L2ServiceProfileFeatures{
 			CloudReach:  ecx.Bool(true),
-			TestProfile: ecx.Bool(true),
 		},
 		Ports: []ecx.L2ServiceProfilePort{
 			{

--- a/equinix/resource_ecx_l2_serviceprofile_test.go
+++ b/equinix/resource_ecx_l2_serviceprofile_test.go
@@ -39,6 +39,7 @@ func TestFabricL2ServiceProfile_createFromResourceData(t *testing.T) {
 	d.Set(ecxL2ServiceProfileSchemaNames["PrivateUserEmails"], testEmails)
 	d.Set(ecxL2ServiceProfileSchemaNames["Features"], flattenECXL2ServiceProfileFeatures(
 		ecx.L2ServiceProfileFeatures{CloudReach: ecx.Bool(true), TestProfile: ecx.Bool(true)},
+		ecx.L2ServiceProfileFeatures{CloudReach: ecx.Bool(true), TestProfile: ecx.Bool(false)},
 	))
 	d.Set(ecxL2ServiceProfileSchemaNames["Port"], flattenECXL2ServiceProfilePorts([]ecx.L2ServiceProfilePort{
 		{
@@ -85,7 +86,7 @@ func TestFabricL2ServiceProfile_createFromResourceData(t *testing.T) {
 		OnProfileApprovalRejectNotification: testEmails,
 		OnVcApprovalRejectionNotification:   testEmails,
 		PrivateUserEmails:                   testEmails,
-		Features:                            expandECXL2ServiceProfileFeatures(d.Get(ecxL2ServiceProfileSchemaNames["Features"]).(*schema.Set))[0],
+		Features:                            expandECXL2ServiceProfileFeatures(d.Get(ecxL2ServiceProfileSchemaNames["Features"]).(*schema.Set).List()),
 		Ports:                               expandECXL2ServiceProfilePorts(d.Get(ecxL2ServiceProfileSchemaNames["Port"]).(*schema.Set)),
 		SpeedBands:                          expandECXL2ServiceProfileSpeedBands(d.Get(ecxL2ServiceProfileSchemaNames["SpeedBand"]).(*schema.Set)),
 	}
@@ -177,7 +178,7 @@ func TestFabricL2ServiceProfile_updateResourceData(t *testing.T) {
 	assert.Equal(t, ecx.StringValue(input.TagType), d.Get(ecxL2ServiceProfileSchemaNames["TagType"]), "TagType matches")
 	assert.Equal(t, ecx.BoolValue(input.VlanSameAsPrimary), d.Get(ecxL2ServiceProfileSchemaNames["VlanSameAsPrimary"]), "VlanSameAsPrimary matches")
 	assert.Equal(t, ecx.StringValue(input.Description), d.Get(ecxL2ServiceProfileSchemaNames["Description"]), "Description matches")
-	assert.Equal(t, input.Features, expandECXL2ServiceProfileFeatures(d.Get(ecxL2ServiceProfileSchemaNames["Features"]).(*schema.Set))[0], "Features matches")
+	assert.Equal(t, input.Features, expandECXL2ServiceProfileFeatures(d.Get(ecxL2ServiceProfileSchemaNames["Features"]).(*schema.Set).List()), "Features matches")
 	assert.Equal(t, input.Ports, expandECXL2ServiceProfilePorts(d.Get(ecxL2ServiceProfileSchemaNames["Port"]).(*schema.Set)), "Ports matches")
 	assert.Equal(t, input.SpeedBands, expandECXL2ServiceProfileSpeedBands(d.Get(ecxL2ServiceProfileSchemaNames["SpeedBand"]).(*schema.Set)), "SpeedBand matches")
 }


### PR DESCRIPTION
Issue #88 

As described in the issue Terraform detectes some changes since the last "terraform apply". 

First one refers to param private_user_emails, since API returns normalized list with lowercase values. 
```
      ~ private_user_emails = [
          - "John.Doe@example.com",
          - "Marry.Doe@example.com",
          + "john.doe@example.com",
          + "marry.doe@example.com",
        ]
```
To verify that this is the case I added a slicesMatchCaseInsensitive function and if so, then we just keep value of previous schema.

https://github.com/equinix/terraform-provider-equinix/blob/f45be6043d7fdf566ae67226e7d60cf52f290692/equinix/resource_ecx_l2_serviceprofile.go#L543-L550


Second issue referes to features. TestProfile is a legacy API parameter that is no longer required and always returns False even if user set True.

```
      + features {
          + allow_remote_connections = true
          + test_profile             = false
        }
      - features {
          - allow_remote_connections = true -> null
          - test_profile             = true -> null
        }
```

To avoid any confusion to terraform users, I've marked it deprecated and keep it optional. It will return value only if it was included in the tf definition

https://github.com/equinix/terraform-provider-equinix/blob/f45be6043d7fdf566ae67226e7d60cf52f290692/equinix/resource_ecx_l2_serviceprofile.go#L291

https://github.com/equinix/terraform-provider-equinix/blob/f45be6043d7fdf566ae67226e7d60cf52f290692/equinix/resource_ecx_l2_serviceprofile.go#L566-L590