### PR TITLE
fix delete and import for redundant l2 connections

### DIFF
--- a/cmd/migration-tool/main.go
+++ b/cmd/migration-tool/main.go
@@ -8,7 +8,6 @@ import (
 )
 
 func main() {
-
 	if len(os.Args) < 2 {
 		fmt.Println("Missing required command. One of [migrate, backup, version]")
 		os.Exit(1)

--- a/docs/resources/equinix_ecx_l2_connection.md
+++ b/docs/resources/equinix_ecx_l2_connection.md
@@ -60,7 +60,7 @@ resource "equinix_ecx_l2_connection" "azure" {
   vlan_stag         = 1482
   vlan_ctag         = 2512
   seller_metro_code = "SV"
-  named_tag         = "Public"
+  named_tag         = "PRIVATE"
   authorization_key = "c4dff8e8-b52f-4b34-b0d4-c4588f7338f3
   secondary_connection {
     name      = "tf-azure-sec"
@@ -118,7 +118,7 @@ the Network Edge virtual device from which the connection would originate.
 - `vlan_ctag` - (Optional) C-Tag/Inner-Tag of the connection - a numeric
 character ranging from 2 - 4094.
 - `named_tag` - (Optional) The type of peering to set up in case when connecting
-to Azure Express Route. One of _"Public"_, _"Private"_, _"Microsoft"_, _"Manual"_
+to Azure Express Route. One of _"PRIVATE"_, _"MICROSOFT"_, _"MANUAL"_
 - `additional_info` - (Optional) one or more additional information key-value objects
   - `name` - (Required) additional information key
   - `value` - (Required) additional information value
@@ -167,8 +167,8 @@ are exported:
 - `provider_status` - Connection provisioning status on service provider's side
 - `redundant_uuid` - Unique identifier of the redundant connection, applicable for
 HA connections
-- `redundancy_type` - Connection redundancy type, applicable for HA connections.
-Either primary or secondary.
+- `redundancy_type` - Connection redundancy type, applicable for HA connections. Either PRIMARY or SECONDARY
+- `redundancy_group` - Unique identifier of group containing a primary and secondary connection.
 - `zside_port_uuid` - when not provided as an argument, it is identifier of the
 z-side port, assigned by the Fabric
 - `zside_vlan_stag` - when not provided as an argument, it is S-Tag/Outer-Tag of
@@ -179,6 +179,8 @@ z-side port, assigned by the Fabric
   - `zside_port_uuid`
   - `zside_vlan_stag`
   - `zside_vlan_ctag`
+  - `redundancy_type`
+  - `redundancy_group`
 
 ## Update operation behavior
 
@@ -202,8 +204,17 @@ options:
 
 ## Import
 
-This resource can be imported using an existing ID:
+Equinix L2 connections can be imported using an existing `id`:
 
 ```sh
-terraform import equinix_ecx_l2_connection.example {existing_id}
+existing_connection_id='00000000-0000-0000-0000-1111111111'
+terraform import equinix_ecx_l2_connection.example ${existing_connection_id}
+```
+
+To import a redundant connection it is required a single string with both connection `id` separated by `:`, e.g.,
+
+```sh
+existing_primary_connection_id='00000000-0000-0000-0000-1111111111'
+existing_secondary_connection_id='00000000-0000-0000-0000-2222222222'
+terraform import equinix_ecx_l2_connection.example ${existing_primary_connection_id}:${existing_secondary_connection_id}
 ```

--- a/docs/resources/equinix_ecx_l2_connection.md
+++ b/docs/resources/equinix_ecx_l2_connection.md
@@ -117,8 +117,9 @@ the Network Edge virtual device from which the connection would originate.
 \- a numeric character ranging from 2 - 4094.
 - `vlan_ctag` - (Optional) C-Tag/Inner-Tag of the connection - a numeric
 character ranging from 2 - 4094.
-- `named_tag` - (Optional) The type of peering to set up in case when connecting
-to Azure Express Route. One of _"PRIVATE"_, _"MICROSOFT"_, _"MANUAL"_
+- `named_tag` - (Optional) The type of peering to set up when connecting
+to Azure Express Route. One of _"PRIVATE"_, _"MICROSOFT"_, _"MANUAL"_, _"PUBLIC"_
+~> **NOTE:** _"PUBLIC"_ peering is deprecated. Use _"MICROSOFT"_ instead. More information is in [Microsoft public peering](https://docs.microsoft.com/en-us/azure/expressroute/about-public-peering) docs.
 - `additional_info` - (Optional) one or more additional information key-value objects
   - `name` - (Required) additional information key
   - `value` - (Required) additional information value

--- a/docs/resources/equinix_metal_device.md
+++ b/docs/resources/equinix_metal_device.md
@@ -7,7 +7,7 @@ subcategory: "Metal"
 Provides an Equinix Metal device resource. This can be used to create,
 modify, and delete devices.
 
-~> **Note:** All arguments including the `root_password` and `user_data` will be stored in
+~> **NOTE:** All arguments including the `root_password` and `user_data` will be stored in
  the raw state as plain-text.
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 

--- a/equinix/resource_ecx_l2_connection.go
+++ b/equinix/resource_ecx_l2_connection.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/equinix/ecx-go/v2"
 	"github.com/equinix/rest-go"
@@ -128,7 +128,7 @@ func resourceECXL2Connection() *schema.Resource {
 		UpdateContext: resourceECXL2ConnectionUpdate,
 		DeleteContext: resourceECXL2ConnectionDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext:  func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				// The expected ID to import redundant connections is '(primaryID):(secondaryID)', e.g.,
 				//   terraform import equinix_ecx_l2_connection.example 1111-11-11-1111:2222-22-22-2222
 				ids := strings.Split(d.Id(), ":")
@@ -1055,7 +1055,6 @@ func createConnectionStatusProvisioningWaitConfiguration(fetchFunc getL2Connecti
 	}
 	return createConnectionStatusWaitConfiguration(fetchFunc, id, delay, timeout, target, pending)
 }
-
 
 func createConnectionStatusDeleteWaitConfiguration(fetchFunc getL2Connection, id string, delay time.Duration, timeout time.Duration) *resource.StateChangeConf {
 	pending := []string{

--- a/equinix/resource_ecx_l2_connection.go
+++ b/equinix/resource_ecx_l2_connection.go
@@ -61,11 +61,11 @@ var ecxL2ConnectionDescriptions = map[string]string{
 	"DeviceInterfaceID":   "Identifier of network interface on a given device, used for a connection. If not specified then first available interface will be selected",
 	"VlanSTag":            "S-Tag/Outer-Tag of the connection, a numeric character ranging from 2 - 4094",
 	"VlanCTag":            "C-Tag/Inner-Tag of the connection, a numeric character ranging from 2 - 4094",
-	"NamedTag":            "The type of peering to set up in case when connecting to Azure Express Route. One of Public, Private, Microsoft, Manual",
+	"NamedTag":            "The type of peering to set up in case when connecting to Azure Express Route. One of PRIVATE, MICROSOFT, MANUAL, PUBLIC (PUBLIC is deprecated, use MICROSOFT instead)",
 	"AdditionalInfo":      "One or more additional information key-value objects",
 	"ZSidePortUUID":       "Unique identifier of the port on the remote side (z-side)",
 	"ZSideVlanSTag":       "S-Tag/Outer-Tag of the connection on the remote side (z-side)",
-	"ZSideVlanCTag":       "C-Tag/Inner-Tag of the connection on the remote side (z-side)",
+	"ZSideVlanCTag":       "C-Tag/Inner-Tag of the connection on the remote side (z-side). This is only applicable for 'MANUAL' peering. (i.e. namedTag  = 'MANUAL')",
 	"SellerRegion":        "The region in which the seller port resides",
 	"SellerMetroCode":     "The metro code that denotes the connection's remote side (z-side)",
 	"AuthorizationKey":    "Text field used to authorize connection on the provider side. Value depends on a provider service profile used for connection",
@@ -257,7 +257,7 @@ func createECXL2ConnectionResourceSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Optional:     true,
 			ForceNew:     true,
-			ValidateFunc: validation.StringInSlice([]string{"PRIVATE", "MICROSOFT", "MANUAL", "Private", "Public", "Microsoft", "Manual"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"PRIVATE", "MICROSOFT", "MANUAL", "PUBLIC"}, true),
 			Description:  ecxL2ConnectionDescriptions["NamedTag"],
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 				return strings.EqualFold(old, new)

--- a/equinix/resource_ecx_l2_connection_acc_test.go
+++ b/equinix/resource_ecx_l2_connection_acc_test.go
@@ -186,7 +186,7 @@ func TestAccFabricL2Connection_Port_HA_Azure(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: newTestAccConfig(contextWithChanges).withPort().withConnection().build(),
+				Config:      newTestAccConfig(contextWithChanges).withPort().withConnection().build(),
 				ExpectError: regexp.MustCompile(`Update request can be done only on Provisioned Connection`),
 			},
 		},
@@ -336,7 +336,7 @@ func TestAccFabricL2Connection_ServiceToken_Single_SP(t *testing.T) {
 		DeleteL2ConnectionFn: func(uuid string) error {
 			err := rest.Error{}
 			err.ApplicationErrors = []rest.ApplicationError{
-				rest.ApplicationError{
+				{
 					Code: "IC-LAYER2-4021",
 				},
 			}

--- a/equinix/resource_ecx_l2_connection_test.go
+++ b/equinix/resource_ecx_l2_connection_test.go
@@ -89,7 +89,7 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 		SellerRegion:        ecx.String(randString(10)),
 		SellerMetroCode:     ecx.String(randString(2)),
 		AuthorizationKey:    ecx.String(randString(10)),
-		RedundantUUID:       ecx.String(randString(36)),
+		RedundancyGroup:     ecx.String(randString(36)),
 		RedundancyType:      ecx.String(randString(10)),
 	}
 	// when
@@ -120,7 +120,7 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 	assert.Equal(t, ecx.StringValue(input.SellerRegion), d.Get(ecxL2ConnectionSchemaNames["SellerRegion"]), "SellerRegion matches")
 	assert.Equal(t, ecx.StringValue(input.SellerMetroCode), d.Get(ecxL2ConnectionSchemaNames["SellerMetroCode"]), "SellerMetroCode matches")
 	assert.Equal(t, ecx.StringValue(input.AuthorizationKey), d.Get(ecxL2ConnectionSchemaNames["AuthorizationKey"]), "AuthorizationKey matches")
-	assert.Equal(t, ecx.StringValue(input.RedundantUUID), d.Get(ecxL2ConnectionSchemaNames["RedundantUUID"]), "RedundantUUID matches")
+	assert.Equal(t, ecx.StringValue(input.RedundancyGroup), d.Get(ecxL2ConnectionSchemaNames["RedundancyGroup"]), "RedundancyGroup matches")
 	assert.Equal(t, ecx.StringValue(input.RedundancyType), d.Get(ecxL2ConnectionSchemaNames["RedundancyType"]), "RedundancyType matches")
 }
 
@@ -144,7 +144,7 @@ func TestFabricL2Connection_flattenSecondary(t *testing.T) {
 		SellerRegion:     ecx.String(randString(10)),
 		SellerMetroCode:  ecx.String(randString(2)),
 		AuthorizationKey: ecx.String(randString(10)),
-		RedundantUUID:    ecx.String(randString(36)),
+		RedundancyGroup:  ecx.String(randString(10)),
 		RedundancyType:   ecx.String(randString(10)),
 	}
 	previousInput := &ecx.L2Connection{
@@ -170,7 +170,7 @@ func TestFabricL2Connection_flattenSecondary(t *testing.T) {
 			ecxL2ConnectionSchemaNames["SellerRegion"]:      input.SellerRegion,
 			ecxL2ConnectionSchemaNames["SellerMetroCode"]:   input.SellerMetroCode,
 			ecxL2ConnectionSchemaNames["AuthorizationKey"]:  input.AuthorizationKey,
-			ecxL2ConnectionSchemaNames["RedundantUUID"]:     input.RedundantUUID,
+			ecxL2ConnectionSchemaNames["RedundancyGroup"]:   input.RedundancyGroup,
 			ecxL2ConnectionSchemaNames["RedundancyType"]:    input.RedundancyType,
 			ecxL2ConnectionSchemaNames["Actions"]:           []interface{}{},
 		},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/equinix/terraform-provider-equinix
 go 1.17
 
 require (
-	github.com/equinix/ecx-go/v2 v2.1.0
+	github.com/equinix/ecx-go/v2 v2.1.1
 	github.com/equinix/ne-go v1.3.0
 	github.com/equinix/oauth2-go v1.0.0
 	github.com/equinix/rest-go v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/equinix/ecx-go/v2 v2.1.0 h1:o+J82rCiJClvmTjtvGA8SMUddX7V8tqLw+m98vDTg/w=
-github.com/equinix/ecx-go/v2 v2.1.0/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
+github.com/equinix/ecx-go/v2 v2.1.1 h1:+P6U4pd5ca8gcO8HwhgmtLLK8GvE9/zNoURq70AjvC0=
+github.com/equinix/ecx-go/v2 v2.1.1/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
 github.com/equinix/ne-go v1.3.0 h1:lYcA9knOZReSdRQvq3GeYT9etJkXnyJr7eDlrTzVsKU=
 github.com/equinix/ne-go v1.3.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=


### PR DESCRIPTION
**Description:** 

Field `RedundantUUID` was used to check if there was a secondary connection. This field is not been returned for new connections anymore. This field can be deleted from the schema but then it will be required a full scan for all connections in the read function to ensure the `terraform import` command works also for redundant connections.

From [terraform import function docs](https://www.terraform.io/plugin/sdkv2/resources/import): 
> This function requires the Read function to be able to refresh the entire resource with d.Id() ONLY

Without `redundantUUID` field returned from the API there is no way to know if it is a redundant connection just with the primary connection ID, since all connections both single and redundant have a `redundancyGroup`. Therefore it will be needed a full scan in the read function to search for a connection with same RedundancyGroup.

To handle that without a full scan I propose to keep `RedundantUUID` but without using the value returned from the API. Instead value will be set in:

- Create function  
https://github.com/equinix/terraform-provider-equinix/blob/e13dbf15a15a165ed08ec74a38907e8dbd4853d2/equinix/resource_ecx_l2_connection.go#L620-L625
- Importer will require users to specify both primary and secondary ID 
https://github.com/equinix/terraform-provider-equinix/blob/e13dbf15a15a165ed08ec74a38907e8dbd4853d2/equinix/resource_ecx_l2_connection.go#L130-L141

**Depends on:**

- [x] new ecx-go version v2.1.1 https://github.com/equinix/ecx-go/pull/5

**Tasks:**

- [x] Fix check for redundancy connections and wait for secondary connection to be deleted - fixes #98 
- [x] Add deleted value as valid target status in delete function  - fixes #61 
- [x] Add named_tag uppercase values field and changes comparison not case-sensitive - fixes #97
- [x] Update l2_connection documentation
- [x] Update e2e test
![image](https://user-images.githubusercontent.com/68897552/156027944-334e19c9-9361-400c-ba47-0f18d50bfbd2.png)