### PR TITLE
NFV-18966, NFV-18994: remove hostname validation and fix acl issues in device deletion flow

### DIFF
--- a/equinix/resource_network_device.go
+++ b/equinix/resource_network_device.go
@@ -273,12 +273,11 @@ func createNetworkDeviceSchema() map[string]*schema.Schema {
 			Description:  networkDeviceDescriptions["ThroughputUnit"],
 		},
 		networkDeviceSchemaNames["HostName"]: {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringLenBetween(2, 44),
-			Description:  networkDeviceDescriptions["HostName"],
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			ForceNew:    true,
+			Description: networkDeviceDescriptions["HostName"],
 		},
 		networkDeviceSchemaNames["PackageCode"]: {
 			Type:         schema.TypeString,
@@ -512,11 +511,10 @@ func createNetworkDeviceSchema() map[string]*schema.Schema {
 						Description: networkDeviceDescriptions["Region"],
 					},
 					networkDeviceSchemaNames["HostName"]: {
-						Type:         schema.TypeString,
-						Optional:     true,
-						ForceNew:     true,
-						ValidateFunc: validation.StringLenBetween(2, 44),
-						Description:  networkDeviceDescriptions["HostName"],
+						Type:        schema.TypeString,
+						Optional:    true,
+						ForceNew:    true,
+						Description: networkDeviceDescriptions["HostName"],
 					},
 					networkDeviceSchemaNames["LicenseToken"]: {
 						Type:          schema.TypeString,
@@ -798,11 +796,10 @@ func createClusterNodeDetailSchema() map[string]*schema.Schema {
 func createVendorConfigurationSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		neDeviceVendorConfigSchemaNames["Hostname"]: {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringLenBetween(2, 50),
-			Description:  neDeviceVendorConfigDescriptions["Hostname"],
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Description: neDeviceVendorConfigDescriptions["Hostname"],
 		},
 		neDeviceVendorConfigSchemaNames["AdminPassword"]: {
 			Type:        schema.TypeString,


### PR DESCRIPTION
Since hostname prefix length check is not the same for different vendors, there is no single length range which could apply to all the vendors. We will remove validation from terraform side and purely rely on the API side validation for that field.

This PR also fix https://github.com/equinix/terraform-provider-equinix/issues/118.