### PR TITLE
change equinix_network_acl_template docs  subcategory to network edge

### DIFF
--- a/docs/resources/equinix_network_acl_template.md
+++ b/docs/resources/equinix_network_acl_template.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Metal"
+subcategory: "Network Edge"
 ---
 
 # equinix_network_acl_template (Resource)


### PR DESCRIPTION
`equinix_network_acl_template` docs was in the metal subcategory. Now it will appear in the Network Edge section of terraform regisitry

fixes https://github.com/equinix/terraform-provider-equinix/issues/127 