### PR TITLE
sync equinix(v1.6.0-alpha.3) and metal(v3.3.0-alpha.3) providers

### DIFF
--- a/docs/data-sources/equinix_metal_connection.md
+++ b/docs/data-sources/equinix_metal_connection.md
@@ -4,7 +4,7 @@ subcategory: "Metal"
 
 # equinix_metal_connection (Data Source)
 
-Use this data source to retrieve a connection resource from [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/)
+Use this data source to retrieve a [connection resource](https://metal.equinix.com/developers/docs/networking/fabric/)
 
 ## Example Usage
 
@@ -24,19 +24,26 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `description` - Description of the connection resource.
 * `name` - Name of the connection resource.
-* `tags` - String list of tags.
-* `facility` - Slug of a facility to which the connection belongs.
 * `metro` - Slug of a metro to which the connection belongs.
-* `organization_id` - ID of organization to which the connection belongs.
-* `project_id` - ID of project to which the connection belongs.
-* `status` - Status of the connection.
-* `token` - Fabric Token for the [Equinix Fabric Portal](https://fabric.equinix.com/dashboard).
-* `type` - Connection type, dedicated or shared.
-* `mode` - Mode for connections in IBX facilities with the dedicated type - standard or tunnel.
+* `facility` - Slug of a facility to which the connection belongs.
 * `redundancy` - Connection redundancy, reduntant or primary.
-* `speed` - Connection speed in bits per second.
+* `type` - Connection type, dedicated or shared.
+* `project_id` - ID of project to which the connection belongs.
+* `speed` - Connection speed, one of 50Mbps, 200Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps.
+* `description` - Description of the connection resource.
+* `mode` - Mode for connections in IBX facilities with the dedicated type - standard or tunnel.
+* `tags` - String list of tags.
+* `vlans` - Attached VLANs. Only available in shared connection. One vlan for Primary/Single connection and two vlans for Redundant connection.
+* `service_token_type` - Type of service token, a_side or z_side. One available in shared connection.
+* `organization_id` - ID of the organization where the connection is scoped to.
+* `status` - Status of the connection resource.
+* `service_tokens` - List of connection service tokens with attributes
+  * `id` - UUID of the service token required to configure the connection in the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard).
+  * `expires_at` - Expiration date of the service token.
+  * `max_allowed_speed` - Maximum allowed speed for the service token, string like in the `speed` attribute.
+  * `type` - Token type, `a_side` or `z_side`.
+  * `role` - Token role, `primary` or `secondary`.
 * `ports` - List of connection ports - primary (`ports[0]`) and secondary (`ports[1]`)
   * `name` - Port name.
   * `id` - Port UUID.
@@ -45,3 +52,4 @@ In addition to all arguments above, the following attributes are exported:
   * `status` - Port status.
   * `link_status` - Port link status.
   * `virtual_circuit_ids` - List of IDs of virtual cicruits attached to this port.
+* `token` - (Deprecated) Token to configure the connection in the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard).

--- a/docs/resources/equinix_metal_connection.md
+++ b/docs/resources/equinix_metal_connection.md
@@ -4,19 +4,21 @@ subcategory: "Metal"
 
 # equinix_metal_connection (Resource)
 
-Use this resource to request of create an Interconnection from
-[Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/)
+Use this resource to request the creation an Interconnection asset to connect with other parties using [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/).
+
+~> Equinix Metal connection with service_token_type `a_side` is not generally available and may not be enabled yet for your organization.
 
 ## Example Usage
 
 ```hcl
 resource "equinix_metal_connection" "test" {
-    name            = "My Interconnection"
-    organization_id = local.my_organization_id
-    project_id      = local.my_project_id
-    metro           = "sv"
-    redundancy      = "redundant"
-    type            = "shared"
+    name               = "My Interconnection"
+    project_id         = equinix_metal_project.test.id
+    type               = "shared"
+    redundancy         = "redundant"
+    metro              = "sv"
+    speed              = "50Mbps"
+    service_token_type = "a_side"
 }
 ```
 
@@ -25,24 +27,25 @@ resource "equinix_metal_connection" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the connection resource
-* `organization_id` - (Required) ID of the organization responsible for the connection.
-* `redundancy` - (Required) Connection redundancy - redundant or primary.
-* `type` - (Required) Connection type - dedicated or shared.
-* `mode` - Mode for connections in IBX facilities with the dedicated type - standard or tunnel
-* `project_id` - (Optional) ID of the project where the connection is scoped to, must be set for
-shared connection.
 * `metro` - (Optional) Metro where the connection will be created.
 * `facility` - (Optional) Facility where the connection will be created.
+* `redundancy` - (Required) Connection redundancy - redundant or primary.
+* `type` - (Required) Connection type - dedicated or shared.
+* `project_id` - (Optional) ID of the project where the connection is scoped to, must be set for.
+* `speed` - (Required) Connection speed - one of 50Mbps, 200Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps.
 * `description` - (Optional) Description for the connection resource.
+* `mode` - (Optional) Mode for connections in IBX facilities with the dedicated type - standard or tunnel. Default is standard.
 * `tags` - (Optional) String list of tags.
+* `vlans` - (Optional) Only used with shared connection. Vlans to attach. Pass one vlan for Primary/Single connection and two vlans for Redundant connection.
+* `service_token_type` - (Optional) Only used with shared connection. Type of service token to use for the connection, a_side or z_side.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
+* `organization_id` - ID of the organization where the connection is scoped to.
 * `status` - Status of the connection resource.
-* `token` - Fabric Token from the [Equinix Fabric Portal](https://fabric.equinix.com/dashboard).
-* `speed` - Port speed in bits per second.
 * `ports` - List of connection ports - primary (`ports[0]`) and secondary (`ports[1]`). Schema of
 port is described in documentation of the
 [equinix_metal_connection datasource](../data-sources/equinix_metal_connection.md).
+* `service_tokens` - List of connection service tokens with attributes. Scehma of service_token is described in documentation of the [equinix_metal_connection datasource](../data-sources/equinix_metal_connection.md).

--- a/docs/resources/equinix_metal_device.md
+++ b/docs/resources/equinix_metal_device.md
@@ -216,6 +216,14 @@ Defaults to `false`.
 * `deprovision_fast` - (Optional) Whether the OS disk should be filled with `00h` bytes before reinstall.
 Defaults to `false`.
 
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/configuration/resources#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 20 mins) Used when creating the Device. This includes the time to provision the OS.
+* `update` - (Defaults to 20 mins) Used when updating the Device. This includes the time needed to reprovision instances when `reinstall` arguments are used.
+* `delete` - (Defaults to 20 mins) Used when deleting the Device. This includes the time to deprovision a hardware reservation when `wait_for_reservation_deprovision` is enabled.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/equinix_metal_reserved_ip_block.md
+++ b/docs/resources/equinix_metal_reserved_ip_block.md
@@ -97,6 +97,8 @@ if type is `public_ipv4` and must be empty if type is `global_ipv4`. Conflicts w
 * `description` - (Optional) Arbitrary description.
 * `tags` - (Optional) String list of tags.
 * `vrf_id` - (Optional) Only valid and required when `type` is `vrf`. VRF ID for type=vrf reservations.
+* `wait_for_state` - (Optional) Wait for the IP reservation block to reach a desired state on resource creation. One of: `pending`, `created`. The `created` state is default and recommended if the addresses are needed within the configuration. An error will be returned if a timeout or the `denied` state is encountered.
+* `custom_data` - (Optional) Custom Data is an arbitrary object (submitted in Terraform as serialized JSON) to assign to the IP Reservation. This may be helpful for self-managed IPAM. The object must be valid JSON.
 * `network` - (Optional) Only valid as an argument and required when `type` is `vrf`. An unreserved network address from an existing `ip_range` in the specified VRF.
 * `cidr` - (Optional) Only valid as an argument and required when `type` is `vrf`. The size of the network to reserve from an existing VRF ip_range. `cidr` can only be specified with `vrf_id`. Range is 22-31. Virtual Circuits require 30-31. Other VRF resources must use a CIDR in the 22-29 range.
 

--- a/docs/resources/equinix_metal_spot_market_request.md
+++ b/docs/resources/equinix_metal_spot_market_request.md
@@ -55,7 +55,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/configuration/resources#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 60 mins) Used when creating the Spot Market Request and `wait_for_devices`
 is set to `true`.

--- a/equinix/data_source_metal_connection.go
+++ b/equinix/data_source_metal_connection.go
@@ -1,9 +1,49 @@
 package equinix
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/packethost/packngo"
 )
+
+func serviceTokenSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Description: "ID of the service token",
+				Computed:    true,
+			},
+			"expires_at": {
+				Type:        schema.TypeString,
+				Description: "Expiration date of the service token",
+				Computed:    true,
+			},
+			"max_allowed_speed": {
+				Type:        schema.TypeString,
+				Description: "Maximum allowed speed for the service token",
+				Computed:    true,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Description: "Type of the service token, a_side or z_side",
+				Computed:    true,
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Description: "State of the service token",
+				Computed:    true,
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Description: "Role of the service token",
+				Computed:    true,
+			},
+		},
+	}
+}
 
 func connectionPortSchema() *schema.Resource {
 	return &schema.Resource{
@@ -49,6 +89,10 @@ func connectionPortSchema() *schema.Resource {
 }
 
 func dataSourceMetalConnection() *schema.Resource {
+	speeds := []string{}
+	for _, allowedSpeed := range allowedSpeeds {
+		speeds = append(speeds, allowedSpeed.Str)
+	}
 	return &schema.Resource{
 		Read: dataSourceMetalConnectionRead,
 
@@ -63,10 +107,45 @@ func dataSourceMetalConnection() *schema.Resource {
 				Computed:    true,
 				Description: "Name of the connection resource",
 			},
+			"facility": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Facility which the connection is scoped to",
+			},
+			"metro": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Metro which the connection is scoped to",
+			},
+			"redundancy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Connection redundancy - redundant or primary",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Connection type - dedicated or shared",
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of project to which the connection belongs",
+			},
+			"speed": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("Port speed. Possible values are %s", strings.Join(speeds, ", ")),
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Description of the connection resource",
+			},
+			"mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Connection mode - standard or tunnel",
 			},
 			"tags": {
 				Type:        schema.TypeList,
@@ -74,61 +153,43 @@ func dataSourceMetalConnection() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"vlans": {
+				Type:        schema.TypeList,
+				Description: "Attached vlans, only in shared connection.",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
+			"service_token_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Only used with shared connection. Type of service token to use for the connection, a_side or z_side.",
+			},
 			"organization_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "ID of organization to which the connection belongs",
-			},
-			"project_id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "ID of project to which the connection belongs",
+				Description: "ID of organization to which the connection is scoped to",
 			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Status of the connection resource",
 			},
-			"redundancy": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Connection redundancy - reduntant or primary",
-			},
-			"facility": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Slug of a facility to which the connection belongs",
-			},
-			"metro": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Slug of a metro to which the connection belongs",
-			},
 			"token": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Fabric Token for the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)",
-			},
-			"type": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Connection type - dedicated or shared",
-			},
-			"mode": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Mode for connections in IBX facilities with the dedicated type - standard or tunnel",
-			},
-			"speed": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Port speed in bits per second",
 			},
 			"ports": {
 				Type:        schema.TypeList,
 				Elem:        connectionPortSchema(),
 				Computed:    true,
 				Description: "List of connection ports - primary (`ports[0]`) and secondary (`ports[1]`)",
+			},
+			"service_tokens": {
+				Type:        schema.TypeList,
+				Description: "Only used with shared connection. List of service tokens to use for the connection.",
+				Computed:    true,
+				Elem:        serviceTokenSchema(),
 			},
 		},
 	}
@@ -164,4 +225,24 @@ func dataSourceMetalConnectionRead(d *schema.ResourceData, meta interface{}) err
 	connId := d.Get("connection_id").(string)
 	d.SetId(connId)
 	return resourceMetalConnectionRead(d, meta)
+}
+
+func getServiceTokens(tokens []packngo.FabricServiceToken) ([]map[string]interface{}, error) {
+	tokenList := []map[string]interface{}{}
+	for _, token := range tokens {
+		speed, err := speedUintToStr(token.MaxAllowedSpeed)
+		if err != nil {
+			return nil, err
+		}
+		rawToken := map[string]interface{}{
+			"id":                token.ID,
+			"expires_at":        token.ExpiresAt.String(),
+			"max_allowed_speed": speed,
+			"role":              string(token.Role),
+			"state":             token.State,
+			"type":              string(token.ServiceTokenType),
+		}
+		tokenList = append(tokenList, rawToken)
+	}
+	return tokenList, nil
 }

--- a/equinix/data_source_metal_ip_block_ranges_acc_test.go
+++ b/equinix/data_source_metal_ip_block_ranges_acc_test.go
@@ -57,7 +57,7 @@ data "equinix_metal_ip_block_ranges" "test" {
 
 resource "equinix_metal_ip_attachment" "test" {
     device_id = equinix_metal_device.test.id
-    cidr_notation = cidrsubnet(data.equinix_metal_ip_block_ranges.test.ipv6.0, 8,2)
+    cidr_notation = cidrsubnet(data.equinix_metal_ip_block_ranges.test.ipv6.0, 8, 2)
 }
 `, name)
 }

--- a/equinix/data_source_metal_reserved_ip_block.go
+++ b/equinix/data_source_metal_reserved_ip_block.go
@@ -125,7 +125,7 @@ func dataSourceMetalReservedIPBlockRead(d *schema.ResourceData, meta interface{}
 	getOpts.Filter("types", "public_ipv4,global_ipv4,private_ipv4,public_ipv6,vrf")
 
 	if !(blockIdOk || (projectIdOk && addressOk)) {
-		return fmt.Errorf("You must specify either id or project_id and ip_address")
+		return fmt.Errorf("you must specify either id or project_id and ip_address")
 	}
 	if blockIdOk {
 		block, _, err := client.ProjectIPs.Get(
@@ -158,7 +158,7 @@ func dataSourceMetalReservedIPBlockRead(d *schema.ResourceData, meta interface{}
 			return loadBlock(d, &b)
 		}
 	}
-	return fmt.Errorf("Could not find matching reserved block, all blocks were \n%s", listOfCidrs(blocks))
+	return fmt.Errorf("could not find matching reserved block, all blocks were \n%s", listOfCidrs(blocks))
 }
 
 func listOfCidrs(blocks []packngo.IPAddressReservation) string {

--- a/equinix/data_source_metal_reserved_ip_block_acc_test.go
+++ b/equinix/data_source_metal_reserved_ip_block_acc_test.go
@@ -8,6 +8,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func testAccDataSourceMetalReservedIPBlockConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "equinix_metal_project" "foobar" {
+	name = "tfacc-reserved_ip_block-%s"
+}
+
+resource "equinix_metal_reserved_ip_block" "test" {
+	project_id  = equinix_metal_project.foobar.id
+	metro       = "sv"
+	type        = "public_ipv4"
+	quantity    = 2
+}
+
+data "equinix_metal_reserved_ip_block" "test" {
+	project_id  = equinix_metal_project.foobar.id
+	ip_address  = cidrhost(equinix_metal_reserved_ip_block.test.cidr_notation,1)
+}
+
+data "equinix_metal_reserved_ip_block" "test_id" {
+	id  = equinix_metal_reserved_ip_block.test.id
+}
+`, name)
+}
+
 func TestAccDataSourceMetalReservedIPBlock_basic(t *testing.T) {
 	rs := acctest.RandString(10)
 
@@ -31,28 +55,4 @@ func TestAccDataSourceMetalReservedIPBlock_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccDataSourceMetalReservedIPBlockConfig_basic(name string) string {
-	return fmt.Sprintf(`
-resource "equinix_metal_project" "foobar" {
-	name = "tfacc-reserved_ip_block-%s"
-}
-
-resource "equinix_metal_reserved_ip_block" "test" {
-	project_id  = equinix_metal_project.foobar.id
-	metro       = "sv"
-	type        = "public_ipv4"
-	quantity    = 2
-}
-
-data "equinix_metal_reserved_ip_block" "test" {
-	project_id  = equinix_metal_project.foobar.id
-    ip_address  = cidrhost(equinix_metal_reserved_ip_block.test.cidr_notation,1)
-}
-
-data "equinix_metal_reserved_ip_block" "test_id" {
-	id  = equinix_metal_reserved_ip_block.test.id
-}
-`, name)
 }

--- a/equinix/data_source_metal_vlan_acc_test.go
+++ b/equinix/data_source_metal_vlan_acc_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceMetalVlan_byVxlanFacility(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccMetalVlanCheckDestroyed,
+		CheckDestroy: testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalVlanConfig_byVxlanFacility(rs, fac, "tfacc-vlan"),
@@ -63,7 +63,7 @@ func TestAccDataSourceMetalVlan_byVxlanMetro(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccMetalVlanCheckDestroyed,
+		CheckDestroy: testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalVlanConfig_byVxlanMetro(rs, metro, "tfacc-vlan"),
@@ -132,7 +132,7 @@ func TestAccDataSourceMetalVlan_byVlanId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccMetalVlanCheckDestroyed,
+		CheckDestroy: testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalVlanConfig_byVlanId(rs, metro, "tfacc-vlan"),
@@ -177,7 +177,7 @@ func TestAccDataSourceMetalVlan_byProjectId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccMetalVlanCheckDestroyed,
+		CheckDestroy: testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalVlanConfig_byProjectId(rs, metro, "tfacc-vlan"),
@@ -311,4 +311,19 @@ func TestMetalVlan_matchingVlan(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testAccMetalDatasourceVlanCheckDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*packngo.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "equinix_metal_vlan" {
+			continue
+		}
+		if _, _, err := client.ProjectVirtualNetworks.Get(rs.Primary.ID, nil); err == nil {
+			return fmt.Errorf("Data source VLAN still exists")
+		}
+	}
+
+	return nil
 }

--- a/equinix/data_source_metal_vlan_acc_test.go
+++ b/equinix/data_source_metal_vlan_acc_test.go
@@ -315,7 +315,7 @@ func TestMetalVlan_matchingVlan(t *testing.T) {
 }
 
 func testAccMetalDatasourceVlanCheckDestroyed(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	client := testAccProvider.Meta().(*Config).metal
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_metal_vlan" {

--- a/equinix/data_source_metal_vlan_acc_test.go
+++ b/equinix/data_source_metal_vlan_acc_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/packethost/packngo"
 )
 

--- a/equinix/helpers_device_test.go
+++ b/equinix/helpers_device_test.go
@@ -1,0 +1,155 @@
+package metal
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/packethost/packngo"
+)
+
+type mockHWService struct {
+	GetFn  func(string, *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error)
+	ListFn func(string, *packngo.ListOptions) ([]packngo.HardwareReservation, *packngo.Response, error)
+	MoveFn func(string, string) (*packngo.HardwareReservation, *packngo.Response, error)
+}
+
+func (m *mockHWService) Get(id string, opt *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+	return m.GetFn(id, opt)
+}
+func (m *mockHWService) List(project string, opt *packngo.ListOptions) ([]packngo.HardwareReservation, *packngo.Response, error) {
+	return m.ListFn(project, opt)
+}
+func (m *mockHWService) Move(id string, dest string) (*packngo.HardwareReservation, *packngo.Response, error) {
+	return m.MoveFn(id, dest)
+}
+
+var _ packngo.HardwareReservationService = (*mockHWService)(nil)
+
+func Test_waitUntilReservationProvisionable(t *testing.T) {
+	type args struct {
+		reservationId string
+		instanceId    string
+		meta          *packngo.Client
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "error",
+			args: args{
+				reservationId: "reservationId",
+				instanceId:    "instanceId",
+				meta: &packngo.Client{
+					HardwareReservations: &mockHWService{
+						GetFn: func(_ string, _ *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+							return nil, nil, fmt.Errorf("boom")
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "provisionable",
+			args: args{
+				reservationId: "reservationId",
+				instanceId:    "instanceId",
+				meta: &packngo.Client{
+					HardwareReservations: (func() *mockHWService {
+						invoked := new(int)
+
+						responses := map[int]struct {
+							id            string
+							provisionable bool
+						}{
+							0: {"instanceId", false}, // should retry
+							1: {"", true},            // should return success
+						}
+
+						return &mockHWService{
+							GetFn: func(_ string, opts *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+								response := responses[*invoked]
+								*invoked++
+
+								var device *packngo.Device
+								if opts != nil && contains(opts.Includes, "device") {
+									device = &packngo.Device{ID: response.id}
+								}
+								return &packngo.HardwareReservation{
+									Device: device, Provisionable: response.provisionable,
+								}, nil, nil
+							},
+						}
+					})(),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "reprovisioned",
+			args: args{
+				reservationId: "reservationId",
+				instanceId:    "instanceId",
+				meta: &packngo.Client{
+					HardwareReservations: (func() *mockHWService {
+						responses := map[int]struct {
+							id            string
+							provisionable bool
+						}{
+							0: {"instanceId", false},      // should retry
+							1: {"new instance id", false}, // should return success
+						}
+						invoked := new(int)
+
+						return &mockHWService{
+							GetFn: func(_ string, opts *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+								response := responses[*invoked]
+								*invoked++
+
+								var device *packngo.Device
+								if opts != nil && contains(opts.Includes, "device") {
+									device = &packngo.Device{ID: response.id}
+								}
+								return &packngo.HardwareReservation{
+									Device: device, Provisionable: response.provisionable,
+								}, nil, nil
+							},
+						}
+					})(),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "foreverDeprovisioning",
+			args: args{
+				reservationId: "reservationId",
+				instanceId:    "instanceId",
+				meta: &packngo.Client{
+					HardwareReservations: &mockHWService{
+						GetFn: func(_ string, _ *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+							return &packngo.HardwareReservation{
+								Device: nil, Provisionable: false,
+							}, nil, nil
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	// delay and minTimeout * 2 should be less than timeout for each test.
+	// timeout * number of tests that reach timeout must be less than 30s (default go test timeout).
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := waitUntilReservationProvisionable(tt.args.meta, tt.args.reservationId, tt.args.instanceId, 50*time.Millisecond, 1*time.Second, 50*time.Millisecond); (err != nil) != tt.wantErr {
+				t.Errorf("waitUntilReservationProvisionable() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/equinix/helpers_device_test.go
+++ b/equinix/helpers_device_test.go
@@ -1,4 +1,4 @@
-package metal
+package equinix
 
 import (
 	"fmt"

--- a/equinix/resource_metal_connection.go
+++ b/equinix/resource_metal_connection.go
@@ -338,7 +338,7 @@ func resourceMetalConnectionRead(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(conn.ID)
 
-	projectId := ""
+	projectId := d.Get("project_id").(string)
 	// fix the project id get when it's added straight to the Connection API resource
 	// https://github.com/packethost/packngo/issues/317
 	if conn.Type == packngo.ConnectionShared {

--- a/equinix/resource_metal_connection_acc_test.go
+++ b/equinix/resource_metal_connection_acc_test.go
@@ -13,45 +13,33 @@ const (
 	metalDedicatedConnIDEnvVar = "TF_ACC_METAL_DEDICATED_CONNECTION_ID"
 )
 
-func TestAccMetalConnection_shared(t *testing.T) {
-	rs := acctest.RandString(10)
+func TestSpeedConversion(t *testing.T) {
+	speedUint, err := speedStrToUint("50Mbps")
+	if err != nil {
+		t.Errorf("Error converting speed string to uint64: %s", err)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccMetalConnectionCheckDestroyed,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccMetalConnectionConfig_shared(rs),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"equinix_metal_connection.test", "metro", "sv"),
-				),
-			},
-			{
-				ResourceName:      "equinix_metal_connection.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
+	}
+	if speedUint != 50*mega {
+		t.Errorf("Speed string conversion failed. Expected: %d, got: %d", 50*mega, speedUint)
+	}
 
-func testAccMetalConnectionConfig_shared(randstr string) string {
-	return fmt.Sprintf(`
-        resource "equinix_metal_project" "test" {
-            name = "tfacc-conn-pro-%s"
-        }
+	speedStr, err := speedUintToStr(50 * mega)
+	if err != nil {
+		t.Errorf("Error converting speed uint to string: %s", err)
+	}
+	if speedStr != "50Mbps" {
+		t.Errorf("Speed uint conversion failed. Expected: %s, got: %s", "50Mbps", speedStr)
+	}
 
-        resource "equinix_metal_connection" "test" {
-            name            = "tfacc-conn-%s"
-            organization_id = equinix_metal_project.test.organization_id
-            project_id      = equinix_metal_project.test.id
-            metro           = "sv"
-            redundancy      = "redundant"
-            type            = "shared"
-        }`,
-		randstr, randstr)
+	speedUint, err = speedStrToUint("100Gbps")
+	if err == nil {
+		t.Errorf("Expected error converting invalid speed string to uint, got: %d", speedUint)
+	}
+
+	speedStr, err = speedUintToStr(100 * giga)
+	if err == nil {
+		t.Errorf("Expected error converting invalid speed uint to string, got: %s", speedStr)
+	}
 }
 
 func testAccMetalConnectionCheckDestroyed(s *terraform.State) error {
@@ -67,6 +55,95 @@ func testAccMetalConnectionCheckDestroyed(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccMetalConnectionConfig_Shared(randstr string) string {
+	return fmt.Sprintf(`
+        resource "equinix_metal_project" "test" {
+            name = "tfacc-conn-pro-%s"
+        }
+
+        resource "equinix_metal_connection" "test" {
+            name               = "tfacc-conn-%s"
+            project_id         = equinix_metal_project.test.id
+            type               = "shared"
+            redundancy         = "redundant"
+            metro              = "sv"
+			speed              = "50Mbps"
+			service_token_type = "a_side"
+        }`,
+		randstr, randstr)
+}
+
+func TestAccMetalConnection_shared(t *testing.T) {
+	rs := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccMetalConnectionCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalConnectionConfig_Shared(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"equinix_metal_connection.test", "metro", "sv"),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_connection.test", "service_tokens.0.type", "a_side"),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_connection.test", "service_token_type", "a_side"),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_connection.test", "service_tokens.0.max_allowed_speed", "50Mbps"),
+				),
+			},
+			{
+				ResourceName:      "equinix_metal_connection.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccMetalConnectionConfig_Shared(rs) + testDataSourceMetalConnectionConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.equinix_metal_connection.test", "metro", "sv"),
+					resource.TestCheckResourceAttr("data.equinix_metal_connection.test", "mode", "standard"),
+					resource.TestCheckResourceAttr("data.equinix_metal_connection.test", "type", "shared"),
+					resource.TestCheckResourceAttr("data.equinix_metal_connection.test", "redundancy", "redundant"),
+					resource.TestCheckResourceAttr(
+						"data.equinix_metal_connection.test", "service_tokens.0.type", "a_side"),
+					resource.TestCheckResourceAttr(
+						"data.equinix_metal_connection.test", "service_token_type", "a_side"),
+					resource.TestCheckResourceAttr(
+						"data.equinix_metal_connection.test", "service_tokens.0.max_allowed_speed", "50Mbps"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMetalConnectionConfig_dedicated(randstr string) string {
+	return fmt.Sprintf(`
+        resource "equinix_metal_project" "test" {
+            name = "tfacc-conn-pro-%s"
+        }
+
+        resource "equinix_metal_connection" "test" {
+            name            = "tfacc-conn-%s"
+            metro           = "sv"
+			project_id      = equinix_metal_project.test.id
+            type            = "dedicated"
+            redundancy      = "redundant"
+			tags            = ["tfacc"]
+			speed           = "50Mbps"
+			mode            = "standard"
+        }`,
+		randstr, randstr)
+}
+
+func testDataSourceMetalConnectionConfig() string {
+	return `
+		data "equinix_metal_connection" "test" {
+            connection_id = equinix_metal_connection.test.id
+        }`
 }
 
 func TestAccMetalConnection_dedicated(t *testing.T) {
@@ -85,7 +162,6 @@ func TestAccMetalConnection_dedicated(t *testing.T) {
 					resource.TestCheckResourceAttr("equinix_metal_connection.test", "mode", "standard"),
 					resource.TestCheckResourceAttr("equinix_metal_connection.test", "type", "dedicated"),
 					resource.TestCheckResourceAttr("equinix_metal_connection.test", "redundancy", "redundant"),
-					resource.TestCheckResourceAttr("equinix_metal_connection.test", "metro", "sv"),
 				),
 			},
 			{
@@ -94,44 +170,35 @@ func TestAccMetalConnection_dedicated(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMetalConnectionConfig_dedicated(rs) + testDataSourceMetalConnectionConfig_dedicated(),
+				Config: testAccMetalConnectionConfig_dedicated(rs) + testDataSourceMetalConnectionConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.equinix_metal_connection.test", "metro", "sv"),
 					resource.TestCheckResourceAttr("data.equinix_metal_connection.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("data.equinix_metal_connection.test", "mode", "standard"),
 					resource.TestCheckResourceAttr("data.equinix_metal_connection.test", "type", "dedicated"),
 					resource.TestCheckResourceAttr("data.equinix_metal_connection.test", "redundancy", "redundant"),
-					resource.TestCheckResourceAttr("data.equinix_metal_connection.test", "metro", "sv"),
 				),
 			},
 		},
 	})
 }
 
-func testAccMetalConnectionConfig_dedicated(randstr string) string {
+func testAccMetalConnectionConfig_tunnel(randstr string) string {
 	return fmt.Sprintf(`
         resource "equinix_metal_project" "test" {
             name = "tfacc-conn-pro-%s"
         }
-        
-        // No project ID. We only use the project resource to get org_id
+
         resource "equinix_metal_connection" "test" {
             name            = "tfacc-conn-%s"
-            organization_id = equinix_metal_project.test.organization_id
+			project_id      = equinix_metal_project.test.id
             metro           = "sv"
             redundancy      = "redundant"
             type            = "dedicated"
-			tags            = ["tfacc"]
-			mode            = "standard"
+            mode            = "tunnel"
+			speed           = "50Mbps"
         }`,
 		randstr, randstr)
-}
-
-func testDataSourceMetalConnectionConfig_dedicated() string {
-	return `
-		data "equinix_metal_connection" "test" {
-            connection_id = equinix_metal_connection.test.id
-        }`
 }
 
 func TestAccMetalConnection_tunnel(t *testing.T) {
@@ -156,21 +223,4 @@ func TestAccMetalConnection_tunnel(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccMetalConnectionConfig_tunnel(randstr string) string {
-	return fmt.Sprintf(`
-        resource "equinix_metal_project" "test" {
-            name = "tfacc-conn-pro-%s"
-        }
-
-        resource "equinix_metal_connection" "test" {
-            name            = "tfacc-conn-%s"
-            organization_id = equinix_metal_project.test.organization_id
-            metro           = "sv"
-            redundancy      = "redundant"
-            type            = "dedicated"
-            mode            = "tunnel"
-        }`,
-		randstr, randstr)
 }

--- a/equinix/resource_metal_device_network_type.go
+++ b/equinix/resource_metal_device_network_type.go
@@ -86,6 +86,7 @@ func resourceMetalDeviceNetworkTypeRead(d *schema.ResourceData, meta interface{}
 	client := meta.(*Config).metal
 
 	_, devNType, err := getDevIDandNetworkType(d, client)
+
 	if err != nil {
 		err = friendlyError(err)
 

--- a/equinix/resource_metal_gateway.go
+++ b/equinix/resource_metal_gateway.go
@@ -81,7 +81,6 @@ func resourceMetalGateway() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 			},
-
 			"state": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/equinix/resource_metal_ip_attachment_acc_test.go
+++ b/equinix/resource_metal_ip_attachment_acc_test.go
@@ -53,8 +53,8 @@ resource "equinix_metal_device" "test" {
 
 resource "equinix_metal_reserved_ip_block" "test" {
     project_id = equinix_metal_project.test.id
-    facility = "sv15"
-	quantity = 2
+    facility   = "sv15"
+	quantity   = 2
 }
 
 
@@ -109,7 +109,7 @@ resource "equinix_metal_device" "test" {
 resource "equinix_metal_reserved_ip_block" "test" {
     project_id = equinix_metal_project.test.id
     metro      = "sv"
-	quantity = 2
+	quantity   = 2
 }
 
 

--- a/equinix/resource_metal_port_vlan_attachment_acc_test.go
+++ b/equinix/resource_metal_port_vlan_attachment_acc_test.go
@@ -19,7 +19,7 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-port-vlan-attachment-test"
-  plan             = "s1.large.x86"
+  plan             = "m2.xlarge.x86"
   facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -103,7 +103,7 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-vlan-l2i-test"
-  plan             = "s1.large.x86"
+  plan             = "m2.xlarge.x86"
   facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -190,7 +190,7 @@ resource "equinix_metal_project" "test" {
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-hybrid-test"
   plan             = "n2.xlarge.x86"
-  facilities       = ["dfw2"]
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
@@ -208,7 +208,7 @@ resource "equinix_metal_device_network_type" "test" {
 
 resource "equinix_metal_vlan" "test" {
   description = "test vlan"
-  facility    = "dfw2"
+  facility    = "ewr1"
   project_id  = "${equinix_metal_project.test.id}"
 }
 
@@ -259,7 +259,7 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-hmv-test"
-  plan             = "s1.large.x86"
+  plan             = "m2.xlarge.x86"
   facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -344,7 +344,6 @@ func testAccMetalPortVlanAttachmentCheckDestroyed(s *terraform.State) error {
 			port_vlan := strings.Split(rs.Primary.ID, ":")
 			vlan_id = port_vlan[0]
 			port_id = port_vlan[1]
-
 		}
 	}
 	d, _, err := client.Devices.Get(device_id, nil)
@@ -373,7 +372,7 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-l2n-test"
-  plan             = "s1.large.x86"
+  plan             = "m2.xlarge.x86"
   facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"

--- a/equinix/resource_metal_project_api_key_acc_test.go
+++ b/equinix/resource_metal_project_api_key_acc_test.go
@@ -28,19 +28,6 @@ func TestAccMetalProjectAPIKey_basic(t *testing.T) {
 	})
 }
 
-func testAccMetalProjectAPIKeyCheckDestroyed(s *terraform.State) error {
-	client := testAccProvider.Meta().(*Config).metal
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "equinix_metal_project_api_key" {
-			continue
-		}
-		if _, err := client.APIKeys.ProjectGet(rs.Primary.ID, rs.Primary.Attributes["project_id"], nil); err == nil {
-			return fmt.Errorf("Metal ProjectAPI key still exists")
-		}
-	}
-	return nil
-}
-
 func testAccMetalProjectAPIKeyConfig_basic() string {
 	return fmt.Sprintf(`
 
@@ -53,4 +40,17 @@ resource "equinix_metal_project_api_key" "test" {
     description = "tfacc-project-key"
     read_only   = true
 }`)
+}
+
+func testAccMetalProjectAPIKeyCheckDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Config).metal
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "equinix_metal_project_api_key" {
+			continue
+		}
+		if _, err := client.APIKeys.ProjectGet(rs.Primary.ID, rs.Primary.Attributes["project_id"], nil); err == nil {
+			return fmt.Errorf("Metal ProjectAPI key still exists")
+		}
+	}
+	return nil
 }

--- a/equinix/resource_metal_project_ssh_key_acc_test.go
+++ b/equinix/resource_metal_project_ssh_key_acc_test.go
@@ -24,8 +24,8 @@ resource "equinix_metal_project_ssh_key" "test" {
 
 resource "equinix_metal_device" "test" {
     hostname            = "tfacc-device-key-test"
-    plan                = "baremetal_0"
-    facilities          = ["ny5"]
+    plan                = "c2.medium.x86"
+    facilities          = ["ny5", "ewr1", "any"]
     operating_system    = "ubuntu_16_04"
     billing_cycle       = "hourly"
     project_ssh_key_ids = ["${equinix_metal_project_ssh_key.test.id}"]

--- a/equinix/resource_metal_reserved_ip_block_acc_test.go
+++ b/equinix/resource_metal_reserved_ip_block_acc_test.go
@@ -153,6 +153,7 @@ func TestAccMetalReservedIPBlock_importBasic(t *testing.T) {
 				ResourceName:      "equinix_metal_reserved_ip_block.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"wait_for_state"},
 			},
 		},
 	})

--- a/equinix/resource_metal_reserved_ip_block_acc_test.go
+++ b/equinix/resource_metal_reserved_ip_block_acc_test.go
@@ -20,6 +20,9 @@ resource "equinix_metal_reserved_ip_block" "test" {
 	type        = "global_ipv4"
 	description = "testdesc"
 	quantity    = 1
+	custom_data = jsonencode({
+		"foo": "bar"
+	})
 }`, name)
 }
 
@@ -75,6 +78,8 @@ func TestAccMetalReservedIPBlock_global(t *testing.T) {
 						"equinix_metal_reserved_ip_block.test", "public", "true"),
 					resource.TestCheckResourceAttr(
 						"equinix_metal_reserved_ip_block.test", "management", "false"),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_reserved_ip_block.test", "custom_data", `{"foo":"bar"}`),
 				),
 			},
 		},

--- a/equinix/resource_metal_spot_market_request_acc_test.go
+++ b/equinix/resource_metal_spot_market_request_acc_test.go
@@ -14,7 +14,7 @@ func TestAccMetalSpotMarketRequest_basic(t *testing.T) {
 	var key packngo.SpotMarketRequest
 	context := map[string]interface{}{
 		"name_suffix": acctest.RandString(10),
-		"facility":    "dc13",
+		"facility":    "sv15",
 		"plan":        "c3.small.x86",
 	}
 	resource.ParallelTest(t, resource.TestCase{
@@ -139,7 +139,7 @@ resource "equinix_metal_spot_market_request" "request" {
 func TestAccMetalSpotMarketRequest_Import(t *testing.T) {
 	context := map[string]interface{}{
 		"name_suffix": acctest.RandString(10),
-		"facility":    "dc13",
+		"facility":    "sv15",
 		"plan":        "c3.small.x86",
 	}
 	resource.ParallelTest(t, resource.TestCase{

--- a/equinix/resource_metal_vrf_acc_test.go
+++ b/equinix/resource_metal_vrf_acc_test.go
@@ -172,6 +172,7 @@ func TestAccMetalVRF_withIPReservations(t *testing.T) {
 				ResourceName:      "equinix_metal_reserved_ip_block.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"wait_for_state"},
 			},
 		},
 	})

--- a/equinix/utils.go
+++ b/equinix/utils.go
@@ -36,6 +36,17 @@ func convertIntArr(ifaceArr []interface{}) []string {
 	return arr
 }
 
+func convertIntArr2(ifaceArr []interface{}) []int {
+	var arr []int
+	for _, v := range ifaceArr {
+		if v == nil {
+			continue
+		}
+		arr = append(arr, v.(int))
+	}
+	return arr
+}
+
 func toLower(v interface{}) string {
 	return strings.ToLower(v.(string))
 }


### PR DESCRIPTION
- [x] docs/data-sources/equinix_metal_*
- [x] docs/resources/equinix_metal_*
- [x] equinix/data_source_metal_connection.go
- [x] equinix/data_source_metal_device_acc_test.go
- [x] equinix/data_source_metal_device.go
- [x] equinix/data_source_metal_facility_acc_test.go
- [x] equinix/data_source_metal_gateway_acc_test.go
- [x] equinix/data_source_metal_ip_block_ranges_acc_test.go
- [x] equinix/data_source_metal_metro_acc_test.go
- [x] equinix/data_source_metal_operating_system_acc_test.go
- [x] equinix/data_source_metal_organization_acc_test.go
- [x] equinix/data_source_metal_port_acc_test.go
- [x] equinix/data_source_metal_precreated_ip_block_acc_test.go
- [x] equinix/data_source_metal_project_ssh_key_acc_test.go
- [x] equinix/data_source_metal_project_acc_test.go
- [x] equinix/data_source_metal_reserved_ip_block.go
- [x] equinix/data_source_metal_reserved_ip_block_acc_test.go
- [x] equinix/data_source_metal_spot_market_price_acc_test.go
- [x] equinix/data_source_metal_spot_market_request_acc_test.go
- [x] equinix/data_source_metal_vlan_acc_test.go
- [x] equinix/data_source_metal_vlan.go
- [x] equinix/errors.go
- [x] equinix/helpers_device.go
- [x] equinix/helpers_device_acc_test.go
- [x] equinix/resource_metal_bgp_setup_acc_test.go
- [x] equinix/resource_metal_connection.go
- [x] equinix/resource_metal_connection_acc_test.go
- [x] equinix/resource_metal_device.go
- [x] equinix/resource_metal_device_acc_test.go
- [x] equinix/resource_metal_gateway_acc_test.go
- [x] equinix/resource_metal_ip_attachment_acc_test.go
- [x] equinix/resource_metal_organization_acc_test.go
- [x] equinix/resource_metal_port_acc_test.go
- [x] equinix/resource_metal_port_vlan_attachment_acc_test.go
- [x] equinix/resource_metal_project.go
- [x] equinix/resource_metal_project_api_key_acc_test.go
- [x] equinix/resource_metal_project_ssh_key_acc_test.go
- [x] equinix/resource_metal_project_acc_test.go
- [x] equinix/resource_metal_reserved_ip_block.go
- [x] equinix/resource_metal_reserved_ip_block_acc_test.go
- [x] equinix/resource_metal_spot_market_request_acc_test.go
- [x] equinix/resource_metal_ssh_key_acc_test.go
- [x] equinix/resource_metal_user_api_key_acc_test.go
- [x] equinix/resource_metal_virtual_circuit_acc_test.go
- [x] equinix/resource_metal_vlan_acc_test.go
- [x] equinix/utils.go