### PR TITLE
Metal organization address field

### DIFF
--- a/docs/data-sources/equinix_metal_organization.md
+++ b/docs/data-sources/equinix_metal_organization.md
@@ -37,3 +37,9 @@ In addition to all arguments above, the following attributes are exported:
 * `website` - Website link.
 * `twitter` - Twitter handle.
 * `logo` - Logo URL.
+* `address` - Address information
+  * `address` - Postal address.
+  * `city` - City name.
+  * `country` - Two letter country code (ISO 3166-1 alpha-2), e.g. US.
+  * `zip_code` - Zip Code.
+  * `state` - State name.

--- a/docs/resources/equinix_metal_organization.md
+++ b/docs/resources/equinix_metal_organization.md
@@ -21,10 +21,22 @@ resource "equinix_metal_organization" "tf_organization_1" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Organization.
+* `address` - (Required) An object that has the address information. See [Address](#address)
+below for more details.
 * `description` - (Optional) Description string.
 * `website` - (Optional) Website link.
 * `twitter` - (Optional) Twitter handle.
 * `logo` - (Optional) Logo URL.
+
+### Address
+
+The `address` block contains:
+
+* `address` - (Required) Postal address.
+* `city` - (Required) City name.
+* `country` - (Required) Two letter country code (ISO 3166-1 alpha-2), e.g. US.
+* `zip_code` - (Required) Zip Code.
+* `state` - (Optional) State name.
 
 ## Attributes Reference
 

--- a/equinix/data_source_metal_organization_acc_test.go
+++ b/equinix/data_source_metal_organization_acc_test.go
@@ -30,6 +30,22 @@ func TestAccDataSourceMetalOrganization_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.equinix_metal_organization.test", "name",
 						fmt.Sprintf("tfacc-datasource-org-%d", rInt)),
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_organization.test", "address.0.address",
+						"data.equinix_metal_organization.test", "address.0.address",
+					),
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_organization.test", "address.0.city",
+						"data.equinix_metal_organization.test", "address.0.city",
+					),
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_organization.test", "address.0.country",
+						"data.equinix_metal_organization.test", "address.0.country",
+					),
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_organization.test", "address.0.zip_code",
+						"data.equinix_metal_organization.test", "address.0.zip_code",
+					),
 				),
 			},
 		},
@@ -39,8 +55,14 @@ func TestAccDataSourceMetalOrganization_basic(t *testing.T) {
 func testAccDataSourceMetalOrganizationConfig_basic(r int) string {
 	return fmt.Sprintf(`
 resource "equinix_metal_organization" "test" {
-  name = "tfacc-datasource-org-%d"
-  description = "quux"
+	name = "tfacc-datasource-org-%d"
+	description = "quux"
+	address {
+		address = "tfacc org street"
+		city = "london"
+		zip_code = "12345"
+		country = "GB"
+	}
 }
 
 data "equinix_metal_organization" "test" {

--- a/equinix/resource_metal_project_acc_test.go
+++ b/equinix/resource_metal_project_acc_test.go
@@ -412,11 +412,17 @@ func testAccMetalProjectConfig_organization(r string) string {
 	return fmt.Sprintf(`
 resource "equinix_metal_organization" "test" {
 	name = "tfacc-project-%s"
+	address {
+		address = "tfacc org street"
+		city = "london"
+		zip_code = "12345"
+		country = "GB"
+	}
 }
 
 resource "equinix_metal_project" "foobar" {
-		name = "tfacc-project-%s"
-		organization_id = "${equinix_metal_organization.test.id}"
+	name = "tfacc-project-%s"
+	organization_id = "${equinix_metal_organization.test.id}"
 }`, r, r)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
-	github.com/packethost/packngo v0.23.0
+	github.com/packethost/packngo v0.24.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
 )

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/packethost/packngo v0.23.0 h1:AnG26Th7v68solhArM/sF/mCB8hV2LI70VYxebF4bgE=
-github.com/packethost/packngo v0.23.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
+github.com/packethost/packngo v0.24.0 h1:49/sf+fxn4vcNePpt6NlmpBrDerEKn3TRCLW7dMnChU=
+github.com/packethost/packngo v0.24.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This PR adds field address (mandatory now to create an Equinix Metal organization) in both resource and data source `equinix_metal_organization`. 

- Some `optional` tags and validations for nil values have been added to the data source to be able to return previous organizations without address.
- Acceptance test updated. 
- Documentation updated.

fix https://github.com/equinix/terraform-provider-equinix/issues/134