### PR TITLE
fix metal VC and GW deletes by waiting for the resource through the "deleting" state

### DIFF
--- a/equinix/resource_metal_virtual_circuit.go
+++ b/equinix/resource_metal_virtual_circuit.go
@@ -371,8 +371,8 @@ func resourceMetalVirtualCircuitDelete(d *schema.ResourceData, meta interface{})
 
 	_, err = deleteWaiter.WaitForState()
 	if ignoreResponseErrors(httpForbidden, httpNotFound)(resp, err) != nil {
-		return nil
+		return fmt.Errorf("Error deleting virtual circuit %s: %s", d.Id(), err)
 	}
-
-	return fmt.Errorf("Error deleting virtual circuit %s: %s", d.Id(), err)
+	d.SetId("")
+	return nil
 }


### PR DESCRIPTION
During VRF PoCs it was determined that the order in which resources are deleted results in some deletion failures on the first pass:

```
│ Error: Error deleting IP reservation block {uuid}: DELETE https://api.equinix.com/metal/v1/ips/{uuid}: 422 IP Reservation "192.168.100.0/29" error: Cannot delete with associated metal gateway
```

In order to avoid this, and for general best-practice, we should wait for the Metal Gateway devices to pass through the "deleting" status phase and finally 404/403 before returning flow control back to Terraform.

I borrowed this code from the VirtualCircuit deletion code and found a bug in how the "deleting" state was awaited there. That has also been addressed in this PR.