### PR TITLE
resource/datasource equinix_metal_connection service_token expires_at can be null

### DIFF
--- a/equinix/data_source_metal_connection.go
+++ b/equinix/data_source_metal_connection.go
@@ -234,13 +234,16 @@ func getServiceTokens(tokens []packngo.FabricServiceToken) ([]map[string]interfa
 		if err != nil {
 			return nil, err
 		}
+
 		rawToken := map[string]interface{}{
 			"id":                token.ID,
-			"expires_at":        token.ExpiresAt.String(),
 			"max_allowed_speed": speed,
 			"role":              string(token.Role),
 			"state":             token.State,
 			"type":              string(token.ServiceTokenType),
+		}
+		if token.ExpiresAt != nil {
+			rawToken["expires_at"] = token.ExpiresAt.String()
 		}
 		tokenList = append(tokenList, rawToken)
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
-	github.com/packethost/packngo v0.24.0
+	github.com/packethost/packngo v0.25.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
 )

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/packethost/packngo v0.24.0 h1:49/sf+fxn4vcNePpt6NlmpBrDerEKn3TRCLW7dMnChU=
-github.com/packethost/packngo v0.24.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
+github.com/packethost/packngo v0.25.0 h1:ujGXL3lVqTiaQoX2/Go74lQAlYfTeop7jBNy5w99w2A=
+github.com/packethost/packngo v0.25.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Added validation to check expires_at is not null before converting Timestamp to string

Bug fix https://github.com/equinix/terraform-provider-equinix/issues/147

Packngo version update required to v0.25.0