### PR TITLE
add termination_time to metal_device resources in acceptance

### DIFF
--- a/equinix/data_source_metal_device_acc_test.go
+++ b/equinix/data_source_metal_device_acc_test.go
@@ -50,12 +50,13 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
+  termination_time = "%s"
 }
 
 data "equinix_metal_device" "test" {
   project_id       = equinix_metal_project.test.id
   hostname         = equinix_metal_device.test.hostname
-}`, projSuffix)
+}`, projSuffix, testDeviceTerminationTime())
 }
 
 func TestAccDataSourceMetalDevice_byID(t *testing.T) {
@@ -100,9 +101,10 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
+  termination_time = "%s"
 }
 
 data "equinix_metal_device" "test" {
   device_id       = equinix_metal_device.test.id
-}`, projSuffix)
+}`, projSuffix, testDeviceTerminationTime())
 }

--- a/equinix/data_source_metal_ip_block_ranges_acc_test.go
+++ b/equinix/data_source_metal_ip_block_ranges_acc_test.go
@@ -48,6 +48,7 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = equinix_metal_project.test.id
+  termination_time = "%s"
 }
 
 data "equinix_metal_ip_block_ranges" "test" {
@@ -59,5 +60,5 @@ resource "equinix_metal_ip_attachment" "test" {
     device_id = equinix_metal_device.test.id
     cidr_notation = cidrsubnet(data.equinix_metal_ip_block_ranges.test.ipv6.0, 8, 2)
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }

--- a/equinix/data_source_metal_port_acc_test.go
+++ b/equinix/data_source_metal_port_acc_test.go
@@ -40,6 +40,7 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = equinix_metal_project.test.id
+  termination_time = "%s"
 }
 
 data "equinix_metal_port" "test" {
@@ -47,7 +48,7 @@ data "equinix_metal_port" "test" {
     name      = "eth0"
 }
 
-`, name)
+`, name, testDeviceTerminationTime())
 }
 
 func TestAccDataSourceMetalPort_byId(t *testing.T) {
@@ -82,10 +83,11 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = equinix_metal_project.test.id
+  termination_time = "%s"
 }
 
 data "equinix_metal_port" "test" {
   port_id        = equinix_metal_device.test.ports[0].id
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }

--- a/equinix/data_source_metal_precreated_ip_block_acc_test.go
+++ b/equinix/data_source_metal_precreated_ip_block_acc_test.go
@@ -48,6 +48,7 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = equinix_metal_project.test.id
+  termination_time = "%s"
 }
 
 data "equinix_metal_precreated_ip_block" "test" {
@@ -61,5 +62,5 @@ resource "equinix_metal_ip_attachment" "test" {
     device_id = equinix_metal_device.test.id
     cidr_notation = cidrsubnet(data.equinix_metal_precreated_ip_block.test.cidr_notation,8,2)
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }

--- a/equinix/resource_metal_bgp_setup_acc_test.go
+++ b/equinix/resource_metal_bgp_setup_acc_test.go
@@ -83,6 +83,7 @@ resource "equinix_metal_device" "test" {
     operating_system = "ubuntu_16_04"
     billing_cycle    = "hourly"
     project_id       = "${equinix_metal_project.test.id}"
+    termination_time = "%s"
 }
 
 resource "equinix_metal_bgp_session" "test4" {
@@ -100,5 +101,5 @@ resource "equinix_metal_bgp_session" "test6" {
 data "equinix_metal_device_bgp_neighbors" "test" {
   device_id  = equinix_metal_bgp_session.test4.device_id
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }

--- a/equinix/resource_metal_connection.go
+++ b/equinix/resource_metal_connection.go
@@ -353,9 +353,17 @@ func resourceMetalConnectionRead(d *schema.ResourceData, meta interface{}) error
 	if len(conn.Tokens) > 0 {
 		side = string(conn.Tokens[0].ServiceTokenType)
 	}
-	speed, err := speedUintToStr(conn.Speed)
-	if err != nil {
-		return err
+	// speed, err := speedUintToStr(conn.Speed)
+	// if err != nil {
+	// 	return err
+	// }
+
+	speed := "0"
+	if conn.Speed > 0 {
+		speed, err = speedUintToStr(conn.Speed)
+		if err != nil {
+			return err
+		}
 	}
 
 	serviceTokens, err := getServiceTokens(conn.Tokens)

--- a/equinix/resource_metal_device.go
+++ b/equinix/resource_metal_device.go
@@ -624,10 +624,10 @@ func resourceMetalDeviceRead(d *schema.ResourceData, meta interface{}) error {
 	if _, ok := d.GetOk(fdv); !ok {
 		d.Set(fdv, nil)
 
-		tt := "termination_time"
-		if _, ok := d.GetOk(tt); !ok {
-			d.Set(tt, nil)
-		}
+	}
+	tt := "termination_time"
+	if _, ok := d.GetOk(tt); !ok {
+		d.Set(tt, nil)
 	}
 
 	d.Set("tags", device.Tags)

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -64,6 +65,10 @@ func testSweepDevices(region string) error {
 // Regexp vars for use with resource.ExpectError
 var matchErrMustBeProvided = regexp.MustCompile(".* must be provided when .*")
 var matchErrShouldNotBeAnIPXE = regexp.MustCompile(`.*"user_data" should not be an iPXE.*`)
+
+func testDeviceTerminationTime() string {
+	return time.Now().UTC().Add(60 * time.Minute).Format(time.RFC3339)
+}
 
 func TestAccMetalDevice_facilityList(t *testing.T) {
 	var device packngo.Device
@@ -486,8 +491,9 @@ resource "equinix_metal_device" "test" {
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
   tags             = ["%d"]
+  termination_time = "%s"
 }
-`, projSuffix, rInt, rInt)
+`, projSuffix, rInt, rInt, testDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_reinstall(rInt int, projSuffix string) string {
@@ -505,13 +511,14 @@ resource "equinix_metal_device" "test" {
   project_id       = "${equinix_metal_project.test.id}"
   tags             = ["%d"]
   user_data = "#!/usr/bin/env sh\necho Reinstall\n"
+  termination_time = "%s"
 
   reinstall {
 	  enabled = true
 	  deprovision_fast = true
   }
 }
-`, projSuffix, rInt, rInt)
+`, projSuffix, rInt, rInt, testDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_varname(rInt int, projSuffix string) string {
@@ -529,8 +536,9 @@ resource "equinix_metal_device" "test" {
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
   tags             = ["%d"]
+  termination_time = "%s"
 }
-`, projSuffix, rInt, rInt, rInt)
+`, projSuffix, rInt, rInt, rInt, testDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_varname_pxe(rInt int, projSuffix string) string {
@@ -550,8 +558,9 @@ resource "equinix_metal_device" "test" {
   tags             = ["%d"]
   always_pxe       = true
   ipxe_script_url  = "http://matchbox.foo.wtf:8080/boot.ipxe"
+  termination_time = "%s"
 }
-`, projSuffix, rInt, rInt, rInt)
+`, projSuffix, rInt, rInt, rInt, testDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_metro(projSuffix string) string {
@@ -567,7 +576,8 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
-}`, projSuffix)
+  termination_time = "%s"
+}`, projSuffix, testDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_minimal(projSuffix string) string {
@@ -597,7 +607,8 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
-}`, projSuffix)
+  termination_time = "%s"
+}`, projSuffix, testDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_facility_list(projSuffix string) string {
@@ -614,7 +625,8 @@ resource "equinix_metal_device" "test"  {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
-}`, projSuffix)
+  termination_time = "%s"
+}`, projSuffix, testDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_ipxe_script_url(projSuffix, url, pxe string) string {
@@ -634,7 +646,8 @@ resource "equinix_metal_device" "test_ipxe_script_url"  {
   project_id       = "${equinix_metal_project.test.id}"
   ipxe_script_url  = "%s"
   always_pxe       = "%s"
-}`, projSuffix, url, pxe)
+  termination_time = "%s"
+}`, projSuffix, url, pxe, testDeviceTerminationTime())
 }
 
 var testAccMetalDeviceConfig_ipxe_conflict = `

--- a/equinix/resource_metal_ip_attachment_acc_test.go
+++ b/equinix/resource_metal_ip_attachment_acc_test.go
@@ -49,6 +49,7 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = equinix_metal_project.test.id
+  termination_time = "%s"
 }
 
 resource "equinix_metal_reserved_ip_block" "test" {
@@ -61,7 +62,7 @@ resource "equinix_metal_reserved_ip_block" "test" {
 resource "equinix_metal_ip_attachment" "test" {
 	device_id = equinix_metal_device.test.id
 	cidr_notation = "${cidrhost(equinix_metal_reserved_ip_block.test.cidr_notation,0)}/32"
-}`, name)
+}`, name, testDeviceTerminationTime())
 }
 
 func TestAccMetalIPAttachment_metro(t *testing.T) {
@@ -104,6 +105,7 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = equinix_metal_project.test.id
+  termination_time = "%s"
 }
 
 resource "equinix_metal_reserved_ip_block" "test" {
@@ -116,7 +118,7 @@ resource "equinix_metal_reserved_ip_block" "test" {
 resource "equinix_metal_ip_attachment" "test" {
 	device_id = equinix_metal_device.test.id
 	cidr_notation = "${cidrhost(equinix_metal_reserved_ip_block.test.cidr_notation,0)}/32"
-}`, name)
+}`, name, testDeviceTerminationTime())
 }
 
 func testAccMetalIPAttachmentCheckDestroyed(s *terraform.State) error {

--- a/equinix/resource_metal_port_acc_test.go
+++ b/equinix/resource_metal_port_acc_test.go
@@ -23,6 +23,7 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
+  termination_time = "%s"
 }
 
 locals {
@@ -31,7 +32,7 @@ locals {
   eth0_id = [for p in equinix_metal_device.test.ports: p.id if p.name == "eth0"][0]
 }
 
-`, name)
+`, name, testDeviceTerminationTime())
 }
 
 func confAccMetalPort_L3(name string) string {

--- a/equinix/resource_metal_port_vlan_attachment_acc_test.go
+++ b/equinix/resource_metal_port_vlan_attachment_acc_test.go
@@ -24,8 +24,9 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
+  termination_time = "%s"
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }
 
 func testAccMetalPortVlanAttachmentConfig_L2Bonded_2(name string) string {
@@ -108,8 +109,9 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
+  termination_time = "%s"
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }
 
 func testAccMetalPortVlanAttachmentConfig_L2Individual_2(name string) string {
@@ -194,7 +196,8 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
-}`, name)
+  termination_time = "%s"
+}`, name, testDeviceTerminationTime())
 }
 
 func testAccMetalPortVlanAttachmentConfig_Hybrid_2(name string) string {
@@ -264,7 +267,8 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = equinix_metal_project.test.id
-}`, name)
+  termination_time = "%s"
+}`, name, testDeviceTerminationTime())
 }
 
 func testAccMetalPortVlanAttachmentConfig_HybridMultipleVlans_2(name string) string {
@@ -377,7 +381,8 @@ resource "equinix_metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
-}`, name)
+  termination_time = "%s"
+}`, name, testDeviceTerminationTime())
 }
 
 func testAccMetalPortVlanAttachmentConfig_L2Native_2(name string) string {

--- a/equinix/resource_metal_project_ssh_key_acc_test.go
+++ b/equinix/resource_metal_project_ssh_key_acc_test.go
@@ -30,9 +30,10 @@ resource "equinix_metal_device" "test" {
     billing_cycle       = "hourly"
     project_ssh_key_ids = ["${equinix_metal_project_ssh_key.test.id}"]
     project_id          = "${equinix_metal_project.test.id}"
+    termination_time    = "%s"
 }
 
-`, name, publicSshKey)
+`, name, publicSshKey, testDeviceTerminationTime())
 }
 
 func TestAccMetalProjectSSHKey_basic(t *testing.T) {

--- a/equinix/resource_metal_reserved_ip_block_acc_test.go
+++ b/equinix/resource_metal_reserved_ip_block_acc_test.go
@@ -244,8 +244,9 @@ resource "equinix_metal_device" "test" {
   ip_address {
 	 type = "private_ipv4"
   }
+  termination_time = "%s"
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }
 
 func TestAccMetalReservedIPBlock_device(t *testing.T) {


### PR DESCRIPTION
PR transferred from https://github.com/equinix/terraform-provider-metal/pull/190

> [t0mk](https://github.com/t0mk) commented [on 10 Sep 2021](https://github.com/equinix/terraform-provider-metal/pull/190#issue-993027922)
This PR adds termination_time to all the relevant metal_device resources in provider acceptance tests. Fixes https://github.com/equinix/terraform-provider-equinix/issues/166
Signed-off-by: Tomas Karasek [tom.to.the.k@gmail.com](mailto:tom.to.the.k@gmail.com)