### PR TITLE
r/ds equinix_metal_connection fixed and sync behavoir with terraform-provider-metal

### DIFF
--- a/docs/data-sources/equinix_metal_connection.md
+++ b/docs/data-sources/equinix_metal_connection.md
@@ -6,6 +6,8 @@ subcategory: "Metal"
 
 Use this data source to retrieve a [connection resource](https://metal.equinix.com/developers/docs/networking/fabric/)
 
+~> Equinix Metal connection with service_token_type `a_side` is not generally available and may not be enabled yet for your organization.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/equinix_metal_vrf.md
+++ b/docs/resources/equinix_metal_vrf.md
@@ -18,12 +18,12 @@ resource "equinix_metal_project" "example" {
 }
 
 resource "equinix_metal_vrf" "example" {
-	description = "VRF with ASN 65000 and a pool of address space that includes 192.168.100.0/25"
-	name = "example-vrf"
-	metro = "da"
-	local_asn = "65000"
-	ip_ranges = ["192.168.100.0/25", "192.168.200.0/25"]
-	project_id = equinix_metal_project.example.id
+    description = "VRF with ASN 65000 and a pool of address space that includes 192.168.100.0/25"
+    name = "example-vrf"
+    metro = "da"
+    local_asn = "65000"
+    ip_ranges = ["192.168.100.0/25", "192.168.200.0/25"]
+    project_id = equinix_metal_project.example.id
 }
 ```
 
@@ -31,19 +31,19 @@ Create IP reservations and assign them to a Metal Gateway resources. The Gateway
 
 ```hcl
 resource "equinix_metal_reserved_ip_block" "example" {
-	description = "Reserved IP block (192.168.100.0/29) taken from on of the ranges in the VRF's pool of address space."
+    description = "Reserved IP block (192.168.100.0/29) taken from on of the ranges in the VRF's pool of address space."
     project_id = equinix_metal_project.example.id
-	metro = equinix_metal_vrf.example.metro
-	type = "vrf"
-	vrf_id = equinix_metal_vrf.example.id
-	cidr = 29
+    metro = equinix_metal_vrf.example.metro
+    type = "vrf"
+    vrf_id = equinix_metal_vrf.example.id
+    cidr = 29
     network = "192.168.100.0"
 }
 
 resource "equinix_metal_vlan" "example" {
-	description = "A VLAN for Layer2 and Hybrid Metal devices"
-	metro       = equinix_metal_vrf.example.metro
-	project_id  = equinix_metal_project.example.id
+    description = "A VLAN for Layer2 and Hybrid Metal devices"
+    metro       = equinix_metal_vrf.example.metro
+    project_id  = equinix_metal_project.example.id
 }
 
 resource "equinix_metal_gateway" "example" {

--- a/equinix/data_source_metal_connection.go
+++ b/equinix/data_source_metal_connection.go
@@ -196,11 +196,8 @@ func dataSourceMetalConnection() *schema.Resource {
 }
 
 func getConnectionPorts(cps []packngo.ConnectionPort) []map[string]interface{} {
-	ret := make([]map[string]interface{}, len(cps))
-	order := map[packngo.ConnectionPortRole]int{
-		packngo.ConnectionPortPrimary:   0,
-		packngo.ConnectionPortSecondary: 1,
-	}
+	ret := make([]map[string]interface{}, 0, 1)
+
 	for _, p := range cps {
 		vcIDs := []string{}
 		for _, vc := range p.VirtualCircuits {
@@ -215,8 +212,7 @@ func getConnectionPorts(cps []packngo.ConnectionPort) []map[string]interface{} {
 			"link_status":         p.LinkStatus,
 			"virtual_circuit_ids": vcIDs,
 		}
-		// sort the ports by role, asserting the API always returns primary for len of 1 responses
-		ret[order[p.Role]] = connPort
+		ret = append(ret, connPort)
 	}
 	return ret
 }

--- a/equinix/data_source_metal_connection.go
+++ b/equinix/data_source_metal_connection.go
@@ -216,7 +216,6 @@ func getConnectionPorts(cps []packngo.ConnectionPort) []map[string]interface{} {
 			"link_status":         p.LinkStatus,
 			"virtual_circuit_ids": vcIDs,
 		}
-		ret = append(ret, connPort)
 		// sort the ports by role, asserting the API always returns primary for len of 1 responses
 		ret[order[p.Role]] = connPort
 	}

--- a/equinix/data_source_metal_connection.go
+++ b/equinix/data_source_metal_connection.go
@@ -196,7 +196,11 @@ func dataSourceMetalConnection() *schema.Resource {
 }
 
 func getConnectionPorts(cps []packngo.ConnectionPort) []map[string]interface{} {
-	ret := make([]map[string]interface{}, 0, 1)
+	ret := make([]map[string]interface{}, len(cps))
+	order := map[packngo.ConnectionPortRole]int{
+		packngo.ConnectionPortPrimary:   0,
+		packngo.ConnectionPortSecondary: 1,
+	}
 
 	for _, p := range cps {
 		vcIDs := []string{}
@@ -213,6 +217,8 @@ func getConnectionPorts(cps []packngo.ConnectionPort) []map[string]interface{} {
 			"virtual_circuit_ids": vcIDs,
 		}
 		ret = append(ret, connPort)
+		// sort the ports by role, asserting the API always returns primary for len of 1 responses
+		ret[order[p.Role]] = connPort
 	}
 	return ret
 }

--- a/equinix/data_source_metal_facility_acc_test.go
+++ b/equinix/data_source_metal_facility_acc_test.go
@@ -46,24 +46,24 @@ func TestAccDataSourceMetalFacility_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceMetalFacility_features(t *testing.T) {
+func TestAccDataSourceMetalFacility_Features(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDataSourceMetalFacilityConfig_features(),
+				Config:      testAccDataSourceMetalFacilityConfig_missingFeatures(),
 				ExpectError: matchErrMissingFeature,
 			},
 		},
 	})
 }
 
-func testAccDataSourceMetalFacilityConfig_features() string {
+func testAccDataSourceMetalFacilityConfig_missingFeatures() string {
 	return `
 data "equinix_metal_facility" "test" {
-    code = "ny5"
-    features_required = ["baremetal", "ibx"]
+    code = "da11"
+    features_required = ["baremetal", "ibx", "foofeature"]
 }
 `
 }

--- a/equinix/data_source_metal_gateway_acc_test.go
+++ b/equinix/data_source_metal_gateway_acc_test.go
@@ -34,7 +34,7 @@ resource "equinix_metal_project" "test" {
 }
 
 resource "equinix_metal_vlan" "test" {
-    description = "test VLAN in SV"
+    description = "tfacc-vlan test VLAN in SV"
     metro       = "sv"
     project_id  = equinix_metal_project.test.id
 }

--- a/equinix/data_source_metal_organization.go
+++ b/equinix/data_source_metal_organization.go
@@ -153,12 +153,12 @@ func dataSourceMetalOrganizationRead(d *schema.ResourceData, meta interface{}) e
 	d.SetId(org.ID)
 	return setMap(d, map[string]interface{}{
 		"organization_id": org.ID,
-		"name":        	   org.Name,
-		"description": 	   org.Description,
-		"website":     	   org.Website,
-		"twitter":     	   org.Twitter,
-		"logo":        	   org.Logo,
+		"name":            org.Name,
+		"description":     org.Description,
+		"website":         org.Website,
+		"twitter":         org.Twitter,
+		"logo":            org.Logo,
 		"project_ids":     projectIds,
-		"address":     	   flattenMetalOrganizationAddress(org.Address),
+		"address":         flattenMetalOrganizationAddress(org.Address),
 	})
 }

--- a/equinix/data_source_metal_spot_market_price_acc_test.go
+++ b/equinix/data_source_metal_spot_market_price_acc_test.go
@@ -34,7 +34,7 @@ data "equinix_metal_spot_market_price" "metro" {
 }
 
 data "equinix_metal_spot_market_price" "facility" {
-	metro    = "sv"
+	facility = "sv15"
 	plan     = "c3.medium.x86"
 }
 `)

--- a/equinix/data_source_metal_spot_market_request_acc_test.go
+++ b/equinix/data_source_metal_spot_market_request_acc_test.go
@@ -58,7 +58,7 @@ resource "equinix_metal_project" "test" {
 resource "equinix_metal_spot_market_request" "req" {
   project_id    = "${equinix_metal_project.test.id}"
   max_bid_price = 0.01
-  metro         = "sv"
+  facilities    = ["da11"]
   devices_min   = 1
   devices_max   = 1
   wait_for_devices = false
@@ -67,7 +67,7 @@ resource "equinix_metal_spot_market_request" "req" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_20_04"
-    plan             = "c3.small.x86"
+    plan             = "c3.medium.x86"
   }
 }
 
@@ -87,7 +87,7 @@ resource "equinix_metal_project" "test" {
 resource "equinix_metal_spot_market_request" "req" {
   project_id    = "${equinix_metal_project.test.id}"
   max_bid_price = 0.01
-  metro = "sv"
+  metro = "da"
   devices_min   = 1
   devices_max   = 1
   wait_for_devices = false
@@ -96,7 +96,7 @@ resource "equinix_metal_spot_market_request" "req" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_20_04"
-    plan             = "c3.small.x86"
+    plan             = "c3.medium.x86"
   }
 }
 

--- a/equinix/data_source_metal_vlan_acc_test.go
+++ b/equinix/data_source_metal_vlan_acc_test.go
@@ -115,6 +115,7 @@ data "equinix_metal_vlan" "dsvlan" {
 resource "equinix_metal_vlan" "barvlan" {
     project_id = equinix_metal_project.foobar.id
     metro = equinix_metal_vlan.foovlan.metro
+	description = "%s"
     vxlan = 6
 }
 
@@ -123,7 +124,7 @@ data "equinix_metal_vlan" "bardsvlan" {
     project_id = equinix_metal_vlan.barvlan.project_id
     vxlan = equinix_metal_vlan.barvlan.vxlan
 }
-`, projSuffix, metro, desc)
+`, projSuffix, metro, desc, desc)
 }
 
 func TestAccDataSourceMetalVlan_byVlanId(t *testing.T) {

--- a/equinix/data_source_metal_vlan_acc_test.go
+++ b/equinix/data_source_metal_vlan_acc_test.go
@@ -115,7 +115,7 @@ data "equinix_metal_vlan" "dsvlan" {
 resource "equinix_metal_vlan" "barvlan" {
     project_id = equinix_metal_project.foobar.id
     metro = equinix_metal_vlan.foovlan.metro
-	description = "%s"
+    description = "%s"
     vxlan = 6
 }
 

--- a/equinix/data_source_network_device.go
+++ b/equinix/data_source_network_device.go
@@ -43,6 +43,7 @@ func getNeDeviceStatusList(deviceStateText string) (*[]string, error) {
 	}
 	return &validItems, nil
 }
+
 func stringIsValidDeviceStateList(i interface{}, k string) ([]string, []error) {
 	v, ok := i.(string)
 	if !ok {

--- a/equinix/data_source_network_device_test.go
+++ b/equinix/data_source_network_device_test.go
@@ -1,13 +1,14 @@
 package equinix
 
 import (
-	"github.com/equinix/ne-go"
 	"reflect"
 	"testing"
+
+	"github.com/equinix/ne-go"
 )
 
 func TestGetDeviceStatusList(t *testing.T) {
-	var input = ""
+	input := ""
 	result, err := getNeDeviceStatusList(input)
 	if err != nil {
 		t.Errorf("got error %v for input: %v", err, input)
@@ -38,7 +39,7 @@ func TestGetDeviceStatusList(t *testing.T) {
 	}
 
 	input = "provisioned" // single item
-	var expected = &[]string{ne.DeviceStateProvisioned}
+	expected := &[]string{ne.DeviceStateProvisioned}
 	test(input, expected, false)
 
 	input = "provisioning,provisioned" // 2 items

--- a/equinix/helpers_device_test.go
+++ b/equinix/helpers_device_test.go
@@ -17,9 +17,11 @@ type mockHWService struct {
 func (m *mockHWService) Get(id string, opt *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
 	return m.GetFn(id, opt)
 }
+
 func (m *mockHWService) List(project string, opt *packngo.ListOptions) ([]packngo.HardwareReservation, *packngo.Response, error) {
 	return m.ListFn(project, opt)
 }
+
 func (m *mockHWService) Move(id string, dest string) (*packngo.HardwareReservation, *packngo.Response, error) {
 	return m.MoveFn(id, dest)
 }

--- a/equinix/resource_metal_bgp_setup_acc_test.go
+++ b/equinix/resource_metal_bgp_setup_acc_test.go
@@ -79,7 +79,7 @@ resource "equinix_metal_project" "test" {
 resource "equinix_metal_device" "test" {
     hostname         = "tfacc-test-bgp-sesh"
     plan             = "c3.small.x86"
-    facilities       = ["ny5"]
+    facilities       = ["ny5", "ny7", "any"]
     operating_system = "ubuntu_16_04"
     billing_cycle    = "hourly"
     project_id       = "${equinix_metal_project.test.id}"

--- a/equinix/resource_metal_connection.go
+++ b/equinix/resource_metal_connection.go
@@ -10,20 +10,22 @@ import (
 	"github.com/packethost/packngo"
 )
 
-var mega uint64 = 1000 * 1000
-var giga uint64 = 1000 * mega
-var allowedSpeeds = []struct {
-	Int uint64
-	Str string
-}{
-	{50 * mega, "50Mbps"},
-	{200 * mega, "200Mbps"},
-	{500 * mega, "500Mbps"},
-	{1 * giga, "1Gbps"},
-	{2 * giga, "2Gbps"},
-	{5 * giga, "5Gbps"},
-	{10 * giga, "10Gbps"},
-}
+var (
+	mega          uint64 = 1000 * 1000
+	giga          uint64 = 1000 * mega
+	allowedSpeeds        = []struct {
+		Int uint64
+		Str string
+	}{
+		{50 * mega, "50Mbps"},
+		{200 * mega, "200Mbps"},
+		{500 * mega, "500Mbps"},
+		{1 * giga, "1Gbps"},
+		{2 * giga, "2Gbps"},
+		{5 * giga, "5Gbps"},
+		{10 * giga, "10Gbps"},
+	}
+)
 
 func speedStrToUint(speed string) (uint64, error) {
 	allowedStrings := []string{}
@@ -91,7 +93,8 @@ func resourceMetalConnection() *schema.Resource {
 				Description: "Connection redundancy - redundant or primary",
 				ValidateFunc: validation.StringInSlice([]string{
 					string(packngo.ConnectionRedundant),
-					string(packngo.ConnectionPrimary)}, false),
+					string(packngo.ConnectionPrimary),
+				}, false),
 			},
 			"type": {
 				Type:        schema.TypeString,
@@ -100,7 +103,8 @@ func resourceMetalConnection() *schema.Resource {
 				ForceNew:    true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(packngo.ConnectionDedicated),
-					string(packngo.ConnectionShared)}, false),
+					string(packngo.ConnectionShared),
+				}, false),
 			},
 			"project_id": {
 				Type:        schema.TypeString,
@@ -125,7 +129,8 @@ func resourceMetalConnection() *schema.Resource {
 				Default:     "standard",
 				ValidateFunc: validation.StringInSlice([]string{
 					string(packngo.ConnectionModeStandard),
-					string(packngo.ConnectionModeTunnel)}, false),
+					string(packngo.ConnectionModeTunnel),
+				}, false),
 			},
 			"tags": {
 				Type:        schema.TypeList,
@@ -135,7 +140,7 @@ func resourceMetalConnection() *schema.Resource {
 			},
 			"vlans": {
 				Type:        schema.TypeList,
-				Description: "Only used with shared connection. Vlans to attach. Pass one vlan for Primary/Single connection and two vlans for Redundant connection",
+				Description: "Only used with shared connection. VLANs to attach. Pass one vlan for Primary/Single connection and two vlans for Redundant connection",
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeInt},
 				MaxItems:    2,
@@ -335,7 +340,6 @@ func resourceMetalConnectionUpdate(d *schema.ResourceData, meta interface{}) err
 		if _, _, err := client.Connections.Update(d.Id(), &ur, nil); err != nil {
 			return friendlyError(err)
 		}
-
 	}
 	return resourceMetalConnectionRead(d, meta)
 }

--- a/equinix/resource_metal_connection_acc_test.go
+++ b/equinix/resource_metal_connection_acc_test.go
@@ -126,10 +126,11 @@ func testAccMetalConnectionConfig_dedicated(randstr string) string {
             name = "tfacc-conn-pro-%s"
         }
 
+		// We use the project resource to get organization_id
         resource "equinix_metal_connection" "test" {
             name            = "tfacc-conn-%s"
             metro           = "sv"
-			project_id      = equinix_metal_project.test.id
+			organization_id = equinix_metal_project.test.organization_id
             type            = "dedicated"
             redundancy      = "redundant"
 			tags            = ["tfacc"]
@@ -189,13 +190,14 @@ func testAccMetalConnectionConfig_tunnel(randstr string) string {
             name = "tfacc-conn-pro-%s"
         }
 
-        resource "equinix_metal_connection" "test" {
-            name            = "tfacc-conn-%s"
+		// We use the project resource to get organization_id internally
+		resource "equinix_metal_connection" "test" {
+			name            = "tfacc-conn-%s"
 			project_id      = equinix_metal_project.test.id
-            metro           = "sv"
-            redundancy      = "redundant"
-            type            = "dedicated"
-            mode            = "tunnel"
+			metro           = "sv"
+			redundancy      = "redundant"
+			type            = "dedicated"
+			mode            = "tunnel"
 			speed           = "50Mbps"
         }`,
 		randstr, randstr)
@@ -217,9 +219,10 @@ func TestAccMetalConnection_tunnel(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "equinix_metal_connection.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "equinix_metal_connection.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id"},
 			},
 		},
 	})

--- a/equinix/resource_metal_connection_acc_test.go
+++ b/equinix/resource_metal_connection_acc_test.go
@@ -17,7 +17,6 @@ func TestSpeedConversion(t *testing.T) {
 	speedUint, err := speedStrToUint("50Mbps")
 	if err != nil {
 		t.Errorf("Error converting speed string to uint64: %s", err)
-
 	}
 	if speedUint != 50*mega {
 		t.Errorf("Speed string conversion failed. Expected: %d, got: %d", 50*mega, speedUint)

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -621,7 +621,7 @@ resource "equinix_metal_device" "test"  {
 
   hostname         = "tfacc-device-test-ipxe-script-url"
   plan             = "c3.small.x86"
-  facilities       = ["sv15", "da11", "any"]
+  facilities       = ["sv15", "any"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"

--- a/equinix/resource_metal_device_network_type.go
+++ b/equinix/resource_metal_device_network_type.go
@@ -86,7 +86,6 @@ func resourceMetalDeviceNetworkTypeRead(d *schema.ResourceData, meta interface{}
 	client := meta.(*Config).metal
 
 	_, devNType, err := getDevIDandNetworkType(d, client)
-
 	if err != nil {
 		err = friendlyError(err)
 

--- a/equinix/resource_metal_gateway_acc_test.go
+++ b/equinix/resource_metal_gateway_acc_test.go
@@ -35,7 +35,7 @@ resource "equinix_metal_project" "test" {
 }
 
 resource "equinix_metal_vlan" "test" {
-    description = "test VLAN in SV"
+    description = "tfacc-vlan VLAN in SV"
     metro       = "sv"
     project_id  = equinix_metal_project.test.id
 }
@@ -76,7 +76,7 @@ resource "equinix_metal_project" "test" {
 }
 
 resource "equinix_metal_vlan" "test" {
-    description = "test VLAN in SV"
+    description = "tfacc-vlan in SV"
     metro       = "sv"
     project_id  = equinix_metal_project.test.id
 }

--- a/equinix/resource_metal_organization.go
+++ b/equinix/resource_metal_organization.go
@@ -1,10 +1,11 @@
 package equinix
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/packethost/packngo"
-	"regexp"
 )
 
 func resourceMetalOrganization() *schema.Resource {
@@ -91,9 +92,9 @@ func createMetalOrganizationAddressResourceSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringMatch(regexp.MustCompile("(?i)^[a-z]{2}$"), "Address country must be a two letter code (ISO 3166-1 alpha-2)"),
 		},
 		"state": {
-			Type:         schema.TypeString,
-			Description:  "State name",
-			Optional:     true,
+			Type:        schema.TypeString,
+			Description: "State name",
+			Optional:    true,
 		},
 	}
 }
@@ -102,7 +103,7 @@ func resourceMetalOrganizationCreate(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*Config).metal
 
 	createRequest := &packngo.OrganizationCreateRequest{
-		Name: d.Get("name").(string),
+		Name:    d.Get("name").(string),
 		Address: expandMetalOrganizationAddress(d.Get("address").([]interface{})),
 	}
 
@@ -232,7 +233,6 @@ func flattenMetalOrganizationAddress(addr packngo.Address) interface{} {
 }
 
 func expandMetalOrganizationAddress(address []interface{}) packngo.Address {
-
 	transformed := packngo.Address{}
 	addr := address[0].(map[string]interface{})
 

--- a/equinix/resource_metal_port_acc_test.go
+++ b/equinix/resource_metal_port_acc_test.go
@@ -118,7 +118,7 @@ resource "equinix_metal_port" "bond0" {
 }
 
 resource "equinix_metal_vlan" "test" {
-  description = "test"
+  description = "tfacc-vlan test"
   metro = "sv"
   project_id = equinix_metal_project.test.id
 }
@@ -138,14 +138,14 @@ resource "equinix_metal_port" "bond0" {
 }
 
 resource "equinix_metal_vlan" "test1" {
-  description = "test1"
+  description = "tfacc-vlan test1"
   metro = "sv"
   project_id = equinix_metal_project.test.id
   vxlan = 1001
 }
 
 resource "equinix_metal_vlan" "test2" {
-  description = "test2"
+  description = "tfacc-vlan test2"
   metro = "sv"
   project_id = equinix_metal_project.test.id
   vxlan = 1002

--- a/equinix/resource_metal_port_vlan_attachment_acc_test.go
+++ b/equinix/resource_metal_port_vlan_attachment_acc_test.go
@@ -19,8 +19,8 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-port-vlan-attachment-test"
-  plan             = "m2.xlarge.x86"
-  facilities       = ["nrt1"]
+  plan             = "m3.xlarge.x86"
+  facilities       = ["ny5"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
@@ -34,14 +34,14 @@ func testAccMetalPortVlanAttachmentConfig_L2Bonded_2(name string) string {
 %s
 
 resource "equinix_metal_vlan" "test1" {
-  description = "test VLAN 1"
-  facility    = "nrt1"
+  description = "tfacc-vlan test VLAN 1"
+  facility    = "ny5"
   project_id  = "${equinix_metal_project.test.id}"
 }
 
 resource "equinix_metal_vlan" "test2" {
-  description = "test VLAN 2"
-  facility    = "nrt1"
+  description = "tfacc-vlan test VLAN 2"
+  facility    = "ny5"
   project_id  = "${equinix_metal_project.test.id}"
 }
 
@@ -104,8 +104,8 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-vlan-l2i-test"
-  plan             = "m2.xlarge.x86"
-  facilities       = ["nrt1"]
+  plan             = "m3.xlarge.x86"
+  facilities       = ["ny5"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
@@ -119,14 +119,14 @@ func testAccMetalPortVlanAttachmentConfig_L2Individual_2(name string) string {
 %s
 
 resource "equinix_metal_vlan" "test1" {
-  description = "test VLAN 1"
-  facility    = "nrt1"
+  description = "tfacc-vlan test VLAN 1"
+  facility    = "ny5"
   project_id  = "${equinix_metal_project.test.id}"
 }
 
 resource "equinix_metal_vlan" "test2" {
-  description = "test VLAN 2"
-  facility    = "nrt1"
+  description = "tfacc-vlan test VLAN 2"
+  facility    = "ny5"
   project_id  = "${equinix_metal_project.test.id}"
 }
 
@@ -192,7 +192,7 @@ resource "equinix_metal_project" "test" {
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-hybrid-test"
   plan             = "n2.xlarge.x86"
-  facilities       = ["ewr1"]
+  facilities       = ["ny5"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
@@ -210,8 +210,8 @@ resource "equinix_metal_device_network_type" "test" {
 }
 
 resource "equinix_metal_vlan" "test" {
-  description = "test vlan"
-  facility    = "ewr1"
+  description = "tfacc-vlan test vlan"
+  facility    = "ny5"
   project_id  = "${equinix_metal_project.test.id}"
 }
 
@@ -262,8 +262,8 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-hmv-test"
-  plan             = "m2.xlarge.x86"
-  facilities       = ["nrt1"]
+  plan             = "m3.xlarge.x86"
+  facilities       = ["ny5"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = equinix_metal_project.test.id
@@ -277,8 +277,8 @@ func testAccMetalPortVlanAttachmentConfig_HybridMultipleVlans_2(name string) str
 
 resource "equinix_metal_vlan" "test" {
   count       = 3
-  description = "test VLAN"
-  facility    = "nrt1"
+  description = "tfacc-vlan test VLAN"
+  facility    = "ny5"
   project_id  = equinix_metal_project.test.id
 }
 
@@ -376,8 +376,8 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-l2n-test"
-  plan             = "m2.xlarge.x86"
-  facilities       = ["nrt1"]
+  plan             = "m3.xlarge.x86"
+  facilities       = ["ny5"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
@@ -390,14 +390,14 @@ func testAccMetalPortVlanAttachmentConfig_L2Native_2(name string) string {
 %s
 
 resource "equinix_metal_vlan" "test1" {
-  description = "test VLAN 1"
-  facility    = "nrt1"
+  description = "tfacc-vlan test VLAN 1"
+  facility    = "ny5"
   project_id  = "${equinix_metal_project.test.id}"
 }
 
 resource "equinix_metal_vlan" "test2" {
-  description = "test VLAN 2"
-  facility    = "nrt1"
+  description = "tfacc-vlan test VLAN 2"
+  facility    = "ny5"
   project_id  = "${equinix_metal_project.test.id}"
 }
 

--- a/equinix/resource_metal_port_vlan_attachment_acc_test.go
+++ b/equinix/resource_metal_port_vlan_attachment_acc_test.go
@@ -19,7 +19,7 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-port-vlan-attachment-test"
-  plan             = "m3.xlarge.x86"
+  plan             = "m3.large.x86"
   facilities       = ["ny5"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -104,7 +104,7 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-vlan-l2i-test"
-  plan             = "m3.xlarge.x86"
+  plan             = "m3.large.x86"
   facilities       = ["ny5"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -262,7 +262,7 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-hmv-test"
-  plan             = "m3.xlarge.x86"
+  plan             = "m3.large.x86"
   facilities       = ["ny5"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -376,7 +376,7 @@ resource "equinix_metal_project" "test" {
 
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-l2n-test"
-  plan             = "m3.xlarge.x86"
+  plan             = "m3.large.x86"
   facilities       = ["ny5"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"

--- a/equinix/resource_metal_project_ssh_key_acc_test.go
+++ b/equinix/resource_metal_project_ssh_key_acc_test.go
@@ -25,7 +25,7 @@ resource "equinix_metal_project_ssh_key" "test" {
 resource "equinix_metal_device" "test" {
     hostname            = "tfacc-device-key-test"
     plan                = "c2.medium.x86"
-    facilities          = ["ny5", "ewr1", "any"]
+    facilities          = ["ny5", "ny7", "any"]
     operating_system    = "ubuntu_16_04"
     billing_cycle       = "hourly"
     project_ssh_key_ids = ["${equinix_metal_project_ssh_key.test.id}"]

--- a/equinix/resource_metal_reserved_ip_block_acc_test.go
+++ b/equinix/resource_metal_reserved_ip_block_acc_test.go
@@ -34,7 +34,7 @@ resource "equinix_metal_project" "foobar" {
 
 resource "equinix_metal_reserved_ip_block" "test" {
 	project_id  = equinix_metal_project.foobar.id
-	facility    = "ewr1"
+	facility    = "ny5"
 	type        = "public_ipv4"
 	quantity    = 2
 	tags        = ["Tag1", "Tag2"]
@@ -150,9 +150,9 @@ func TestAccMetalReservedIPBlock_importBasic(t *testing.T) {
 				Config: testAccMetalReservedIPBlockConfig_public(rs),
 			},
 			{
-				ResourceName:      "equinix_metal_reserved_ip_block.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "equinix_metal_reserved_ip_block.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"wait_for_state"},
 			},
 		},

--- a/equinix/resource_metal_reserved_ip_block_acc_test.go
+++ b/equinix/resource_metal_reserved_ip_block_acc_test.go
@@ -34,7 +34,7 @@ resource "equinix_metal_project" "foobar" {
 
 resource "equinix_metal_reserved_ip_block" "test" {
 	project_id  = equinix_metal_project.foobar.id
-	facility    = "ny5"
+	facility    = "ewr1"
 	type        = "public_ipv4"
 	quantity    = 2
 	tags        = ["Tag1", "Tag2"]

--- a/equinix/resource_metal_spot_market_request_acc_test.go
+++ b/equinix/resource_metal_spot_market_request_acc_test.go
@@ -145,7 +145,7 @@ func TestAccMetalSpotMarketRequest_Import(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccMetalSSHKeyCheckDestroyed,
+		CheckDestroy: testAccMetalSpotMarketRequestCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckMetalSpotMarketRequestConfig_import(context),

--- a/equinix/resource_metal_virtual_circuit_acc_test.go
+++ b/equinix/resource_metal_virtual_circuit_acc_test.go
@@ -3,8 +3,8 @@ package equinix
 import (
 	"fmt"
 	"log"
-	"testing"
 	"os"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/equinix/resource_metal_virtual_circuit_acc_test.go
+++ b/equinix/resource_metal_virtual_circuit_acc_test.go
@@ -73,40 +73,52 @@ func testAccMetalVirtualCircuitCheckDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccMetalVirtualCircuitConfig_dedicated(randstr string, randint int) string {
+
+func testAccMetalConnectionConfig_vc(randint int) string {
 	// Dedicated connection in DA metro
 	testConnection := os.Getenv(metalDedicatedConnIDEnvVar)
 
 	return fmt.Sprintf(`
-		data "equinix_metal_connection" test {
-			connection_id = "%[1]s"
-		}
-
-        resource "equinix_metal_project" "test" {
-            name = "tfacc-conn-pro-%[2]s"
+        locals {
+                conn_id = "%s"
         }
 
-		resource "equinix_metal_vlan" "test" {
+        data "equinix_metal_connection" test {
+            connection_id = local.conn_id
+        }
+
+        resource "equinix_metal_project" "test" {
+            name = "tfacc-conn-pro-%[2]d"
+        }
+
+        resource "equinix_metal_vlan" "test" {
             project_id = equinix_metal_project.test.id
-            metro      = "da"
+            metro      = data.equinix_metal_connection.test.metro
 			description = "tfacc-vlan test"
         }
 
         resource "equinix_metal_virtual_circuit" "test" {
-			name = "tfacc-vc-%[2]s"
-			description = "tfacc-vc-%[2]s"
-            connection_id = data.equinix_metal_connection.test.id
+            name = "tfacc-vc-%[2]d"
+            description = "tfacc-vc-%[2]d"
+            connection_id = data.equinix_metal_connection.test.connection_id
             project_id = equinix_metal_project.test.id
             port_id = data.equinix_metal_connection.test.ports[0].id
             vlan_id = equinix_metal_vlan.test.id
-            nni_vlan = %[3]d
+            nni_vlan = %[2]d
         }
         `,
-		testConnection, randstr, randint)
+		testConnection, randint)
+}
+
+func testAccMetalConnectionConfig_vcds(randint int) string {
+	return testAccMetalConnectionConfig_vc(randint) + `
+	datasource "equinix_metal_virtual_circuit" "test" {
+		virtual_circuit_id = equinix_metal_virtual_circuit.test.id
+	}
+	`
 }
 
 func TestAccMetalVirtualCircuit_dedicated(t *testing.T) {
-	rs := acctest.RandString(10)
 	ri := acctest.RandIntRange(1024, 1093)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -115,7 +127,7 @@ func TestAccMetalVirtualCircuit_dedicated(t *testing.T) {
 		CheckDestroy: testAccMetalVirtualCircuitCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMetalVirtualCircuitConfig_dedicated(rs, ri),
+				Config: testAccMetalConnectionConfig_vc(ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"equinix_metal_virtual_circuit.test", "vlan_id",

--- a/equinix/resource_metal_vrf_acc_test.go
+++ b/equinix/resource_metal_vrf_acc_test.go
@@ -169,9 +169,9 @@ func TestAccMetalVRF_withIPReservations(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName:      "equinix_metal_reserved_ip_block.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "equinix_metal_reserved_ip_block.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"wait_for_state"},
 			},
 		},

--- a/equinix/resource_metal_vrf_acc_test.go
+++ b/equinix/resource_metal_vrf_acc_test.go
@@ -274,6 +274,7 @@ func TestAccMetalVRFConfig_withConnection(t *testing.T) {
 				ResourceName:      "equinix_metal_reserved_ip_block.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"wait_for_state"},
 			},
 			{
 				ResourceName:      "equinix_metal_vlan.test",

--- a/equinix/resource_network_device.go
+++ b/equinix/resource_network_device.go
@@ -275,11 +275,11 @@ func createNetworkDeviceSchema() map[string]*schema.Schema {
 			Description:  neDeviceDescriptions["ThroughputUnit"],
 		},
 		neDeviceSchemaNames["HostName"]: {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ForceNew:     true,
-			Description:  neDeviceDescriptions["HostName"],
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			ForceNew:    true,
+			Description: neDeviceDescriptions["HostName"],
 		},
 		neDeviceSchemaNames["PackageCode"]: {
 			Type:         schema.TypeString,
@@ -513,10 +513,10 @@ func createNetworkDeviceSchema() map[string]*schema.Schema {
 						Description: neDeviceDescriptions["Region"],
 					},
 					neDeviceSchemaNames["HostName"]: {
-						Type:         schema.TypeString,
-						Optional:     true,
-						ForceNew:     true,
-						Description:  neDeviceDescriptions["HostName"],
+						Type:        schema.TypeString,
+						Optional:    true,
+						ForceNew:    true,
+						Description: neDeviceDescriptions["HostName"],
 					},
 					neDeviceSchemaNames["LicenseToken"]: {
 						Type:          schema.TypeString,


### PR DESCRIPTION
Sync https://github.com/equinix/terraform-provider-metal/pull/223

- Always return project_id specified in the schema (to cover dedicated connection without project), and later for shared connections check project assigned to the virtual circuit.
- Allow retrieve existing connections created through the portal with speed value 0.
- Sort ports by role , asserting the API always returns primary for len of 1 responses (to replicate current provider equinix behavoir)
- Solved r/equinix_metal_connection producing non-empty plan after apply if type is dedicated (More details https://github.com/equinix/terraform-provider-metal/issues/222)
- Fix https://github.com/equinix/terraform-provider-equinix/issues/144
