### PR TITLE
Add end_at param to spot_market_request to allow limiting SMR duration

### DIFF
--- a/docs/resources/equinix_metal_spot_market_request.md
+++ b/docs/resources/equinix_metal_spot_market_request.md
@@ -39,11 +39,11 @@ The following arguments are supported:
 * `wait_for_devices` - (Optional) On resource creation wait until all desired devices are active.
 On resource destruction wait until devices are removed.
 * `facilities` - (Optional) Facility IDs where devices should be created.
+* `end_at` - (Optional) Deadline for the request. For example \"2021-09-03T16:32:00+03:00\". If you don't supply timezone info, timestamp is assumed to be in UTC."
 * `metro` - (Optional) Metro where devices should be created.
 * `locked` - (Optional) Blocks deletion of the SpotMarketRequest device until the lock is disabled.
 * `instance_parameters` - (Required) Key/Value pairs of parameters for devices provisioned from
-this request. Valid keys are: `billing_cycle`, `plan`, `operating_system`, `hostname`,
-`termintation_time`, `always_pxe`, `description`, `features`, `locked`, `project_ssh_keys`,
+this request. Valid keys are: `billing_cycle`, `plan`, `operating_system`, `hostname`, `always_pxe` (Defaults to false), `description`, `features`, `locked`, `project_ssh_keys`,
 `user_ssh_keys`, `userdata`, `customdata`, `ipxe_script_url`, `tags`. You can find each parameter
 description in [equinix_metal_device](equinix_metal_device.md) docs.
 
@@ -52,6 +52,10 @@ description in [equinix_metal_device](equinix_metal_device.md) docs.
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the Spot Market Request.
+
+The `instance_parameters` block additionally exports:
+
+* `termination_time` - Timestamp for device termination shown once the device has been outbid.
 
 ### Timeouts
 

--- a/equinix/resource_metal_spot_market_request_acc_test.go
+++ b/equinix/resource_metal_spot_market_request_acc_test.go
@@ -3,6 +3,7 @@ package equinix
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -10,12 +11,17 @@ import (
 	"github.com/packethost/packngo"
 )
 
+func testSpotMarketRequestTerminationTime() string {
+	return time.Now().UTC().Add(60 * time.Minute).Format(time.RFC3339)
+}
+
 func TestAccMetalSpotMarketRequest_basic(t *testing.T) {
 	var key packngo.SpotMarketRequest
 	context := map[string]interface{}{
 		"name_suffix": acctest.RandString(10),
 		"facility":    "sv15",
 		"plan":        "c3.small.x86",
+		"end_at":      testSpotMarketRequestTerminationTime(),
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -98,6 +104,7 @@ resource "equinix_metal_spot_market_request" "request" {
   devices_min      = 1
   devices_max      = 1
   wait_for_devices = true
+  end_at           = "%{end_at}"
 
   instance_parameters {
     hostname         = "tfacc-testspot"
@@ -126,6 +133,7 @@ resource "equinix_metal_spot_market_request" "request" {
   devices_min      = 1
   devices_max      = 1
   wait_for_devices = true
+  end_at           = "%{end_at}"
 
   instance_parameters {
     hostname         = "tfacc-testspot"
@@ -141,6 +149,7 @@ func TestAccMetalSpotMarketRequest_Import(t *testing.T) {
 		"name_suffix": acctest.RandString(10),
 		"facility":    "sv15",
 		"plan":        "c3.small.x86",
+		"end_at":      testSpotMarketRequestTerminationTime(),
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
Formerly: https://github.com/equinix/terraform-provider-metal/pull/191

> This PR adds end_at parameter to metal_spot_market_request to allow removing the SMR in future. Will be useful for our acceptance tests.
> 
> Signed-off-by: Tomas Karasek [tom.to.the.k@gmail.com](mailto:tom.to.the.k@gmail.com)

I have added some changes based on the conversation in the original PR thread:

- Replaced termin**t**ation with termination in both doc and code (should instead mark the wrong schema attribute "termintation_time" as deprecated? https://www.terraform.io/plugin/sdkv2/best-practices/deprecations#renaming-a-computed-attribute)
- Update docs to keep termination_time in the attributes section
- Moved testSpotMarketRequestTerminationTime function to the SMR acceptance test file 