### PR TITLE
Fix gateway and vc delete waiting

### DIFF
--- a/equinix/resource_metal_gateway.go
+++ b/equinix/resource_metal_gateway.go
@@ -166,7 +166,7 @@ func resourceMetalGatewayDelete(d *schema.ResourceData, meta interface{}) error 
 	)
 
 	_, err = deleteWaiter.WaitForState()
-	if ignoreResponseErrors(httpForbidden, httpNotFound)(resp, err) != nil {
+	if ignoreResponseErrors(httpForbidden, httpNotFound)(nil, err) != nil {
 		return fmt.Errorf("Error deleting Metal Gateway %s: %s", d.Id(), err)
 	}
 

--- a/equinix/resource_metal_virtual_circuit.go
+++ b/equinix/resource_metal_virtual_circuit.go
@@ -343,7 +343,7 @@ func resourceMetalVirtualCircuitDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	// then we delete the VC. VRF VCs will be in the "active" state.
+	// we wait until vc status is not deactivating. VRF VCs will be in the "active" state.
 	detachWaiter := getVCStateWaiter(
 		client,
 		d.Id(),
@@ -354,9 +354,10 @@ func resourceMetalVirtualCircuitDelete(d *schema.ResourceData, meta interface{})
 
 	_, err = detachWaiter.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error deleting virtual circuit %s: %s", d.Id(), err)
+		return fmt.Errorf("Error waiting for virtual circuit %s status is not deactivating before deleting it: %s", d.Id(), err)
 	}
 
+	// then we delete the VC. VRF VCs will be in the "active" state.
 	resp, err := client.VirtualCircuits.Delete(d.Id())
 	if ignoreResponseErrors(httpForbidden, httpNotFound)(resp, err) != nil {
 		return friendlyError(err)
@@ -371,7 +372,7 @@ func resourceMetalVirtualCircuitDelete(d *schema.ResourceData, meta interface{})
 	)
 
 	_, err = deleteWaiter.WaitForState()
-	if ignoreResponseErrors(httpForbidden, httpNotFound)(resp, err) != nil {
+	if ignoreResponseErrors(httpForbidden, httpNotFound)(nil, err) != nil {
 		return fmt.Errorf("Error deleting virtual circuit %s: %s", d.Id(), err)
 	}
 	d.SetId("")

--- a/equinix/resource_metal_virtual_circuit_acc_test.go
+++ b/equinix/resource_metal_virtual_circuit_acc_test.go
@@ -106,7 +106,7 @@ func testAccMetalConnectionConfig_vc(randint int) string {
 
 func testAccMetalConnectionConfig_vcds(randint int) string {
 	return testAccMetalConnectionConfig_vc(randint) + `
-	datasource "equinix_metal_virtual_circuit" "test" {
+	data "equinix_metal_virtual_circuit" "test" {
 		virtual_circuit_id = equinix_metal_virtual_circuit.test.id
 	}
 	`


### PR DESCRIPTION
`ignoreResponseErrors` after `deleteWaiter.WaitForState` for both gw and vc was taking a previous http response an not the one coming from the last API request originated in the WaitForState `Refresh` function. `ignoreResponseErrors` functions (`httpForbidden`, `httpNotFound`,...) check the http StatusCode if the response arg is not `nil`, otherwise they check the error arg and see if it is of type `packngo.ErrorResponse` and then get the `StatusCode` from the error.

~`if ignoreResponseErrors(httpForbidden, httpNotFound)(resp, err)`~
`if ignoreResponseErrors(httpForbidden, httpNotFound)(nil, err)`