### PR TITLE
fix missing attribute connection_id in ds equinix_metal_virtual_circuit

### DIFF
--- a/docs/data-sources/equinix_metal_virtual_circuit.md
+++ b/docs/data-sources/equinix_metal_virtual_circuit.md
@@ -33,6 +33,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `name` - Name of the virtual circuit resource.
+* `connection_id` - UUID of Connection where the VC is scoped to.
 * `status` - Status of the virtal circuit.
 * `port_id` - UUID of the Connection Port where the VC is scoped to.
 * `project_id` - ID of project to which the VC belongs.

--- a/equinix/data_source_metal_virtual_circuit.go
+++ b/equinix/data_source_metal_virtual_circuit.go
@@ -14,6 +14,11 @@ func dataSourceMetalVirtualCircuit() *schema.Resource {
 				Required:    true,
 				Description: "ID of the virtual circuit to lookup",
 			},
+			"connection_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UUID of Connection where the VC is scoped to",
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Computed:    true,


### PR DESCRIPTION
This PR adds missing `connection_id` in data source `equinix_metal_virtual_circuit`

All data source using same read function than their matching resource must have same schema keys or it [will produce an error in the d.Set(key, value) function if the key is invalid.](https://pkg.go.dev/github.com/hashicorp/terraform/helper/schema#ResourceData.Set
) 

This error was found in the equinix metal provider: https://github.com/equinix/terraform-provider-metal/runs/7204768928?check_suite_focus=true#step:5:629