### PR TITLE
add attribute zside_service_token to equinix_ecx_l2_connection

### DIFF
--- a/docs/resources/equinix_ecx_l2_connection.md
+++ b/docs/resources/equinix_ecx_l2_connection.md
@@ -112,6 +112,25 @@ resource "equinix_ecx_l2_connection" "token-to-gcp" {
 }
 ```
 
+### Non-redundant Connection from own Equinix Port to an Equinix customer port using Z-Side Service token
+
+```hcl
+data "equinix_ecx_port" "sv-qinq-pri" {
+  name = "CX-SV5-NL-Dot1q-BO-10G-PRI"
+}
+
+resource "equinix_ecx_l2_connection" "port-to-token" {
+  name                = "tf-port-token"
+  zside_service_token = "e9c22453-d3a7-4d5d-9112-d50173531392"
+  speed               = 200
+  speed_unit          = "MB"
+  notifications       = ["john@equinix.com", "marry@equinix.com"]
+  seller_metro_code   = "FR"
+  port_uuid           = data.equinix_ecx_port.sv-qinq-pri.id
+  vlan_stag           = 1000
+}
+```
+
 -> **NOTE:** See [Equinix Fabric connecting to the cloud](../guides/equinix_fabric_cloud_providers.md)
 guide for more details on how to connect to a CSP.
 
@@ -134,10 +153,14 @@ the Network Edge virtual device from which the connection would originate.
 * `device_interface_id` - (Optional) Applicable with `device_uuid`, identifier of network interface
 on a given device, used for a connection. If not specified then first available interface will be
 selected.
-* `service_token`- (Required when `port_uuid` or `device_uuid` are not set) - Unique Equinix Fabric
-key given by a provider that grants you authorization to the Equinix Port or virtual device from
-which the connection would originate.
-More details in [A-Side Fabric Service Tokens](https://docs.equinix.com/en-us/Content/Interconnection/Fabric/service%20tokens/Fabric-Service-Tokens.htm).
+* `service_token`- (Required when `port_uuid` or `device_uuid` are not set) - A-side
+service tokens authorize you to create a connection from a customer port, which created the token
+for you, to a service profile or your own port.
+More details in [A-Side Fabric Service Tokens](https://docs.equinix.com/en-us/Content/Interconnection/Fabric/service%20tokens/Fabric-Service-Tokens.htm#:~:text=the%20service%20token.-,A%2DSide%20Service%20Tokens,-If%20you%20want).
+* `zside_service_token`- (Required when `profile_uuid` or `zside_port_uuid` are not set) - Z-side
+service tokens authorize you to create a connection from your port or virtual device to a customer
+port which created the token for you.
+More details in [Z-Side Fabric Service Tokens](https://docs.equinix.com/en-us/Content/Interconnection/Fabric/service%20tokens/Fabric-Service-Tokens.htm#:~:text=requirements%20per%20provider.-,Z%2DSide%20Service%20Tokens,-If%20you%20want).
 
 -> **NOTE:** Service tokens can't be reused. To recreate a resource or to create a new one for
 another connection even from same interconnection asset, you will need to request another token

--- a/docs/resources/equinix_ecx_l2_connection.md
+++ b/docs/resources/equinix_ecx_l2_connection.md
@@ -261,12 +261,15 @@ assigned by the Fabric.
 * `zside_vlan_stag` - When not provided as an argument, it is S-Tag/Outer-Tag of the connection on
 the Z side, assigned by the Fabric.
 * `actions` - One or more pending actions to complete connection provisioning.
+* `vendor_token` - The Equinix Fabric Token the connection was created with. Applicable if the
+connection was created with a `service_token` (a-side) or `zside_service_token` (z-side).
 * `secondary_connection`:
   * `zside_port_uuid`
   * `zside_vlan_stag`
   * `zside_vlan_ctag`
   * `redundancy_type`
   * `redundancy_group`
+  * `vendor_token`
 
 ## Update operation behavior
 
@@ -289,6 +292,9 @@ options:
 
 ## Import
 
+-> **NOTE:** Connections created with a Service Token (both a-side/z-side), will populate the token
+into `vendor_token` but `service_token` and `zside_service_token` will remain empty.
+
 Equinix L2 connections can be imported using an existing `id`:
 
 ```sh
@@ -296,8 +302,10 @@ existing_connection_id='example-uuid-1'
 terraform import equinix_ecx_l2_connection.example ${existing_connection_id}
 ```
 
-**Please Note** that to import a redundant connection you must concatenate `id` of both connections
-(primary and secondary) into a single string separated by `:`, e.g.,
+-> **NOTE:** To import a redundant connection you must concatenate `id` of both connections
+(primary and secondary) into a single string separated by `:`.
+
+To import a redundant Equinix L2 connection:
 
 ```sh
 existing_primary_connection_id='example-uuid-1'

--- a/docs/resources/equinix_ecx_l2_connection.md
+++ b/docs/resources/equinix_ecx_l2_connection.md
@@ -9,7 +9,7 @@ layer 2 connections.
 
 ## Example Usage
 
-### Non-redundant Connection from own Equinix Port
+### Non-redundant Connection from own Equinix Fabric Port
 
 ```hcl
 data "equinix_ecx_l2_sellerprofile" "aws" {
@@ -35,7 +35,7 @@ resource "equinix_ecx_l2_connection" "port-2-aws" {
 }
 ```
 
-### Redundant Connection from own Equinix Ports
+### Redundant Connection from own Equinix Fabric Ports
 
 ```hcl
 data "equinix_ecx_l2_sellerprofile" "azure" {
@@ -112,7 +112,7 @@ resource "equinix_ecx_l2_connection" "token-to-gcp" {
 }
 ```
 
-### Non-redundant Connection from own Equinix Port to an Equinix customer port using Z-Side Service token
+### Non-redundant Connection from own Equinix Fabric Port to an Equinix customer port using Z-Side Service token
 
 ```hcl
 data "equinix_ecx_port" "sv-qinq-pri" {
@@ -147,7 +147,7 @@ hyphens and underscores
 notifications.
 * `purchase_order_number` - (Optional) Connection's purchase order number to reflect on the invoice
 * `port_uuid` - (Required when `device_uuid` or `service_token` are not set) Unique identifier of
-the Equinix port from which the connection would originate.
+the Equinix Fabric Port from which the connection would originate.
 * `device_uuid` - (Required when `port_uuid` or `service_token` are not set) Unique identifier of
 the Network Edge virtual device from which the connection would originate.
 * `device_interface_id` - (Optional) Applicable with `device_uuid`, identifier of network interface
@@ -159,7 +159,7 @@ for you, to a service profile or your own port.
 More details in [A-Side Fabric Service Tokens](https://docs.equinix.com/en-us/Content/Interconnection/Fabric/service%20tokens/Fabric-Service-Tokens.htm#:~:text=the%20service%20token.-,A%2DSide%20Service%20Tokens,-If%20you%20want).
 * `zside_service_token`- (Required when `profile_uuid` or `zside_port_uuid` are not set) - Z-side
 service tokens authorize you to create a connection from your port or virtual device to a customer
-port which created the token for you.
+port which created the token for you. `zside_service_token` cannot be used with `secondary_connection`.
 More details in [Z-Side Fabric Service Tokens](https://docs.equinix.com/en-us/Content/Interconnection/Fabric/service%20tokens/Fabric-Service-Tokens.htm#:~:text=requirements%20per%20provider.-,Z%2DSide%20Service%20Tokens,-If%20you%20want).
 
 -> **NOTE:** Service tokens can't be reused. To recreate a resource or to create a new one for
@@ -210,7 +210,7 @@ connectivity. See [Secondary Connection](#secondary-connection) below for more d
 
 -> **NOTE:** Some service provider do not directly support redundant connections in their service
 profiles. However, some of them offer active/active (BGP multipath) or active/passive (failover)
-configurations in their platforms and you can still achieve that highly resilient network
+configurations in their platforms and you still achieve that highly resilient network
 connections by creating an `equinix_ecx_l2_connection` resource for each connection instead of
 defining a `secondary_connection` block.
 
@@ -221,7 +221,7 @@ The `secondary_connection` block supports the following arguments:
 specified primary `speed` will be used.
 * `speed_unit` - (Optional) Unit of the speed/bandwidth to be allocated to the secondary
 connection. If not specified primary `speed_unit` will be used.
-* `port_uuid` - (Optional) Applicable with primary `port_uuid`. Identifier of the Equinix port from
+* `port_uuid` - (Optional) Applicable with primary `port_uuid`. Identifier of the Equinix Fabric Port from
 which the secondary connection would originate. If not specified primary `port_uuid` will be used.
 * `device_uuid` - (Optional) Applicable with primary `device_uuid`. Identifier of the Network Edge
 virtual device from which the secondary connection would originate. If not specified primary
@@ -229,7 +229,7 @@ virtual device from which the secondary connection would originate. If not speci
 * `device_interface_id` - (Optional) Applicable with `device_uuid`, identifier of network interface
 on a given device. If not specified then first available interface will be selected.
 * `service_token`- (Optional) Required with primary `service_token`. Unique Equinix Fabric key
-given by a provider that grants you authorization to enable connectivity from an Equinix Port or
+given by a provider that grants you authorization to enable connectivity from an Equinix Fabric Port or
 virtual device. Each connection (primary and secondary) requires a separate token.
 More details in [Fabric Service Tokens](https://docs.equinix.com/en-us/Content/Interconnection/Fabric/service%20tokens/Fabric-Service-Tokens.htm).
 * `vlan_stag` - (Required when `port_uuid` is set) S-Tag/Outer-Tag of the secondary connection, a

--- a/docs/resources/equinix_metal_connection.md
+++ b/docs/resources/equinix_metal_connection.md
@@ -45,7 +45,7 @@ resource "equinix_ecx_l2_connection" "example" {
 }
 ```
 
-### Shared Connection with z_side token - Non-redundant Connection from your Equinix Fabric Port to Equinix Metal
+### Shared Connection with z_side token - Non-redundant Connection from your own Equinix Fabric Port to Equinix Metal
 
 ```hcl
 resource "equinix_metal_connection" "example" {

--- a/equinix/resource_ecx_l2_connection_test.go
+++ b/equinix/resource_ecx_l2_connection_test.go
@@ -29,6 +29,7 @@ func TestFabricL2Connection_createFromResourceData(t *testing.T) {
 		ecxL2ConnectionSchemaNames["SellerMetroCode"]:     "SV",
 		ecxL2ConnectionSchemaNames["AuthorizationKey"]:    "123456789012",
 		ecxL2ConnectionSchemaNames["ServiceToken"]:        "1c356a7b-d632-18a5-c357-a33146cab65d",
+		ecxL2ConnectionSchemaNames["ZSideServiceToken"]:   "febc9d80-11e0-4dc8-8eb8-c41b6b378df2",
 	}
 	d := schema.TestResourceDataRaw(t, createECXL2ConnectionResourceSchema(), rawData)
 	d.Set(ecxL2ConnectionSchemaNames["Notifications"], []string{"test@test.com"})
@@ -52,6 +53,7 @@ func TestFabricL2Connection_createFromResourceData(t *testing.T) {
 		SellerMetroCode:     ecx.String(rawData[ecxL2ConnectionSchemaNames["SellerMetroCode"]].(string)),
 		AuthorizationKey:    ecx.String(rawData[ecxL2ConnectionSchemaNames["AuthorizationKey"]].(string)),
 		ServiceToken:        ecx.String(rawData[ecxL2ConnectionSchemaNames["ServiceToken"]].(string)),
+		ZSideServiceToken:   ecx.String(rawData[ecxL2ConnectionSchemaNames["ZSideServiceToken"]].(string)),
 	}
 
 	// when
@@ -78,8 +80,7 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 		PurchaseOrderNumber: ecx.String(randString(10)),
 		PortUUID:            ecx.String(randString(36)),
 		DeviceUUID:          ecx.String(randString(36)),
-		ServiceToken:        ecx.String(randString(36)),
-		ZSideServiceToken:   ecx.String(randString(36)),
+		VendorToken:         ecx.String(randString(36)),
 		VlanSTag:            ecx.Int(randInt(2000)),
 		VlanCTag:            ecx.Int(randInt(2000)),
 		NamedTag:            ecx.String(randString(100)),
@@ -93,6 +94,11 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 		RedundancyGroup:     ecx.String(randString(36)),
 		RedundancyType:      ecx.String(randString(10)),
 	}
+	prevServiceToken := ecx.String(randString(20))
+	d.Set(ecxL2ConnectionSchemaNames["ServiceToken"], prevServiceToken)
+	prevZsideServiceToken := ecx.String(randString(20))
+	d.Set(ecxL2ConnectionSchemaNames["ZSideServiceToken"], prevZsideServiceToken)
+
 	// when
 	err := updateECXL2ConnectionResource(input, nil, d)
 
@@ -110,8 +116,11 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 	assert.Equal(t, ecx.StringValue(input.PortUUID), d.Get(ecxL2ConnectionSchemaNames["PortUUID"]), "PortUUID matches")
 	assert.Equal(t, ecx.StringValue(input.DeviceUUID), d.Get(ecxL2ConnectionSchemaNames["DeviceUUID"]), "DeviceUUID matches")
 	assert.Equal(t, ecx.IntValue(input.DeviceInterfaceID), d.Get(ecxL2ConnectionSchemaNames["DeviceInterfaceID"]), "DeviceInterfaceID matches")
-	assert.Equal(t, ecx.StringValue(input.ServiceToken), d.Get(ecxL2ConnectionSchemaNames["ServiceToken"]), "ServiceToken matches")
-	assert.Equal(t, ecx.StringValue(input.ZSideServiceToken), d.Get(ecxL2ConnectionSchemaNames["ZSideServiceToken"]), "ZSideServiceToken matches")
+	assert.Equal(t, ecx.StringValue(input.VendorToken), d.Get(ecxL2ConnectionSchemaNames["VendorToken"]), "VendorToken matches")
+	assert.Equal(t, ecx.StringValue(input.VendorToken), d.Get(ecxL2ConnectionSchemaNames["ServiceToken"]), "ServiceToken and VendorToken match")
+	assert.NotEqual(t, ecx.StringValue(prevServiceToken), d.Get(ecxL2ConnectionSchemaNames["ServiceToken"]), "ServiceToken updated")
+	assert.Equal(t, ecx.StringValue(input.VendorToken), d.Get(ecxL2ConnectionSchemaNames["ZSideServiceToken"]), "ZSideServiceToken and VendorToken match")
+	assert.NotEqual(t, ecx.StringValue(prevZsideServiceToken), d.Get(ecxL2ConnectionSchemaNames["ZSideServiceToken"]), "ZSideServiceToken updated")
 	assert.Equal(t, ecx.IntValue(input.VlanSTag), d.Get(ecxL2ConnectionSchemaNames["VlanSTag"]), "VlanSTag matches")
 	assert.Equal(t, ecx.IntValue(input.VlanCTag), d.Get(ecxL2ConnectionSchemaNames["VlanCTag"]), "VlanCTag matches")
 	assert.Equal(t, ecx.StringValue(input.NamedTag), d.Get(ecxL2ConnectionSchemaNames["NamedTag"]), "NamedTag matches")
@@ -148,10 +157,11 @@ func TestFabricL2Connection_flattenSecondary(t *testing.T) {
 		AuthorizationKey: ecx.String(randString(10)),
 		RedundancyGroup:  ecx.String(randString(10)),
 		RedundancyType:   ecx.String(randString(10)),
-		ServiceToken:     ecx.String(randString(36)),
+		VendorToken:      ecx.String(randString(36)),
 	}
 	previousInput := &ecx.L2Connection{
 		DeviceInterfaceID: ecx.Int(randInt(10)),
+		ServiceToken:      ecx.String(randString(36)),
 	}
 	expected := []interface{}{
 		map[string]interface{}{
@@ -176,7 +186,8 @@ func TestFabricL2Connection_flattenSecondary(t *testing.T) {
 			ecxL2ConnectionSchemaNames["RedundancyGroup"]:   input.RedundancyGroup,
 			ecxL2ConnectionSchemaNames["RedundancyType"]:    input.RedundancyType,
 			ecxL2ConnectionSchemaNames["Actions"]:           []interface{}{},
-			ecxL2ConnectionSchemaNames["ServiceToken"]:      input.ServiceToken,
+			ecxL2ConnectionSchemaNames["ServiceToken"]:      input.VendorToken,
+			ecxL2ConnectionSchemaNames["VendorToken"]:       input.VendorToken,
 		},
 	}
 

--- a/equinix/resource_ecx_l2_connection_test.go
+++ b/equinix/resource_ecx_l2_connection_test.go
@@ -79,6 +79,7 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 		PortUUID:            ecx.String(randString(36)),
 		DeviceUUID:          ecx.String(randString(36)),
 		ServiceToken:        ecx.String(randString(36)),
+		ZSideServiceToken:   ecx.String(randString(36)),
 		VlanSTag:            ecx.Int(randInt(2000)),
 		VlanCTag:            ecx.Int(randInt(2000)),
 		NamedTag:            ecx.String(randString(100)),
@@ -110,6 +111,7 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 	assert.Equal(t, ecx.StringValue(input.DeviceUUID), d.Get(ecxL2ConnectionSchemaNames["DeviceUUID"]), "DeviceUUID matches")
 	assert.Equal(t, ecx.IntValue(input.DeviceInterfaceID), d.Get(ecxL2ConnectionSchemaNames["DeviceInterfaceID"]), "DeviceInterfaceID matches")
 	assert.Equal(t, ecx.StringValue(input.ServiceToken), d.Get(ecxL2ConnectionSchemaNames["ServiceToken"]), "ServiceToken matches")
+	assert.Equal(t, ecx.StringValue(input.ZSideServiceToken), d.Get(ecxL2ConnectionSchemaNames["ZSideServiceToken"]), "ZSideServiceToken matches")
 	assert.Equal(t, ecx.IntValue(input.VlanSTag), d.Get(ecxL2ConnectionSchemaNames["VlanSTag"]), "VlanSTag matches")
 	assert.Equal(t, ecx.IntValue(input.VlanCTag), d.Get(ecxL2ConnectionSchemaNames["VlanCTag"]), "VlanCTag matches")
 	assert.Equal(t, ecx.StringValue(input.NamedTag), d.Get(ecxL2ConnectionSchemaNames["NamedTag"]), "NamedTag matches")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/equinix/terraform-provider-equinix
 go 1.17
 
 require (
-	github.com/equinix/ecx-go/v2 v2.2.1-0.20220713144045-34e67110c095
+	github.com/equinix/ecx-go/v2 v2.2.1-0.20220715091446-0d7d6eee8bc5
 	github.com/equinix/ne-go v1.6.0
 	github.com/equinix/oauth2-go v1.0.0
 	github.com/equinix/rest-go v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/equinix/terraform-provider-equinix
 go 1.17
 
 require (
-	github.com/equinix/ecx-go/v2 v2.2.1-0.20220715091446-0d7d6eee8bc5
+	github.com/equinix/ecx-go/v2 v2.3.0
 	github.com/equinix/ne-go v1.6.0
 	github.com/equinix/oauth2-go v1.0.0
 	github.com/equinix/rest-go v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/equinix/terraform-provider-equinix
 go 1.17
 
 require (
-	github.com/equinix/ecx-go/v2 v2.2.0
+	github.com/equinix/ecx-go/v2 v2.2.1-0.20220713144045-34e67110c095
 	github.com/equinix/ne-go v1.6.0
 	github.com/equinix/oauth2-go v1.0.0
 	github.com/equinix/rest-go v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -97,10 +97,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/equinix/ecx-go/v2 v2.2.1-0.20220713144045-34e67110c095 h1:Hzncnz4Ni3ZF3doZR2bgVgq5QyB3AEmA9scykqPiBlk=
-github.com/equinix/ecx-go/v2 v2.2.1-0.20220713144045-34e67110c095/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
-github.com/equinix/ecx-go/v2 v2.2.1-0.20220715091446-0d7d6eee8bc5 h1:/uHyhExXyBLom3GkTcNa+1gDPVEy9dvTgKwWG3aH96w=
-github.com/equinix/ecx-go/v2 v2.2.1-0.20220715091446-0d7d6eee8bc5/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
+github.com/equinix/ecx-go/v2 v2.3.0 h1:SOABrI2TP073Mx3gVoWa4qGlot1Z2hECAOY8W4nYDPU=
+github.com/equinix/ecx-go/v2 v2.3.0/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
 github.com/equinix/ne-go v1.6.0 h1:jp95igkZoMi161wycIIzvQiW2Vyh2Uy5GnOICZ7CjSQ=
 github.com/equinix/ne-go v1.6.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/equinix/ecx-go/v2 v2.2.1-0.20220713144045-34e67110c095 h1:Hzncnz4Ni3ZF3doZR2bgVgq5QyB3AEmA9scykqPiBlk=
 github.com/equinix/ecx-go/v2 v2.2.1-0.20220713144045-34e67110c095/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
+github.com/equinix/ecx-go/v2 v2.2.1-0.20220715091446-0d7d6eee8bc5 h1:/uHyhExXyBLom3GkTcNa+1gDPVEy9dvTgKwWG3aH96w=
+github.com/equinix/ecx-go/v2 v2.2.1-0.20220715091446-0d7d6eee8bc5/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
 github.com/equinix/ne-go v1.6.0 h1:jp95igkZoMi161wycIIzvQiW2Vyh2Uy5GnOICZ7CjSQ=
 github.com/equinix/ne-go v1.6.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/equinix/ecx-go/v2 v2.2.0 h1:8aFOVUVsN4923w+OGY9m7KnfcgMkaIKAQzryS+P9iAY=
-github.com/equinix/ecx-go/v2 v2.2.0/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
+github.com/equinix/ecx-go/v2 v2.2.1-0.20220713144045-34e67110c095 h1:Hzncnz4Ni3ZF3doZR2bgVgq5QyB3AEmA9scykqPiBlk=
+github.com/equinix/ecx-go/v2 v2.2.1-0.20220713144045-34e67110c095/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
 github.com/equinix/ne-go v1.6.0 h1:jp95igkZoMi161wycIIzvQiW2Vyh2Uy5GnOICZ7CjSQ=
 github.com/equinix/ne-go v1.6.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=


### PR DESCRIPTION
Feature required to support z-side service token.

This field is documented at 

https://docs.equinix.com/en-us/Content/Interconnection/Fabric/service%20tokens/Fabric-Service-Tokens.htm#:~:text=requirements%20per%20provider.-,Z%2DSide%20Service%20Tokens,-If%20you%20want

And

https://developer.equinix.com/docs/fabric-connect-using-service-token-parameters-mapping

Depends on https://github.com/equinix/ecx-go/pull/8: already merged and included in new release https://github.com/equinix/ecx-go/releases/tag/v2.3.0

Fix https://github.com/equinix/terraform-provider-equinix/issues/223