### PR TITLE
Modules and service token documentation

### DIFF
--- a/docs/data-sources/equinix_metal_connection.md
+++ b/docs/data-sources/equinix_metal_connection.md
@@ -6,7 +6,7 @@ subcategory: "Metal"
 
 Use this data source to retrieve a [connection resource](https://metal.equinix.com/developers/docs/networking/fabric/)
 
-~> Equinix Metal connection with service_token_type `a_side` is not generally available and may not be enabled yet for your organization.
+~> Equinix Metal connection with service_token_type `a_side`/`z_side` is not generally available and may not be enabled yet for your organization.
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ In addition to all arguments above, the following attributes are exported:
 * `organization_id` - ID of the organization where the connection is scoped to.
 * `status` - Status of the connection resource.
 * `service_tokens` - List of connection service tokens with attributes
-  * `id` - UUID of the service token required to configure the connection in the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard).
+  * `id` - UUID of the service token required to configure the connection in Equinix Fabric with the [equinix_ecx_l2_connection](../resources/equinix_ecx_l2_connection.md) resource or from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard).
   * `expires_at` - Expiration date of the service token.
   * `max_allowed_speed` - Maximum allowed speed for the service token, string like in the `speed` attribute.
   * `type` - Token type, `a_side` or `z_side`.
@@ -54,4 +54,4 @@ In addition to all arguments above, the following attributes are exported:
   * `status` - Port status.
   * `link_status` - Port link status.
   * `virtual_circuit_ids` - List of IDs of virtual cicruits attached to this port.
-* `token` - (Deprecated) Token to configure the connection in the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard).
+* `token` - (Deprecated) Fabric Token required to configure the connection in Equinix Fabric with the [equinix_ecx_l2_connection](../resources/equinix_ecx_l2_connection.md) resource or from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard). If your organization already has connection service tokens enabled, use `service_tokens` instead.

--- a/docs/data-sources/equinix_metal_connection.md
+++ b/docs/data-sources/equinix_metal_connection.md
@@ -6,7 +6,7 @@ subcategory: "Metal"
 
 Use this data source to retrieve a [connection resource](https://metal.equinix.com/developers/docs/networking/fabric/)
 
-~> Equinix Metal connection with service_token_type `a_side`/`z_side` is not generally available and may not be enabled yet for your organization.
+~> Equinix Metal connection with with Service Token A-side / Z-side (service_token_type) is not generally available and may not be enabled yet for your organization.
 
 ## Example Usage
 

--- a/docs/guides/equinix_fabric_cloud_providers.md
+++ b/docs/guides/equinix_fabric_cloud_providers.md
@@ -142,10 +142,10 @@ resource "equinix_network_bgp" "secondary" {
 Although the configuration will look similar on the Equinix side, all the resources required to
 complete the configuration will depend on each cloud provider. This requires you to have prior
 knowledge on how to configure the interconnection on each platform. Alternatively, you can take
-advantage of the [Equinix Fabric connection terraform modules](https://registry.terraform.io/search/modules?namespace=equinix-labs&q=fabric-connection).
+advantage of the [Equinix Fabric Terraform Modules](https://registry.terraform.io/search/modules?namespace=equinix-labs&q=fabric-connection).
 
 The terraform modules containerize multiple resources that are used together in a configuration.
-With the [Equinix Fabric modules](https://registry.terraform.io/search/modules?namespace=equinix-labs&q=fabric-connection)
+With the [Equinix Fabric Terraform Modules](https://registry.terraform.io/search/modules?namespace=equinix-labs&q=fabric-connection)
 you can configure all described above just defining a single resource. In addition, in the
 terraform registry you will get information about the specific parameters required for your cloud
 provider's configuration, as well as some examples with the most frequent use cases.
@@ -181,10 +181,16 @@ module "equinix-fabric-connection-azure" {
 }
 ```
 
-There are (April 2022) modules available to interconnect with
-[AWS Direct Connect](https://registry.terraform.io/modules/equinix-labs/fabric-connection-aws/equinix/latest),
-[Azure ExpressRoute](https://registry.terraform.io/modules/equinix-labs/fabric-connection-azure/equinix/latest) and
-[Google Cloud Interconnect](https://registry.terraform.io/modules/equinix-labs/fabric-connection-gcp/equinix/latest).
+List of available (July 2022) Equinix Fabric Terraform Modules:
+
+- [Alibaba Cloud Express Connect](https://registry.terraform.io/modules/equinix-labs/fabric-connection-alibaba/equinix/latest)
+- [AWS Direct Connect](https://registry.terraform.io/modules/equinix-labs/fabric-connection-aws/equinix/latest)
+- [Azure ExpressRoute](https://registry.terraform.io/modules/equinix-labs/fabric-connection-azure/equinix/latest)
+- [Equinix Metal Connection](https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest)
+- [Google Cloud Interconnect](https://registry.terraform.io/modules/equinix-labs/fabric-connection-gcp/equinix/latest)
+- [IBM Cloud Direct Link 2](https://registry.terraform.io/modules/equinix-labs/fabric-connection-ibm/equinix/latest)
+- [Oracle Cloud Infrastructure -OCI- FastConnect](https://registry.terraform.io/modules/equinix-labs/fabric-connection-oci/equinix/latest)
+
 Some others will be available soon. If you don't find one for your cloud provider you can still
 take advantage of the [Equinix Fabric connection base module](https://registry.terraform.io/modules/equinix-labs/fabric-connection/equinix/latest)
 or open a ticket in the [github repository](https://github.com/equinix/terraform-provider-equinix)

--- a/docs/resources/equinix_metal_connection.md
+++ b/docs/resources/equinix_metal_connection.md
@@ -6,7 +6,7 @@ subcategory: "Metal"
 
 Use this resource to request the creation an Interconnection asset to connect with other parties using [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/).
 
-~> Equinix Metal connection with service_token_type `a_side`/`z_side` is not generally available and may not be enabled yet for your organization.
+~> Equinix Metal connection with with Service Token A-side / Z-side (service_token_type) is not generally available and may not be enabled yet for your organization.
 
 ## Example Usage
 
@@ -45,6 +45,14 @@ resource "equinix_ecx_l2_connection" "example" {
 }
 ```
 
+-> NOTE: There are multiple [Equinix Fabric L2 Connection Terraform modules](https://registry.terraform.io/search/modules?namespace=equinix-labs&q=fabric-connection) available with full-fledged examples of connections from Fabric Ports, Network Edge Devices or Service Token to most popular Cloud Service Providers. Check out the examples for Equinix Metal shared connection with A-side Service Token included in each of them:
+[AWS](https://registry.terraform.io/modules/equinix-labs/fabric-connection-aws/equinix/latest/examples/service-token-metal-to-aws-connection),
+[Azure](https://registry.terraform.io/modules/equinix-labs/fabric-connection-azure/equinix/latest/examples/service-token-metal-to-azure-connection),
+[Google Cloud](https://registry.terraform.io/modules/equinix-labs/fabric-connection-gcp/equinix/latest/examples/service-token-metal-to-gcp-connection),
+[IBM Cloud](https://registry.terraform.io/modules/equinix-labs/fabric-connection-ibm/equinix/latest/examples/service-token-metal-to-ibm-connection),
+[Oracle Cloud](https://registry.terraform.io/modules/equinix-labs/fabric-connection-oci/equinix/latest/examples/service-token-metal-to-oci-connection),
+[Alibaba Cloud](https://registry.terraform.io/modules/equinix-labs/fabric-connection-alibaba/equinix/latest/examples/service-token-metal-to-alibaba-connection).
+
 ### Shared Connection with z_side token - Non-redundant Connection from your own Equinix Fabric Port to Equinix Metal
 
 ```hcl
@@ -70,6 +78,34 @@ resource "equinix_ecx_l2_connection" "example" {
   notifications       = ["example@equinix.com"]
   port_uuid           = data.equinix_ecx_port.example.id
   vlan_stag           = 1020
+}
+```
+
+-> NOTE: There is an [Equinix Fabric L2 Connection To Equinix Metal Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest) available with full-fledged examples of connections from Fabric Ports, Network Edge Devices or Service Tokens. Check out the [example for shared connection with Z-side Service Token](https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/0.2.0/examples/fabric-port-connection-with-zside-token).
+
+### Shared Connection for organizations without Connection Services Token feature enabled
+
+```hcl
+resource "equinix_metal_connection" "example" {
+    name            = "tf-port-to-metal-legacy"
+    project_id      = local.my_project_id
+    metro           = "SV"
+    redundancy      = "redundant"
+    type            = "shared"
+}
+
+data "equinix_ecx_port" "example" {
+  name = "CX-FR5-NL-Dot1q-BO-1G-PRI"
+}
+
+resource "equinix_ecx_l2_connection" "example" {
+  name                = "tf-port-to-metal-legacy"
+  speed               = "200"
+  speed_unit          = "MB"
+  notifications       = ["example@equinix.com"]
+  port_uuid           = data.equinix_ecx_port.example.id
+  vlan_stag           = 1020
+  authorization_key   = equinix_metal_connection.example.token
 }
 ```
 

--- a/docs/resources/equinix_metal_connection.md
+++ b/docs/resources/equinix_metal_connection.md
@@ -6,7 +6,7 @@ subcategory: "Metal"
 
 Use this resource to request the creation an Interconnection asset to connect with other parties using [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/).
 
-~> Equinix Metal connection with service_token_type `a_side` is not generally available and may not be enabled yet for your organization.
+~> Equinix Metal connection with service_token_type `a_side`/`z_side` is not generally available and may not be enabled yet for your organization.
 
 ## Example Usage
 
@@ -68,7 +68,6 @@ resource "equinix_ecx_l2_connection" "example" {
   speed               = "200"
   speed_unit          = "MB"
   notifications       = ["example@equinix.com"]
-  seller_metro_code   = "FR"
   port_uuid           = data.equinix_ecx_port.example.id
   vlan_stag           = 1020
 }
@@ -100,4 +99,5 @@ In addition to all arguments above, the following attributes are exported:
 * `ports` - List of connection ports - primary (`ports[0]`) and secondary (`ports[1]`). Schema of
 port is described in documentation of the
 [equinix_metal_connection datasource](../data-sources/equinix_metal_connection.md).
-* `service_tokens` - List of connection service tokens with attributes. Scehma of service_token is described in documentation of the [equinix_metal_connection datasource](../data-sources/equinix_metal_connection.md).
+* `service_tokens` - List of connection service tokens with attributes required to configure the connection in Equinix Fabric with the [equinix_ecx_l2_connection](./equinix_ecx_l2_connection.md) resource or from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard). Scehma of service_token is described in documentation of the [equinix_metal_connection datasource](../data-sources/equinix_metal_connection.md).
+* `token` - (Deprecated) Fabric Token required to configure the connection in Equinix Fabric with the [equinix_ecx_l2_connection](./equinix_ecx_l2_connection.md) resource or from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard). If your organization already has connection service tokens enabled, use `service_tokens` instead.

--- a/equinix/data_source_metal_connection.go
+++ b/equinix/data_source_metal_connection.go
@@ -177,7 +177,8 @@ func dataSourceMetalConnection() *schema.Resource {
 			"token": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Fabric Token for the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)",
+				Description: "Only used with shared connection. Fabric Token required to continue the setup process with [equinix_ecx_l2_connection](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_ecx_l2_connection) or from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)",
+				Deprecated:  "If your organization already has connection service tokens enabled, use `service_tokens` instead",
 			},
 			"ports": {
 				Type:        schema.TypeList,
@@ -187,7 +188,7 @@ func dataSourceMetalConnection() *schema.Resource {
 			},
 			"service_tokens": {
 				Type:        schema.TypeList,
-				Description: "Only used with shared connection. List of service tokens to use for the connection.",
+				Description: "Only used with shared connection. List of service tokens required to continue the setup process with [equinix_ecx_l2_connection](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_ecx_l2_connection) or from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)",
 				Computed:    true,
 				Elem:        serviceTokenSchema(),
 			},

--- a/equinix/resource_metal_connection.go
+++ b/equinix/resource_metal_connection.go
@@ -166,8 +166,8 @@ func resourceMetalConnection() *schema.Resource {
 			"token": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Fabric Token from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)",
-				Deprecated:  "token is deprecated. Use service_tokens instead",
+				Description: "Only used with shared connection. Fabric Token required to continue the setup process with [equinix_ecx_l2_connection](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_ecx_l2_connection) or from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)",
+				Deprecated:  "If your organization already has connection service tokens enabled, use `service_tokens` instead",
 			},
 			"ports": {
 				Type:        schema.TypeList,
@@ -177,7 +177,7 @@ func resourceMetalConnection() *schema.Resource {
 			},
 			"service_tokens": {
 				Type:        schema.TypeList,
-				Description: "Only used with shared connection. List of service tokens to use for the connection.",
+				Description: "Only used with shared connection. List of service tokens required to continue the setup process with [equinix_ecx_l2_connection](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_ecx_l2_connection) or from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)",
 				Computed:    true,
 				Elem:        serviceTokenSchema(),
 			},

--- a/examples/connectivity/README.md
+++ b/examples/connectivity/README.md
@@ -1,21 +1,56 @@
 # Equinix Provider Examples - connectivity
 
-This directory contains examples of using Equinix Fabric resources
-to establish connectivity with most popular service providers
+## Equinix Fabric Terraform Modules
 
-* [alibaba-cloud](alibaba-cloud/) - establishing layer 2 connection between
+Terraform modules encapsulate groups of resources dedicated to one task, reducing
+the amount of code you have to develop for similar infrastructure components.
+
+Below table lists Terraform modules that can be used for convenient and
+quick deployment of Equinix Fabric connections to most popular Service Providers.
+They include all the necessary resources and configuration at both ends of the
+connection.
+
+Please check module links to for usage details and examples.
+
+| Service Provider | Terraform module |
+|------------------|------------------|
+| Alibaba Cloud Express Connect | [Equinix Fabric L2 Connection To Alibaba Express Connect Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-alibaba/equinix/latest) |
+| AWS Direct Connect / AWS Direct Connect - High Capacity | [Equinix Fabric L2 Connection To AWS Direct Connect Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-aws/equinix/latest) |
+| Azure ExpressRoute | [Equinix Fabric L2 Connection To Microsoft Azure ExpressRoute Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-azure/equinix/latest) |
+| Equinix Metal | [Equinix Fabric L2 Connection To Equinix Metal Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest) |
+| Google Cloud Partner Interconnect Zone 1 / Zone 2 | [Equinix Fabric L2 Connection To Google Cloud Interconnect Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-gcp/equinix/latest) |
+| IBM Cloud Direct Link 2 | [Equinix Fabric L2 Connection To IBM Direct Link 2.0 Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-ibm/equinix/latest) |
+| Oracle Cloud Infrastructure -OCI- FastConnect | [Equinix Fabric L2 Connection To Oracle Cloud Infrastructure FastConnect Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-oci/equinix/latest) |
+
+## Equinix Fabric Examples Without Modules
+
+If you don't want to take advantage of the [Equinix Fabric Terraform Modules](#equinix-fabric-terraform-modules)
+you can also find below some basic examples on how to establish connectivity with
+the most popular service providers.
+
+* [alibaba-cloud](alibaba-cloud-connection/) - establishing layer 2 connection between
 Equinix Fabric port and Alibaba Express Connect
 * [aws-connection](aws-connection/) - establishing layer 2 connection between
 Equinix Fabric port and AWS Direct Connect
 * [azure-connection](azure-connection/) - establishing layer 2 connection between
 Equinix Fabric port and Microsoft Azure ExpressRoute
+* [equinix-metal](equinix-metal-to-fabric-connection/) - establishing layer 2 connection between
+Equinix Fabric port and Equinix Metal
 * [gcp-connection](gcp-connection/) - establishing layer 2 connection between
 Equinix Fabric port and Google Cloud Partner Interconnect
 * [ibm-cloud-connection](ibm-cloud-connection/) - establishing layer 2 connection
 between Equinix Fabric port and IBM Direct Link
 * [oracle-cloud-connection](oracle-cloud-connection/) - establishing layer2 connection
 between Equinix Fabric port and Oracle Cloud FastConnect
+
+## Equinix Fabric Examples To Connect To Your Own Assets
+
 * [self-port-port-connection](self-port-port-connection/) - establishing layer2 connection
 between two Equinix Fabric ports
+
+## Equinix Fabric examples To Create a Seller Profile
+Examples of using Equinix Fabric resources
+to establish connectivity with most popular service providers
+
 * [private-profile](private-profile/) - creating layer 2 private service  profile
 * [public-profile](public-profile/) - creating layer 2 public service seller profile

--- a/examples/connectivity/alibaba-cloud-connection/README.md
+++ b/examples/connectivity/alibaba-cloud-connection/README.md
@@ -1,5 +1,10 @@
 # ECX Fabric Layer2 Connection to Alibaba Cloud
 
+**NOTE:** There is an
+[Equinix Fabric L2 Connection To Alibaba Express Connect Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-alibaba/equinix/latest)
+available with full-fledged examples of connections from Fabric Ports, Network Edge Devices
+or Service Tokens.
+
 This example shows how create layer 2 connection between ECX Fabric port
 and Alibaba Express Connect.
 

--- a/examples/connectivity/aws-connection/README.md
+++ b/examples/connectivity/aws-connection/README.md
@@ -1,5 +1,10 @@
 # ECX Fabric Layer2 Connection to AWS
 
+**NOTE:** There is an
+[Equinix Fabric L2 Connection To AWS Direct Connect Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-aws/equinix/latest)
+available with full-fledged examples of connections from Fabric Ports, Network Edge Devices
+or Service Tokens.
+
 This example shows how create layer 2 connection between ECX Fabric port
 and AWS Direct Connect, including creation of Direct Connect private
 virtual interface.

--- a/examples/connectivity/azure-connection/README.md
+++ b/examples/connectivity/azure-connection/README.md
@@ -1,7 +1,13 @@
 # ECX Fabric Layer2 Connection to Microsoft Azure
 
+**NOTE:** There is an
+[Equinix Fabric L2 Connection To Microsoft Azure ExpressRoute Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-azure/equinix/latest)
+available with full-fledged examples of connections from Fabric Ports, Network Edge Devices
+or Service Tokens.
+
 This example shows how create redundant layer 2 connection between ECX Fabric port
 and Microsoft Azure ExpressRoute.
+
 Example covers **provisioning of both sides** of the connection.
 
 ## Adjust variables

--- a/examples/connectivity/equinix-metal-to-fabric-connection/README.md
+++ b/examples/connectivity/equinix-metal-to-fabric-connection/README.md
@@ -1,5 +1,9 @@
 # ECX Fabric Layer2 Connection from Equinix Metal to Service Provider
 
+**NOTE:** Equinix Metal connection with Service Token A-side (service_token_type `a_side`) is not generally available and may not be enabled yet for your organization.
+
+**NOTE:** There is an [Equinix Fabric L2 Connection To Equinix Metal Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest) with available full-fledged examples of connections from Fabric Ports, Network Edge Devices or Service Tokens.
+
 This example shows how to create a layer 2 connection between Equinix Metal and a service provider, using an Equinix Metal a-side service token
 
 ## Adjust variables

--- a/examples/connectivity/gcp-connection/README.md
+++ b/examples/connectivity/gcp-connection/README.md
@@ -1,5 +1,10 @@
 # ECX Fabric Layer2 Connection to Google Cloud Platform
 
+**NOTE:** There is an
+[Equinix Fabric L2 Connection To Google Cloud Interconnect Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-gcp/equinix/latest)
+available with full-fledged examples of connections from Fabric Ports, Network Edge Devices
+or Service Tokens.
+
 This example shows how create layer 2 connection between ECX Fabric port
 and Google Cloud Partner Interconnect.
 Example covers **provisioning of both sides** of the connection.

--- a/examples/connectivity/ibm-cloud-connection/README.md
+++ b/examples/connectivity/ibm-cloud-connection/README.md
@@ -1,5 +1,10 @@
 # ECX Fabric Layer2 Connection to IBM Cloud
 
+**NOTE:** There is an
+[Equinix Fabric L2 Connection To IBM Cloud Direct Link Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-ibm/equinix/latest)
+available with full-fledged examples of connections from Fabric Ports, Network Edge Devices
+or Service Tokens.
+
 This example shows how create layer 2 connection between ECX Fabric port
 and IBM Direct Link.
 

--- a/examples/connectivity/oracle-cloud-connection/README.md
+++ b/examples/connectivity/oracle-cloud-connection/README.md
@@ -1,5 +1,10 @@
 # ECX Fabric Layer2 Connection to Oracle Cloud
 
+**NOTE:** There is an 
+[Equinix Fabric L2 Connection To Oracle Cloud Infrastructure FastConnect Terraform module](https://registry.terraform.io/modules/equinix-labs/fabric-connection-oci/equinix/latest)
+available with full-fledged examples of connections from Fabric Ports, Network Edge Devices
+or Service Tokens.
+
 This example shows how create layer 2 connection between ECX Fabric port
 and Oracle Cloud FastConnect.
 Example covers **provisioning of both sides** of the connection.


### PR DESCRIPTION
This PR includes: 

- Set deprecated token field description in equinix_metal_connection schema and set legacy example back in the documentation. Fix #226
- Update connectivity examples available in github and the equinix_metal_connection documentation to link available Equinix Fabric terraform modules
- Update the list of the available modules in the `Connecting to the cloud with Equinix Fabric via Terraform` guide