### PR TITLE
Update equinix_metal_hardware_reservation.md

### DIFF
--- a/docs/data-sources/equinix_metal_hardware_reservation.md
+++ b/docs/data-sources/equinix_metal_hardware_reservation.md
@@ -12,12 +12,12 @@ You can look up hardware reservation by its ID or by ID of device which occupies
 
 ```hcl
 // lookup by ID
-data "hardware_reservation" "example" {
+data "equinix_metal_hardware_reservation" "example" {
   id = "4347e805-eb46-4699-9eb9-5c116e6a0172"
 }
 
 // lookup by device ID
-data "hardware_reservation" "example_by_device_id" {
+data "equinix_metal_hardware_reservation" "example_by_device_id" {
   device_id = "ff85aa58-c106-4624-8f1c-7c64554047ea"
 }
 ```


### PR DESCRIPTION
The equinix_metal_hardware_reservation datasource example was missing the `equinix_metal_` name prefix.

Signed-off-by: Marques Johansson <mjohansson@equinix.com>