### PR TITLE
NFV-19565: add description field for the acl template inbound rule

### DIFF
--- a/docs/resources/equinix_network_acl_template.md
+++ b/docs/resources/equinix_network_acl_template.md
@@ -22,6 +22,7 @@ resource "equinix_network_acl_template" "myacl" {
     protocol = "IP"
     src_port = "any"
     dst_port = "any"
+    description = "inbound rule description"
   }
   inbound_rule {
     subnet  = "172.16.25.0/24"
@@ -37,7 +38,7 @@ resource "equinix_network_acl_template" "myacl" {
 The following arguments are supported:
 
 * `name` - (Required) ACL template name.
-* `description` - (Optional) ACL template description.
+* `description` - (Optional) ACL template description, up to 200 characters.
 * `metro_code` - (Deprecated) ACL template location metro code.
 * `inbound_rule` - (Required) One or more rules to specify allowed inbound traffic.
 Rules are ordered, matching traffic rule stops processing subsequent ones.
@@ -51,6 +52,7 @@ The `inbound_rule` block has below fields:
 of ports, e.g., `20,22,23`, port range, e.g., `1023-1040` or word `any`.
 * `dst_port` - (Required) Inbound traffic destination ports. Allowed values are a comma separated
 list of ports, e.g., `20,22,23`, port range, e.g., `1023-1040` or word `any`.
+* `description` - (Optional) Inbound rule description, up to 200 characters.
 
 ## Attributes Reference
 

--- a/equinix/resource_network_acl_template.go
+++ b/equinix/resource_network_acl_template.go
@@ -27,7 +27,7 @@ var networkACLTemplateSchemaNames = map[string]string{
 var networkACLTemplateDescriptions = map[string]string{
 	"UUID":            "Unique identifier of ACL template resource",
 	"Name":            "ACL template name",
-	"Description":     "ACL template description",
+	"Description":     "ACL template description, up to 200 characters",
 	"MetroCode":       "ACL template location metro code",
 	"DeviceUUID":      "Identifier of a network device where template was applied",
 	"DeviceACLStatus": "Status of ACL template provisioning process on a device, where template was applied",
@@ -36,23 +36,25 @@ var networkACLTemplateDescriptions = map[string]string{
 }
 
 var networkACLTemplateInboundRuleSchemaNames = map[string]string{
-	"SeqNo":    "sequence_number",
-	"SrcType":  "source_type",
-	"Subnets":  "subnets",
-	"Subnet":   "subnet",
-	"Protocol": "protocol",
-	"SrcPort":  "src_port",
-	"DstPort":  "dst_port",
+	"SeqNo":       "sequence_number",
+	"SrcType":     "source_type",
+	"Subnets":     "subnets",
+	"Subnet":      "subnet",
+	"Protocol":    "protocol",
+	"SrcPort":     "src_port",
+	"DstPort":     "dst_port",
+	"Description": "description",
 }
 
 var networkACLTemplateInboundRuleDescriptions = map[string]string{
-	"SeqNo":    "Inbound rule sequence number",
-	"SrcType":  "Type of traffic source used in a given innbound rule",
-	"Subnets":  "Inbound traffic source IP subnets in CIDR format",
-	"Subnet":   "Inbound traffic source IP subnet in CIDR format",
-	"Protocol": "Inbound traffic protocol. One of: `IP`, `TCP`, `UDP`",
-	"SrcPort":  "Inbound traffic source ports. Either up to 10, comma separated ports or port range or any word",
-	"DstPort":  "Inbound traffic destination ports. Either up to 10, comma separated ports or port range or any word",
+	"SeqNo":       "Inbound rule sequence number",
+	"SrcType":     "Type of traffic source used in a given inbound rule",
+	"Subnets":     "Inbound traffic source IP subnets in CIDR format",
+	"Subnet":      "Inbound traffic source IP subnet in CIDR format",
+	"Protocol":    "Inbound traffic protocol. One of: `IP`, `TCP`, `UDP`",
+	"SrcPort":     "Inbound traffic source ports. Either up to 10, comma separated ports or port range or any word",
+	"DstPort":     "Inbound traffic destination ports. Either up to 10, comma separated ports or port range or any word",
+	"Description": "Inbound rule description, up to 200 characters",
 }
 
 var networkACLTemplateDeviceDetailSchemaNames = map[string]string{
@@ -103,7 +105,7 @@ func createNetworkACLTemplateSchema() map[string]*schema.Schema {
 		networkACLTemplateSchemaNames["Description"]: {
 			Type:         schema.TypeString,
 			Optional:     true,
-			ValidateFunc: validation.StringLenBetween(1, 100),
+			ValidateFunc: validation.StringLenBetween(1, 200),
 			Description:  networkACLTemplateDescriptions["Description"],
 		},
 		networkACLTemplateSchemaNames["MetroCode"]: {
@@ -191,6 +193,12 @@ func createNetworkACLTemplateInboundRuleSchema() map[string]*schema.Schema {
 			Required:     true,
 			ValidateFunc: stringIsPortDefinition(),
 			Description:  networkACLTemplateInboundRuleDescriptions["DstPort"],
+		},
+		networkACLTemplateInboundRuleSchemaNames["Description"]: {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringLenBetween(1, 200),
+			Description:  networkACLTemplateInboundRuleDescriptions["Description"],
 		},
 	}
 }
@@ -337,6 +345,9 @@ func expandACLTemplateInboundRules(rules []interface{}) []ne.ACLTemplateInboundR
 		if v, ok := ruleMap[networkACLTemplateInboundRuleSchemaNames["DstPort"]]; ok {
 			rule.DstPort = ne.String(v.(string))
 		}
+		if v, ok := ruleMap[networkACLTemplateInboundRuleSchemaNames["Description"]]; ok {
+			rule.Description = ne.String(v.(string))
+		}
 		transformed[i] = rule
 	}
 	return transformed
@@ -353,6 +364,7 @@ func flattenACLTemplateInboundRules(existingRules []ne.ACLTemplateInboundRule, r
 		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["SrcPort"]] = rules[i].SrcPort
 		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["DstPort"]] = rules[i].DstPort
 		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["Subnet"]] = rules[i].Subnet
+		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["Description"]] = rules[i].Description
 		if setSubnets {
 			transformedTemplate[networkACLTemplateInboundRuleSchemaNames["Subnets"]] = rules[i].Subnets
 		}

--- a/equinix/resource_network_acl_template_acc_test.go
+++ b/equinix/resource_network_acl_template_acc_test.go
@@ -52,24 +52,26 @@ func testSweepNetworkACLTemplate(region string) error {
 
 func TestAccNetworkACLTemplate(t *testing.T) {
 	context := map[string]interface{}{
-		"resourceName":            "test",
-		"name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"description":             randString(50),
-		"inbound_rule_1_subnet":   "10.0.0.0/16",
-		"inbound_rule_1_protocol": "TCP",
-		"inbound_rule_1_src_port": "any",
-		"inbound_rule_1_dst_port": "22-23",
-		"inbound_rule_2_subnet":   "192.168.16.0/24",
-		"inbound_rule_2_protocol": "UDP",
-		"inbound_rule_2_src_port": "any",
-		"inbound_rule_2_dst_port": "53",
-		"inbound_rule_3_subnet":   "2.2.2.2/32",
-		"inbound_rule_3_protocol": "UDP",
-		"inbound_rule_3_src_port": "any",
-		"inbound_rule_3_dst_port": "any",
+		"resourceName":               "test",
+		"name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"description":                randString(50),
+		"inbound_rule_1_subnet":      "10.0.0.0/16",
+		"inbound_rule_1_protocol":    "TCP",
+		"inbound_rule_1_src_port":    "any",
+		"inbound_rule_1_dst_port":    "22-23",
+		"inbound_rule_1_description": randString(50),
+		"inbound_rule_2_subnet":      "192.168.16.0/24",
+		"inbound_rule_2_protocol":    "UDP",
+		"inbound_rule_2_src_port":    "any",
+		"inbound_rule_2_dst_port":    "53",
+		"inbound_rule_3_subnet":      "2.2.2.2/32",
+		"inbound_rule_3_protocol":    "UDP",
+		"inbound_rule_3_src_port":    "any",
+		"inbound_rule_3_dst_port":    "any",
 	}
 	contextWithChanges := copyMap(context)
 	contextWithChanges["description"] = randString(50)
+	contextWithChanges["inbound_rule_1_description"] = randString(50)
 	contextWithChanges["inbound_rule_3_subnet"] = "4.4.4.4/32"
 	contextWithChanges["inbound_rule_3_protocol"] = "TCP"
 	contextWithChanges["inbound_rule_3_dst_port"] = "2048"
@@ -115,6 +117,7 @@ resource "equinix_network_acl_template" "%{resourceName}" {
 	protocol = "%{inbound_rule_1_protocol}"
 	src_port = "%{inbound_rule_1_src_port}"
 	dst_port = "%{inbound_rule_1_dst_port}"
+	description = "%{inbound_rule_1_description}"
   }
 
   inbound_rule {
@@ -159,7 +162,7 @@ func testAccNetworkACLTemplateAttributes(template *ne.ACLTemplate, ctx map[strin
 			return fmt.Errorf("name does not match %v - %v", ne.StringValue(template.Name), v)
 		}
 		if v, ok := ctx["description"]; ok && ne.StringValue(template.Description) != v.(string) {
-			return fmt.Errorf("name does not match %v - %v", ne.StringValue(template.Description), v)
+			return fmt.Errorf("description does not match %v - %v", ne.StringValue(template.Description), v)
 		}
 		if len(template.InboundRules) != 3 {
 			return fmt.Errorf("number of inbound rules does not match %v - %v", len(template.InboundRules), 3)
@@ -179,6 +182,9 @@ func testAccNetworkACLTemplateAttributes(template *ne.ACLTemplate, ctx map[strin
 			}
 			if v, ok := ctx[fmt.Sprintf("inbound_rule_%d_dst_port", i+1)]; ok && ne.StringValue(template.InboundRules[i].DstPort) != v.(string) {
 				return fmt.Errorf("inbound_rule %d dst_port does not match %v - %v", i+1, ne.StringValue(template.InboundRules[i].DstPort), v)
+			}
+			if v, ok := ctx[fmt.Sprintf("inbound_rule_%d_description", i+1)]; ok && ne.StringValue(template.InboundRules[i].Description) != v.(string) {
+				return fmt.Errorf("inbound_rule %d description does not match %v - %v", i+1, ne.StringValue(template.InboundRules[i].Description), v)
 			}
 		}
 		return nil

--- a/equinix/resource_network_acl_template_test.go
+++ b/equinix/resource_network_acl_template_test.go
@@ -15,12 +15,13 @@ func TestNetworkACLTemplate_createFromResourceData(t *testing.T) {
 		MetroCode:   ne.String("SV"),
 		InboundRules: []ne.ACLTemplateInboundRule{
 			{
-				SeqNo:    ne.Int(1),
-				Subnets:  []string{"10.0.0.0/24", "1.1.1.1/32"},
-				Subnet:   ne.String("10.0.0.0/24"),
-				Protocol: ne.String("TCP"),
-				SrcPort:  ne.String("any"),
-				DstPort:  ne.String("8080"),
+				SeqNo:       ne.Int(1),
+				Subnets:     []string{"10.0.0.0/24", "1.1.1.1/32"},
+				Subnet:      ne.String("10.0.0.0/24"),
+				Protocol:    ne.String("TCP"),
+				SrcPort:     ne.String("any"),
+				DstPort:     ne.String("8080"),
+				Description: ne.String("test inbound rule"),
 			},
 		},
 	}
@@ -67,12 +68,13 @@ func TestNetworkACLTemplate_updateResourceData(t *testing.T) {
 		MetroCode:   ne.String("SV"),
 		InboundRules: []ne.ACLTemplateInboundRule{
 			{
-				SeqNo:    ne.Int(1),
-				Subnets:  []string{"10.0.0.0/24", "1.1.1.1/32"},
-				Subnet:   ne.String("10.0.0.0/24"),
-				Protocol: ne.String("TCP"),
-				SrcPort:  ne.String("any"),
-				DstPort:  ne.String("8080"),
+				SeqNo:       ne.Int(1),
+				Subnets:     []string{"10.0.0.0/24", "1.1.1.1/32"},
+				Subnet:      ne.String("10.0.0.0/24"),
+				Protocol:    ne.String("TCP"),
+				SrcPort:     ne.String("any"),
+				DstPort:     ne.String("8080"),
+				Description: ne.String("test inbound rule"),
 			},
 		},
 		DeviceDetails: []ne.ACLTemplateDeviceDetails{
@@ -97,10 +99,11 @@ func TestNetworkACLTemplate_expandInboundRules(t *testing.T) {
 	// given
 	input := []interface{}{
 		map[string]interface{}{
-			networkACLTemplateInboundRuleSchemaNames["Subnets"]:  []interface{}{"10.0.0.0/24", "1.1.1.1/32"},
-			networkACLTemplateInboundRuleSchemaNames["Protocol"]: "TCP",
-			networkACLTemplateInboundRuleSchemaNames["SrcPort"]:  "any",
-			networkACLTemplateInboundRuleSchemaNames["DstPort"]:  "8080",
+			networkACLTemplateInboundRuleSchemaNames["Subnets"]:     []interface{}{"10.0.0.0/24", "1.1.1.1/32"},
+			networkACLTemplateInboundRuleSchemaNames["Protocol"]:    "TCP",
+			networkACLTemplateInboundRuleSchemaNames["SrcPort"]:     "any",
+			networkACLTemplateInboundRuleSchemaNames["DstPort"]:     "8080",
+			networkACLTemplateInboundRuleSchemaNames["Description"]: "description of inbound rule",
 		},
 		map[string]interface{}{
 			networkACLTemplateInboundRuleSchemaNames["Subnet"]:   "3.3.3.3/32",
@@ -115,12 +118,13 @@ func TestNetworkACLTemplate_expandInboundRules(t *testing.T) {
 
 	expected := []ne.ACLTemplateInboundRule{
 		{
-			SeqNo:    ne.Int(1),
-			Subnets:  expandListToStringList(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Subnets"]].([]interface{})),
-			Subnet:   nilSubnet,
-			Protocol: ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Protocol"]].(string)),
-			SrcPort:  ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["SrcPort"]].(string)),
-			DstPort:  ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["DstPort"]].(string)),
+			SeqNo:       ne.Int(1),
+			Subnets:     expandListToStringList(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Subnets"]].([]interface{})),
+			Subnet:      nilSubnet,
+			Protocol:    ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Protocol"]].(string)),
+			SrcPort:     ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["SrcPort"]].(string)),
+			DstPort:     ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["DstPort"]].(string)),
+			Description: ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Description"]].(string)),
 		},
 		{
 			SeqNo:    ne.Int(2),
@@ -140,12 +144,13 @@ func TestNetworkACLTemplate_expandInboundRules(t *testing.T) {
 func TestNetworkACLTemplate_flattenInboundRules(t *testing.T) {
 	input := []ne.ACLTemplateInboundRule{
 		{
-			SeqNo:    ne.Int(1),
-			SrcType:  ne.String("SUBNET"),
-			Subnets:  []string{"10.0.0.0/24", "1.1.1.1/32"},
-			Protocol: ne.String("TCP"),
-			SrcPort:  ne.String("any"),
-			DstPort:  ne.String("8080"),
+			SeqNo:       ne.Int(1),
+			SrcType:     ne.String("SUBNET"),
+			Subnets:     []string{"10.0.0.0/24", "1.1.1.1/32"},
+			Protocol:    ne.String("TCP"),
+			SrcPort:     ne.String("any"),
+			DstPort:     ne.String("8080"),
+			Description: ne.String("description of inbound rule"),
 		},
 		{
 			SeqNo:    ne.Int(2),
@@ -159,22 +164,24 @@ func TestNetworkACLTemplate_flattenInboundRules(t *testing.T) {
 	initial := input
 	expected := []interface{}{
 		map[string]interface{}{
-			networkACLTemplateInboundRuleSchemaNames["SeqNo"]:    input[0].SeqNo,
-			networkACLTemplateInboundRuleSchemaNames["SrcType"]:  input[0].SrcType,
-			networkACLTemplateInboundRuleSchemaNames["Subnets"]:  input[0].Subnets,
-			networkACLTemplateInboundRuleSchemaNames["Subnet"]:   input[0].Subnet,
-			networkACLTemplateInboundRuleSchemaNames["Protocol"]: input[0].Protocol,
-			networkACLTemplateInboundRuleSchemaNames["SrcPort"]:  input[0].SrcPort,
-			networkACLTemplateInboundRuleSchemaNames["DstPort"]:  input[0].DstPort,
+			networkACLTemplateInboundRuleSchemaNames["SeqNo"]:       input[0].SeqNo,
+			networkACLTemplateInboundRuleSchemaNames["SrcType"]:     input[0].SrcType,
+			networkACLTemplateInboundRuleSchemaNames["Subnets"]:     input[0].Subnets,
+			networkACLTemplateInboundRuleSchemaNames["Subnet"]:      input[0].Subnet,
+			networkACLTemplateInboundRuleSchemaNames["Protocol"]:    input[0].Protocol,
+			networkACLTemplateInboundRuleSchemaNames["SrcPort"]:     input[0].SrcPort,
+			networkACLTemplateInboundRuleSchemaNames["DstPort"]:     input[0].DstPort,
+			networkACLTemplateInboundRuleSchemaNames["Description"]: input[0].Description,
 		},
 		map[string]interface{}{
-			networkACLTemplateInboundRuleSchemaNames["SeqNo"]:    input[1].SeqNo,
-			networkACLTemplateInboundRuleSchemaNames["SrcType"]:  input[1].SrcType,
-			networkACLTemplateInboundRuleSchemaNames["Subnets"]:  input[1].Subnets,
-			networkACLTemplateInboundRuleSchemaNames["Subnet"]:   input[1].Subnet,
-			networkACLTemplateInboundRuleSchemaNames["Protocol"]: input[1].Protocol,
-			networkACLTemplateInboundRuleSchemaNames["SrcPort"]:  input[1].SrcPort,
-			networkACLTemplateInboundRuleSchemaNames["DstPort"]:  input[1].DstPort,
+			networkACLTemplateInboundRuleSchemaNames["SeqNo"]:       input[1].SeqNo,
+			networkACLTemplateInboundRuleSchemaNames["SrcType"]:     input[1].SrcType,
+			networkACLTemplateInboundRuleSchemaNames["Subnets"]:     input[1].Subnets,
+			networkACLTemplateInboundRuleSchemaNames["Subnet"]:      input[1].Subnet,
+			networkACLTemplateInboundRuleSchemaNames["Protocol"]:    input[1].Protocol,
+			networkACLTemplateInboundRuleSchemaNames["SrcPort"]:     input[1].SrcPort,
+			networkACLTemplateInboundRuleSchemaNames["DstPort"]:     input[1].DstPort,
+			networkACLTemplateInboundRuleSchemaNames["Description"]: input[1].Description,
 		},
 	}
 	// when

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/equinix/ecx-go/v2 v2.3.0
-	github.com/equinix/ne-go v1.6.0
+	github.com/equinix/ne-go v1.7.0
 	github.com/equinix/oauth2-go v1.0.0
 	github.com/equinix/rest-go v1.3.0
 	github.com/hashicorp/errwrap v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/equinix/ecx-go/v2 v2.3.0 h1:SOABrI2TP073Mx3gVoWa4qGlot1Z2hECAOY8W4nYDPU=
 github.com/equinix/ecx-go/v2 v2.3.0/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
-github.com/equinix/ne-go v1.6.0 h1:jp95igkZoMi161wycIIzvQiW2Vyh2Uy5GnOICZ7CjSQ=
-github.com/equinix/ne-go v1.6.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
+github.com/equinix/ne-go v1.7.0 h1:Z2KJYaS624kqhZrDG+uLtdCVC/cWs8USgXaNLV7UiwE=
+github.com/equinix/ne-go v1.7.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=
 github.com/equinix/oauth2-go v1.0.0/go.mod h1:4pulXvUNMktJlewLPnUeJyMW52iCoF1aM+A/Z5xY1ws=
 github.com/equinix/rest-go v1.3.0 h1:m38scYTOfV6N+gcrwchgVDutDffYd+QoYCMm9Jn6jyk=


### PR DESCRIPTION
As part of August release, we add a description field for each inbound rule of acl template. We want to add that field as part of terraform script as well.
This description field will always be optional and the field length should not be longer than 200 characters.
It will be part of create/update request. It will also be part of get response.
Sample payload as follows:
```
  "inboundRules": [
        {
            "description": "description of the rule",
            "protocol": "TCP",
            "srcPort": "any",
            "dstPort": "any",
            "subnet": "216.221.225.13/32",
            "seqNo": 1
        },
        {
            "protocol": "TCP",
            "srcPort": "53",
            "dstPort": "any",
            "subnet": "1.1.1.1/32",
            "seqNo": 2
        }
  ]
```