### PR TITLE
remove check of tokenTypeOk to support legacy fabric connections

### DIFF
--- a/docs/resources/equinix_metal_connection.md
+++ b/docs/resources/equinix_metal_connection.md
@@ -124,7 +124,7 @@ The following arguments are supported:
 * `mode` - (Optional) Mode for connections in IBX facilities with the dedicated type - standard or tunnel. Default is standard.
 * `tags` - (Optional) String list of tags.
 * `vlans` - (Optional) Only used with shared connection. Vlans to attach. Pass one vlan for Primary/Single connection and two vlans for Redundant connection.
-* `service_token_type` - (Optional) Only used with shared connection. Type of service token to use for the connection, a_side or z_side.
+* `service_token_type` - (Optional) Only used with shared connection. Type of service token to use for the connection, a_side or z_side. (**NOTE: To support the legacy non-automated way to create connections, terraform will not check if `service_token_type` is specified. If your organization already has `service_token_type` enabled, be sure to specify it or the connection will return a legacy connection token instead of a service token**)
 
 ## Attributes Reference
 

--- a/equinix/resource_metal_connection.go
+++ b/equinix/resource_metal_connection.go
@@ -248,9 +248,6 @@ func resourceMetalConnectionCreate(d *schema.ResourceData, meta interface{}) err
 		if connMode == string(packngo.ConnectionModeTunnel) {
 			return fmt.Errorf("tunnel mode is not supported for \"shared\" connections")
 		}
-		if !tokenTypeOk {
-			return fmt.Errorf("you must set service_token_type for \"shared\" connection")
-		}
 		if connRedundancy == packngo.ConnectionPrimary && vlansNum == 2 {
 			return fmt.Errorf("when you create a \"shared\" connection without redundancy, you must only set max 1 vlan")
 		}


### PR DESCRIPTION
Allow to not define `service_token_type` for shared connections in organizations where service token is not enabled.

Fix https://github.com/equinix/terraform-provider-equinix/issues/246