### PR TITLE
Remove optional flag for address fields in organization data source

### DIFF
--- a/equinix/data_source_metal_organization.go
+++ b/equinix/data_source_metal_organization.go
@@ -57,7 +57,6 @@ func dataSourceMetalOrganization() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "Business' address",
 				Computed:    true,
-				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: createOrganizationAddressDataSourceSchema(),
 				},
@@ -71,28 +70,23 @@ func createOrganizationAddressDataSourceSchema() map[string]*schema.Schema {
 		"address": {
 			Type:     schema.TypeString,
 			Computed: true,
-			Optional: true,
 		},
 		"city": {
 			Type:     schema.TypeString,
 			Computed: true,
-			Optional: true,
 		},
 		"zip_code": {
 			Type:     schema.TypeString,
 			Computed: true,
-			Optional: true,
 		},
 		"country": {
 			Type:        schema.TypeString,
 			Description: "Two letter country code (ISO 3166-1 alpha-2), e.g. US",
 			Computed:    true,
-			Optional:    true,
 		},
 		"state": {
 			Type:     schema.TypeString,
 			Computed: true,
-			Optional: true,
 		},
 	}
 }


### PR DESCRIPTION
The organization data source does not support filtering organizations by address, so the address field (and all nested fields within it) should not have the `Optional` flag set.  This removes the flag so that the organization data source schema matches the behavior.

Fixes #151.