### PR TITLE
Force new metal connection when VLANs attribute is changed

### DIFF
--- a/equinix/resource_metal_connection.go
+++ b/equinix/resource_metal_connection.go
@@ -144,6 +144,7 @@ func resourceMetalConnection() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeInt},
 				MaxItems:    2,
+				ForceNew:    true,
 			},
 			"service_token_type": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
The `vlans` field of an `equinix_metal_connection` resource cannot be changed, but the Equinix provider currently attempts to update the `vlans` attribute via the API, and the API silently ignores the change, giving clients the illusion that they have successfully updated the `vlans` field.  This adds the `ForceNew` flag for the `vlans` attribute so that the terraform provider will correctly destroy & recreate an `equinix_metal_connection` when the `vlans` attribute changes.

Fixes #222.

Closes #273