### PR TITLE
update metal ip resources to retrieve metro from facility if metro is null

### DIFF
--- a/docs/data-sources/equinix_metal_ip_block_ranges.md
+++ b/docs/data-sources/equinix_metal_ip_block_ranges.md
@@ -34,9 +34,9 @@ output "out" {
 The following arguments are supported:
 
 * `project_id` - (Required) ID of the project from which to list the blocks.
-* `facility` - (Optional) Facility code filtering the IP blocks. Global IPv4 blcoks will be listed
+* `facility` - (Optional) Facility code filtering the IP blocks. Global IPv4 blocks will be listed
 anyway. If you omit this and metro, all the block from the project will be listed.
-* `metro` - (Optional) Metro code filtering the IP blocks. Global IPv4 blcoks will be listed
+* `metro` - (Optional) Metro code filtering the IP blocks. Global IPv4 blocks will be listed
 anyway. If you omit this and facility, all the block from the project will be listed.
 
 ## Attributes Reference

--- a/docs/data-sources/equinix_metal_precreated_ip_block.md
+++ b/docs/data-sources/equinix_metal_precreated_ip_block.md
@@ -4,12 +4,14 @@ subcategory: "Metal"
 
 # equinix_metal_precreated_ip_block (Data Source)
 
-Use this data source to get CIDR expression for both precreated(management)/elastic IPv6 and IPv4 blocks in Equinix Metal.
+Use this data source to get CIDR expression for recreated(management) IPv6 and IPv4 blocks in Equinix Metal.
 You can then use the cidrsubnet TF builtin function to derive subnets.
 
--> **NOTE:** Precreated IP blocks for a metro will not be available until first device is created in that metro.
+~> For backward compatibility, this data source will also return reserved (elastic) IP blocks.
 
--> **NOTE:** Public IPv4 blocks auto-assigned to a device cannot be retrieved. If you need that information, consider using the [equinix_metal_device](equinix_metal_device.md) data source instead.
+-> Precreated IP blocks for a metro will not be available until first device is created in that metro.
+
+-> Public IPv4 blocks auto-assigned to a device cannot be retrieved. If you need that information, consider using the [equinix_metal_device](equinix_metal_device.md) data source instead.
 
 ## Example Usage
 

--- a/docs/data-sources/equinix_metal_precreated_ip_block.md
+++ b/docs/data-sources/equinix_metal_precreated_ip_block.md
@@ -4,8 +4,12 @@ subcategory: "Metal"
 
 # equinix_metal_precreated_ip_block (Data Source)
 
-Use this data source to get CIDR expression for precreated IPv6 and IPv4 blocks in Equinix Metal.
+Use this data source to get CIDR expression for both precreated(management)/elastic IPv6 and IPv4 blocks in Equinix Metal.
 You can then use the cidrsubnet TF builtin function to derive subnets.
+
+-> **NOTE:** Precreated IP blocks for a metro will not be available until first device is created in that metro.
+
+-> **NOTE:** Public IPv4 blocks auto-assigned to a device cannot be retrieved. If you need that information, consider using the [equinix_metal_device](equinix_metal_device.md) data source instead.
 
 ## Example Usage
 

--- a/docs/data-sources/equinix_metal_precreated_ip_block.md
+++ b/docs/data-sources/equinix_metal_precreated_ip_block.md
@@ -4,14 +4,14 @@ subcategory: "Metal"
 
 # equinix_metal_precreated_ip_block (Data Source)
 
-Use this data source to get CIDR expression for recreated(management) IPv6 and IPv4 blocks in Equinix Metal.
+Use this data source to get CIDR expression for precreated (management) IPv6 and IPv4 blocks in Equinix Metal.
 You can then use the cidrsubnet TF builtin function to derive subnets.
 
 ~> For backward compatibility, this data source will also return reserved (elastic) IP blocks.
 
--> Precreated IP blocks for a metro will not be available until first device is created in that metro.
+-> Precreated (management) IP blocks for a metro will not be available until first device is created in that metro.
 
--> Public IPv4 blocks auto-assigned to a device cannot be retrieved. If you need that information, consider using the [equinix_metal_device](equinix_metal_device.md) data source instead.
+-> Public IPv4 blocks auto-assigned (management) to a device cannot be retrieved. If you need that information, consider using the [equinix_metal_device](equinix_metal_device.md) data source instead.
 
 ## Example Usage
 

--- a/docs/data-sources/equinix_metal_reserved_ip_block.md
+++ b/docs/data-sources/equinix_metal_reserved_ip_block.md
@@ -7,6 +7,8 @@ subcategory: "Metal"
 Use this data source to find IP address blocks in Equinix Metal. You can use IP address or a block
 ID for lookup.
 
+~> For backward compatibility, this data source can be also used for precreated (management) IP blocks.
+
 ~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
 
 ## Example Usage

--- a/equinix/data_source_metal_ip_block_ranges.go
+++ b/equinix/data_source_metal_ip_block_ranges.go
@@ -19,12 +19,12 @@ func dataSourceMetalIPBlockRanges() *schema.Resource {
 			},
 			"facility": {
 				Type:        schema.TypeString,
-				Description: "Facility code filtering the IP blocks. Global IPv4 blcoks will be listed anyway. If you omit this and metro, all the block from the project will be listed",
+				Description: "Facility code filtering the IP blocks. Global IPv4 blocks will be listed anyway. If you omit this and metro, all the block from the project will be listed",
 				Optional:    true,
 			},
 			"metro": {
 				Type:        schema.TypeString,
-				Description: "Metro code filtering the IP blocks. Global IPv4 blcoks will be listed anyway. If you omit this and facility, all the block from the project will be listed",
+				Description: "Metro code filtering the IP blocks. Global IPv4 blocks will be listed anyway. If you omit this and facility, all the block from the project will be listed",
 				Optional:    true,
 				StateFunc:   toLower,
 			},

--- a/equinix/data_source_metal_ip_block_ranges.go
+++ b/equinix/data_source_metal_ip_block_ranges.go
@@ -76,6 +76,16 @@ func metroMatch(ref string, metro *packngo.Metro) bool {
 	return false
 }
 
+func metroOffacilityMatch(ref string, facility *packngo.Facility) bool {
+	if ref == "" {
+		return true
+	}
+	if facility != nil && facility.Metro != nil && ref == facility.Metro.Code {
+		return true
+	}
+	return false
+}
+
 func dataSourceMetalIPBlockRangesRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Config).metal
 	projectID := d.Get("project_id").(string)
@@ -109,7 +119,7 @@ func dataSourceMetalIPBlockRangesRead(d *schema.ResourceData, meta interface{}) 
 		} else {
 			targetSlice = &theIPv6s
 		}
-		if targetSlice != nil && facilityMatch(facility, ip.Facility) && metroMatch(metro, ip.Metro) {
+		if targetSlice != nil && facilityMatch(facility, ip.Facility) && metroMatch(metro, ip.Metro) && metroOffacilityMatch(metro, ip.Facility) {
 			*targetSlice = append(*targetSlice, cnStr)
 		}
 	}

--- a/equinix/data_source_metal_ip_block_ranges.go
+++ b/equinix/data_source_metal_ip_block_ranges.go
@@ -119,7 +119,12 @@ func dataSourceMetalIPBlockRangesRead(d *schema.ResourceData, meta interface{}) 
 		} else {
 			targetSlice = &theIPv6s
 		}
-		if targetSlice != nil && facilityMatch(facility, ip.Facility) && metroMatch(metro, ip.Metro) && metroOffacilityMatch(metro, ip.Facility) {
+		if targetSlice != nil {
+			if !(facilityMatch(facility, ip.Facility) && metroMatch(metro, ip.Metro)) {
+				if !metroOffacilityMatch(metro, ip.Facility) {
+					continue
+				}
+			}
 			*targetSlice = append(*targetSlice, cnStr)
 		}
 	}

--- a/equinix/data_source_metal_precreated_ip_block_acc_test.go
+++ b/equinix/data_source_metal_precreated_ip_block_acc_test.go
@@ -21,8 +21,6 @@ func TestAccDataSourceMetalPreCreatedIPBlock_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"data.equinix_metal_precreated_ip_block.test_fac_pubv6", "cidr_notation"),
 					resource.TestCheckResourceAttrSet(
-						"data.equinix_metal_precreated_ip_block.test_metro_pubv4", "cidr_notation"),
-					resource.TestCheckResourceAttrSet(
 						"data.equinix_metal_precreated_ip_block.test_metro_priv4", "cidr_notation"),
 					resource.TestCheckResourceAttrPair(
 						"equinix_metal_ip_attachment.test", "device_id",
@@ -67,13 +65,6 @@ data "equinix_metal_precreated_ip_block" "test_fac_pubv6" {
     facility         = equinix_metal_device.test.deployed_facility
     project_id       = equinix_metal_device.test.project_id
     address_family   = 6
-    public           = true
-}
-
-data "equinix_metal_precreated_ip_block" "test_metro_pubv4" {
-    metro            = equinix_metal_device.test.metro
-    project_id       = equinix_metal_device.test.project_id
-    address_family   = 4
     public           = true
 }
 

--- a/equinix/data_source_metal_reserved_ip_block.go
+++ b/equinix/data_source_metal_reserved_ip_block.go
@@ -26,12 +26,14 @@ func dataSourceMetalReservedIPBlock() *schema.Resource {
 				Computed:      true,
 				Description:   "ID of the project where the searched block should be",
 				ConflictsWith: []string{"id"},
+				RequiredWith:  []string{"ip_address"},
 			},
 			"ip_address": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "Find block containing this IP address in given project",
 				ConflictsWith: []string{"id"},
+				RequiredWith:  []string{"project_id"},
 			},
 
 			"global": {

--- a/equinix/resource_metal_reserved_ip_block.go
+++ b/equinix/resource_metal_reserved_ip_block.go
@@ -396,7 +396,7 @@ func loadBlock(d *schema.ResourceData, reservedBlock *packngo.IPAddressReservati
 		},
 		"metro": func(d *schema.ResourceData, k string) error {
 			if reservedBlock.Metro == nil {
-				if reservedBlock.Facility != nil {
+				if reservedBlock.Facility != nil && reservedBlock.Facility.Metro != nil {
 					return d.Set(k, strings.ToLower(reservedBlock.Facility.Metro.Code))
 				}
 				return nil

--- a/equinix/resource_metal_reserved_ip_block.go
+++ b/equinix/resource_metal_reserved_ip_block.go
@@ -396,6 +396,9 @@ func loadBlock(d *schema.ResourceData, reservedBlock *packngo.IPAddressReservati
 		},
 		"metro": func(d *schema.ResourceData, k string) error {
 			if reservedBlock.Metro == nil {
+				if reservedBlock.Facility != nil {
+					return d.Set(k, strings.ToLower(reservedBlock.Facility.Metro.Code))
+				}
 				return nil
 			}
 			return d.Set(k, strings.ToLower(reservedBlock.Metro.Code))


### PR DESCRIPTION
- `equinix_metal_reserved_ip_block`:
Public IPv4 blocks auto-assigned (management subnets) to a device cannot be retrieved. This PR updates failing test and improve documentation.
- `equinix_metal_reserved_ip_block`, `equinix_metal_ip_block_ranges`:
`metro` is nil for some IP blocks. For those cases `metro` will be retrieved from the `facilitiy`
- update docs

Fix #243