### PR TITLE
Keep value of metal_connection.vlans in sync with API

### DIFF
--- a/equinix/data_source_metal_connection.go
+++ b/equinix/data_source_metal_connection.go
@@ -223,6 +223,30 @@ func getConnectionPorts(cps []packngo.ConnectionPort) []map[string]interface{} {
 	return ret
 }
 
+func getConnectionVlans(conn *packngo.Connection) []int {
+	var ret []int
+
+	if conn.Type == packngo.ConnectionShared {
+		order := map[packngo.ConnectionPortRole]int{
+			packngo.ConnectionPortPrimary:   0,
+			packngo.ConnectionPortSecondary: 1,
+		}
+
+		rawVlans := make([]int, len(conn.Ports))
+		for _, p := range conn.Ports {
+			rawVlans[order[p.Role]] = p.VirtualCircuits[0].VNID
+		}
+
+		for _, v := range rawVlans {
+			if v > 0 {
+				ret = append(ret, v)
+			}
+		}
+	}
+
+	return ret
+}
+
 func dataSourceMetalConnectionRead(d *schema.ResourceData, meta interface{}) error {
 	connId := d.Get("connection_id").(string)
 	d.SetId(connId)

--- a/equinix/data_source_metal_connection_acc_test.go
+++ b/equinix/data_source_metal_connection_acc_test.go
@@ -20,12 +20,12 @@ func TestAccDataSourceMetalConnection_withoutVlans(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"equinix_metal_connection.test", "id",
-						"data.equinix_metal_connection.test", "connection_id"),
+						"data.equinix_metal_connection.test", "id"),
 					resource.TestCheckResourceAttrPair(
-						"equinix_metal_connection.test", "vlans",
-						"data.equinix_metal_connection.test", "vlans"),
-					resource.TestCheckNoResourceAttr(
-						"data.equinix_metal_connection.test", "vlans"),
+						"equinix_metal_connection.test", "vlans.#",
+						"data.equinix_metal_connection.test", "vlans.#"),
+					resource.TestCheckResourceAttr(
+						"data.equinix_metal_connection.test", "vlans.#", "0"),
 				),
 			},
 		},
@@ -66,12 +66,15 @@ func TestAccDataSourceMetalConnection_withVlans(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"equinix_metal_connection.test", "id",
-						"data.equinix_metal_connection.test", "connection_id"),
+						"data.equinix_metal_connection.test", "id"),
+					resource.TestCheckResourceAttr(
+						"data.equinix_metal_connection.test", "vlans.#", "2"),
 					resource.TestCheckResourceAttrPair(
-						"equinix_metal_connection.test", "vlans",
-						"data.equinix_metal_connection.test", "vlans"),
-					resource.TestCheckResourceAttrSet(
-						"data.equinix_metal_connection.test", "vlans"),
+						"equinix_metal_vlan.test1", "vxlan",
+						"data.equinix_metal_connection.test", "vlans.0"),
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_vlan.test2", "vxlan",
+						"data.equinix_metal_connection.test", "vlans.1"),
 				),
 			},
 		},

--- a/equinix/data_source_metal_connection_acc_test.go
+++ b/equinix/data_source_metal_connection_acc_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestAccDataSourceMetalConnection_withoutVlans(t *testing.T) {
-	projectName := fmt.Sprintf("ds-device-%s", acctest.RandString(10))
+	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceMetalConnectionConfig_withoutVlans(projectName),
+				Config: testDataSourceMetalConnectionConfig_withoutVlans(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"equinix_metal_connection.test", "id",
@@ -32,37 +32,37 @@ func TestAccDataSourceMetalConnection_withoutVlans(t *testing.T) {
 	})
 }
 
-func testDataSourceMetalConnectionConfig_withoutVlans(randstr string) string {
+func testDataSourceMetalConnectionConfig_withoutVlans(r int) string {
 	return fmt.Sprintf(`
-        resource "equinix_metal_project" "test" {
-            name = "tfacc-conn-pro-%s"
-        }
+		resource "equinix_metal_project" "test" {
+			name = "tfacc-conn-project-%d"
+		}
 
-        resource "equinix_metal_connection" "test" {
-            name               = "tfacc-conn-%s"
-            project_id         = equinix_metal_project.test.id
-            type               = "shared"
-            redundancy         = "redundant"
-            metro              = "sv"
+		resource "equinix_metal_connection" "test" {
+			name               = "tfacc-conn-%d"
+			project_id         = equinix_metal_project.test.id
+			type               = "shared"
+			redundancy         = "redundant"
+			metro              = "sv"
 			speed              = "50Mbps"
 			service_token_type = "a_side"
-        }
-		
+		}
+
 		data "equinix_metal_connection" "test" {
-    		connection_id = equinix_metal_connection.test.id
+			connection_id = equinix_metal_connection.test.id
 		}`,
-		randstr, randstr)
+		r, r)
 }
 
 func TestAccDataSourceMetalConnection_withVlans(t *testing.T) {
-	projectName := fmt.Sprintf("ds-device-by-id-%s", acctest.RandString(10))
+	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceMetalConnectionConfig_withVlans(projectName),
+				Config: testDataSourceMetalConnectionConfig_withVlans(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"equinix_metal_connection.test", "id",
@@ -78,40 +78,40 @@ func TestAccDataSourceMetalConnection_withVlans(t *testing.T) {
 	})
 }
 
-func testDataSourceMetalConnectionConfig_withVlans(randstr string) string {
+func testDataSourceMetalConnectionConfig_withVlans(r int) string {
 	return fmt.Sprintf(`
-        resource "equinix_metal_project" "test" {
-            name = "tfacc-conn-pro-%s"
-        }
+		resource "equinix_metal_project" "test" {
+			name = "tfacc-conn-pro-%d"
+		}
 
 		resource "equinix_metal_vlan" "test1" {
-			description = "tfacc-conn-vlan-1-%s"
-			metro       = "sv"
-			project_id  = equinix_metal_project.test.id
-		}
-		
-		resource "equinix_metal_vlan" "test2" {
-			description = "tfacc-conn-vlan-2-%s"
+			description = "tfacc-conn-vlan1-%d"
 			metro       = "sv"
 			project_id  = equinix_metal_project.test.id
 		}
 
-        resource "equinix_metal_connection" "test" {
-            name               = "tfacc-conn-%s"
-            project_id         = equinix_metal_project.test.id
-            type               = "shared"
-            redundancy         = "redundant"
-            metro              = "sv"
+		resource "equinix_metal_vlan" "test2" {
+			description = "tfacc-conn-vlan2-%d"
+			metro       = "sv"
+			project_id  = equinix_metal_project.test.id
+		}
+
+		resource "equinix_metal_connection" "test" {
+			name               = "tfacc-conn-%d"
+			project_id         = equinix_metal_project.test.id
+			type               = "shared"
+			redundancy         = "redundant"
+			metro              = "sv"
 			speed              = "50Mbps"
 			service_token_type = "a_side"
 			vlans = [
 				equinix_metal_vlan.test1.vxlan,
 				equinix_metal_vlan.test2.vxlan
 			]
-        }
-		
+		}
+
 		data "equinix_metal_connection" "test" {
     		connection_id = equinix_metal_connection.test.id
 		}`,
-		randstr, randstr, randstr, randstr)
+		r, r, r, r)
 }

--- a/equinix/data_source_metal_connection_acc_test.go
+++ b/equinix/data_source_metal_connection_acc_test.go
@@ -1,0 +1,117 @@
+package equinix
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceMetalConnection_withoutVlans(t *testing.T) {
+	projectName := fmt.Sprintf("ds-device-%s", acctest.RandString(10))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceMetalConnectionConfig_withoutVlans(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_connection.test", "id",
+						"data.equinix_metal_connection.test", "connection_id"),
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_connection.test", "vlans",
+						"data.equinix_metal_connection.test", "vlans"),
+					resource.TestCheckNoResourceAttr(
+						"data.equinix_metal_connection.test", "vlans"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceMetalConnectionConfig_withoutVlans(randstr string) string {
+	return fmt.Sprintf(`
+        resource "equinix_metal_project" "test" {
+            name = "tfacc-conn-pro-%s"
+        }
+
+        resource "equinix_metal_connection" "test" {
+            name               = "tfacc-conn-%s"
+            project_id         = equinix_metal_project.test.id
+            type               = "shared"
+            redundancy         = "redundant"
+            metro              = "sv"
+			speed              = "50Mbps"
+			service_token_type = "a_side"
+        }
+		
+		data "equinix_metal_connection" "test" {
+    		connection_id = equinix_metal_connection.test.id
+		}`,
+		randstr, randstr)
+}
+
+func TestAccDataSourceMetalConnection_withVlans(t *testing.T) {
+	projectName := fmt.Sprintf("ds-device-by-id-%s", acctest.RandString(10))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceMetalConnectionConfig_withVlans(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_connection.test", "id",
+						"data.equinix_metal_connection.test", "connection_id"),
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_connection.test", "vlans",
+						"data.equinix_metal_connection.test", "vlans"),
+					resource.TestCheckResourceAttrSet(
+						"data.equinix_metal_connection.test", "vlans"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceMetalConnectionConfig_withVlans(randstr string) string {
+	return fmt.Sprintf(`
+        resource "equinix_metal_project" "test" {
+            name = "tfacc-conn-pro-%s"
+        }
+
+		resource "equinix_metal_vlan" "test1" {
+			description = "tfacc-conn-vlan-1-%s"
+			metro       = "sv"
+			project_id  = equinix_metal_project.test.id
+		}
+		
+		resource "equinix_metal_vlan" "test2" {
+			description = "tfacc-conn-vlan-2-%s"
+			metro       = "sv"
+			project_id  = equinix_metal_project.test.id
+		}
+
+        resource "equinix_metal_connection" "test" {
+            name               = "tfacc-conn-%s"
+            project_id         = equinix_metal_project.test.id
+            type               = "shared"
+            redundancy         = "redundant"
+            metro              = "sv"
+			speed              = "50Mbps"
+			service_token_type = "a_side"
+			vlans = [
+				equinix_metal_vlan.test1.vxlan,
+				equinix_metal_vlan.test2.vxlan
+			]
+        }
+		
+		data "equinix_metal_connection" "test" {
+    		connection_id = equinix_metal_connection.test.id
+		}`,
+		randstr, randstr, randstr, randstr)
+}

--- a/equinix/resource_metal_connection.go
+++ b/equinix/resource_metal_connection.go
@@ -383,6 +383,11 @@ func resourceMetalConnectionRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
+	vlans := getConnectionVlans(conn)
+	if vlans != nil {
+		d.Set("vlans", vlans)
+	}
+
 	return setMap(d, map[string]interface{}{
 		"organization_id":    conn.Organization.ID,
 		"project_id":         projectId,


### PR DESCRIPTION
This updates the `metal_connection` resource and data source to read the value of `vlans` from the API response to ensure that terraform state stays up-to-date with the real infrastructure if someone modifies the VLANs for a terraform-managed `metal_connection` outside of terraform.

Closes #270