### PR TITLE
limit sweeper to equinix folder

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -76,9 +76,10 @@ jobs:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
         SWEEP: "all" #Flag required to define the regions that the sweeper is to be ran in
         SWEEP_ALLOW_FAILURES: "true" #Enable to allow Sweeper Tests to continue after failures
+        SWEEP_DIR: "./equinix"
       run: |
         # Added sweep-run to filter Metal test
-        go test `go list ./... | grep -v cmd` -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run=$(grep -o 'AddTestSweepers("[^"]*"' equinix/resource_metal_* |cut -d '"' -f2 | paste -s -d, -)
+        go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run=$(grep -o 'AddTestSweepers("[^"]*"' equinix/resource_metal_* |cut -d '"' -f2 | paste -s -d, -)
     - name: Upload coverage to Codecov
       if: ${{ always() }}
       uses: codecov/codecov-action@v2


### PR DESCRIPTION
Test sweeper is [failing](https://github.com/equinix/terraform-provider-equinix/actions/runs/3588142143/jobs/6039220202#step:6:227) after introducing new Terratest acc test of `tests` folder.  Terratest does not include [sweeper flags](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/resource/testing.go#L48-L50).

This change just remove checking of test under `tests` folder but doesn't introduce an alternative solution to prevent failed tests leave active resources, I will open a new issue to find a global solution to cover all acceptance tests