### PR TITLE
Allow updating some `equinix_metal_device` fields without recreating the instance

### DIFF
--- a/docs/resources/equinix_metal_device.md
+++ b/docs/resources/equinix_metal_device.md
@@ -128,14 +128,39 @@ EOS
 }
 ```
 
+Create a device and allow the `user_data` and `custom_data` attributes to change in-place (i.e., without destroying and recreating the device):
+
+```hcl
+resource "equinix_metal_device" "pxe1" {
+  hostname         = "tf.coreos2-pxe"
+  plan             = "c3.small.x86"
+  metro            = "sv"
+  operating_system = "custom_ipxe"
+  billing_cycle    = "hourly"
+  project_id       = local.project_id
+  ipxe_script_url  = "https://rawgit.com/cloudnativelabs/pxe/master/metal/coreos-stable-metal.ipxe"
+  always_pxe       = "false"
+  user_data        = local.user_data
+  custom_data      = local.custom_data
+
+  behavior {
+    allow_changes = [
+      "custom_data",
+      "user_data"
+    ]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `always_pxe` - (Optional) If true, a device with OS `custom_ipxe` will continue to boot via iPXE
 on reboots.
+* `behavior` - (Optional) Behavioral overrides that change how the resource handles certain attribute updates. See [Behavior](#behavior) below for more details.
 * `billing_cycle` - (Optional) monthly or hourly
-* `custom_data` - (Optional) A string of the desired Custom Data for the device.
+* `custom_data` - (Optional) A string of the desired Custom Data for the device.  By default, changing this attribute will cause the provider to destroy and recreate your device.  If `reinstall` is specified or `behavior.allow_changes` includes `"custom_data"`, the device will be updated in-place instead of recreated.
 * `description` - (Optional) The device description.
 * `facilities` - (Optional) List of facility codes with deployment preferences. Equinix Metal API will go
 through the list and will deploy your device to first facility with free capacity. List items must
@@ -186,10 +211,16 @@ be a number string, or size notation string, e.g. "4G" or "8M" (for gigabytes an
 * `tags` - (Optional) Tags attached to the device.
 * `termination_time` - (Optional) Timestamp for device termination. For example `2021-09-03T16:32:00+03:00`.
 If you don't supply timezone info, timestamp is assumed to be in UTC.
-* `user_data` - (Optional) A string of the desired User Data for the device.
+* `user_data` - (Optional) A string of the desired User Data for the device.  By default, changing this attribute will cause the provider to destroy and recreate your device.  If `reinstall` is specified or `behavior.allow_changes` includes `"user_data"`, the device will be updated in-place instead of recreated.
 * `wait_for_reservation_deprovision` - (Optional) Only used for devices in reserved hardware. If
 set, the deletion of this device will block until the hardware reservation is marked provisionable
 (about 4 minutes in August 2019).
+
+### Behavior
+
+The `behavior` block has below fields:
+
+* `allow_changes` - (Optional) List of attributes that are allowed to change without recreating the instance. Supported attributes: `custom_data`, `user_data`"
 
 ### IP address
 

--- a/equinix/resource_metal_device.go
+++ b/equinix/resource_metal_device.go
@@ -67,9 +67,9 @@ func resourceMetalDevice() *schema.Resource {
 
 			"operating_system": {
 				Type:        schema.TypeString,
-				Description: "The operating system slug. To find the slug, or visit [Operating Systems API docs](https://metal.equinix.com/developers/api/operatingsystems), set your API auth token in the top of the page and see JSON from the API response",
+				Description: "The operating system slug. To find the slug, or visit [Operating Systems API docs](https://metal.equinix.com/developers/api/operatingsystems), set your API auth token in the top of the page and see JSON from the API response.  By default, changing this attribute will cause your device to be deleted and recreated.  If `reinstall` is enabled, the device will be updated in-place instead of recreated.",
 				Required:    true,
-				ForceNew:    false,
+				ForceNew:    false, // Computed; see CustomizeDiff below
 			},
 
 			"deployed_facility": {
@@ -270,18 +270,18 @@ func resourceMetalDevice() *schema.Resource {
 
 			"user_data": {
 				Type:        schema.TypeString,
-				Description: "A string of the desired User Data for the device",
+				Description: "A string of the desired User Data for the device.  By default, changing this attribute will cause terraform to destroy and recreate your device.  If `reinstall` is specified or `behavior.allow_changes` includes `\"user_data\"`, the device will be updated in-place instead of recreated.",
 				Optional:    true,
 				Sensitive:   true,
-				ForceNew:    false,
+				ForceNew:    false, // Computed; see CustomizeDiff below
 			},
 
 			"custom_data": {
 				Type:        schema.TypeString,
-				Description: "A string of the desired Custom Data for the device",
+				Description: "A string of the desired Custom Data for the device.  By default, changing this attribute will cause terraform to destroy and recreate your device.  If `reinstall` is specified or `behavior.allow_changes` includes `\"custom_data\"`, the device will be updated in-place instead of recreated.",
 				Optional:    true,
 				Sensitive:   true,
-				ForceNew:    false,
+				ForceNew:    false, // Computed; see CustomizeDiff below
 			},
 
 			"ipxe_script_url": {
@@ -407,39 +407,95 @@ func resourceMetalDevice() *schema.Resource {
 					},
 				},
 			},
+
+			"behavior": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allow_changes": {
+							Type: schema.TypeList,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+									attribute := val.(string)
+									supportedAttributes := []string{"custom_data", "user_data"}
+									if !contains(supportedAttributes, attribute) {
+										errs = []error{fmt.Errorf("behavior.allow_changes was given %s, but only supports %v", attribute, supportedAttributes)}
+									}
+									return
+								},
+							},
+							Description: "List of attributes that are allowed to change without recreating the instance",
+							Optional:    true,
+						},
+					},
+				},
+			},
 		},
 		CustomizeDiff: customdiff.Sequence(
-			customdiff.ForceNewIf("custom_data", shouldReinstall),
-			customdiff.ForceNewIf("operating_system", shouldReinstall),
-			customdiff.ForceNewIf("user_data", shouldReinstall),
+			customdiff.ForceNewIf("custom_data", reinstallDisabledAndNoChangesAllowed("custom_data")),
+			customdiff.ForceNewIf("operating_system", reinstallDisabled),
+			customdiff.ForceNewIf("user_data", reinstallDisabledAndNoChangesAllowed("user_data")),
 		),
 	}
 }
 
-func shouldReinstall(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+// This method returns true if reinstall is disabled, and false if it is enabled.
+// This is used to set ForceNew to true when reinstall is disabled
+func reinstallDisabled(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 	reinstall, ok := d.GetOk("reinstall")
 
-	// Prior behaviour was to always destroy and create,
-	// so in the event we can't get the reinstall config; let's
-	// continue to do so.
 	if !ok {
+		// There is no reinstall attribute, so ForceNew should be true
 		return true
 	}
 
-	// We didn't get a reinstall configuration
-	reinstall_list, ok := reinstall.([]interface{})
-	if !ok {
-		return true
-	}
-
+	reinstall_list := reinstall.([]interface{})
 	reinstall_config, ok := reinstall_list[0].(map[string]interface{})
-
-	// We didn't get a reinstall configuration
 	if !ok {
+		// This should be unreachable (to get here, reinstall attribute had to be specified,
+		// but with an invalid specification...maybe panic?)
 		return true
 	}
 
 	return !reinstall_config["enabled"].(bool)
+}
+
+func reinstallDisabledAndNoChangesAllowed(attribute string) customdiff.ResourceConditionFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+		if reinstallDisabled(ctx, d, meta) {
+			// If reinstall is disabled, we need to see if ForceNew
+			// should be disabled due to behavior settings
+			behavior, ok := d.GetOk("behavior")
+
+			if !ok {
+				// This means reinstall is disabled and there is no behavior
+				// attribute, so ForceNew should be true
+				return true
+			}
+
+			behavior_list := behavior.([]interface{})
+			behavior_config, ok := behavior_list[0].(map[string]interface{})
+
+			if !ok {
+				// This should be unreachable (to get here, behavior attribute had to be specified,
+				// but with an invalid specification...maybe panic?  Or just don't capture & check `ok`?)
+				return true
+			}
+
+			allow_changes := convertStringArr(behavior_config["allow_changes"].([]interface{}))
+
+			// This means we got a valid behavior specification, so we set ForceNew
+			// to true if behavior.allow_changes includes the attribute that is changing
+			return !contains(allow_changes, attribute)
+		}
+
+		// This means reinstall is enabled, so it doesn't matter what the behavior
+		// says; ForceNew should not be set to true in this case
+		return false
+	}
 }
 
 func resourceMetalDeviceCreate(d *schema.ResourceData, meta interface{}) error {
@@ -741,46 +797,53 @@ func resourceMetalDeviceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if err := doReinstall(client, d, meta); err != nil {
+		return err
+	}
+
+	return resourceMetalDeviceRead(d, meta)
+}
+
+func doReinstall(client *packngo.Client, d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("operating_system") || d.HasChange("user_data") || d.HasChange("custom_data") {
-		reinstallOptions, err := getReinstallOptions(d)
-		if err != nil {
-			return friendlyError(err)
+		reinstall, ok := d.GetOk("reinstall")
+
+		if !ok {
+			// Assume we're here because behavior.allow_changes was set
+			return nil
+		}
+
+		reinstall_list := reinstall.([]interface{})
+		reinstall_config, ok := reinstall_list[0].(map[string]interface{})
+
+		if !ok {
+			// This means a reinstall block was provided but it's invalid, so user's intent
+			// is unclear and we should error (this should maybe be a panic?)
+			return fmt.Errorf("expected reinstall configuration and none available")
+		}
+
+		if !reinstall_config["enabled"].(bool) {
+			// This means a reinstall block was provided, but reinstall was explicitly
+			// enabled.  Assume we're here because behavior.allow_changes was set
+			return nil
+		}
+
+		reinstallOptions := packngo.DeviceReinstallFields{
+			OperatingSystem: d.Get("operating_system").(string),
+			PreserveData:    reinstall_config["preserve_data"].(bool),
+			DeprovisionFast: reinstall_config["deprovision_fast"].(bool),
 		}
 
 		if _, err := client.Devices.Reinstall(d.Id(), &reinstallOptions); err != nil {
 			return friendlyError(err)
 		}
 
-		if err = waitForActiveDevice(d, meta); err != nil {
+		if err := waitForActiveDevice(d, meta); err != nil {
 			return err
 		}
 	}
 
-	return resourceMetalDeviceRead(d, meta)
-}
-
-func getReinstallOptions(d *schema.ResourceData) (packngo.DeviceReinstallFields, error) {
-	reinstall_list, ok := d.Get("reinstall").([]interface{})
-
-	if !ok {
-		return packngo.DeviceReinstallFields{}, fmt.Errorf("expected reinstall configuration and none available")
-	}
-
-	if len(reinstall_list) == 0 {
-		return packngo.DeviceReinstallFields{}, fmt.Errorf("expected reinstall configuration and none available")
-	}
-
-	reinstall_config, ok := reinstall_list[0].(map[string]interface{})
-
-	if !ok {
-		return packngo.DeviceReinstallFields{}, fmt.Errorf("expected reinstall configuration and none available")
-	}
-
-	return packngo.DeviceReinstallFields{
-		OperatingSystem: d.Get("operating_system").(string),
-		PreserveData:    reinstall_config["preserve_data"].(bool),
-		DeprovisionFast: reinstall_config["deprovision_fast"].(bool),
-	}, nil
+	return nil
 }
 
 func resourceMetalDeviceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/equinix/resource_metal_device.go
+++ b/equinix/resource_metal_device.go
@@ -270,7 +270,7 @@ func resourceMetalDevice() *schema.Resource {
 
 			"user_data": {
 				Type:        schema.TypeString,
-				Description: "A string of the desired User Data for the device.  By default, changing this attribute will cause terraform to destroy and recreate your device.  If `reinstall` is specified or `behavior.allow_changes` includes `\"user_data\"`, the device will be updated in-place instead of recreated.",
+				Description: "A string of the desired User Data for the device.  By default, changing this attribute will cause the provider to destroy and recreate your device.  If `reinstall` is specified or `behavior.allow_changes` includes `\"user_data\"`, the device will be updated in-place instead of recreated.",
 				Optional:    true,
 				Sensitive:   true,
 				ForceNew:    false, // Computed; see CustomizeDiff below
@@ -278,7 +278,7 @@ func resourceMetalDevice() *schema.Resource {
 
 			"custom_data": {
 				Type:        schema.TypeString,
-				Description: "A string of the desired Custom Data for the device.  By default, changing this attribute will cause terraform to destroy and recreate your device.  If `reinstall` is specified or `behavior.allow_changes` includes `\"custom_data\"`, the device will be updated in-place instead of recreated.",
+				Description: "A string of the desired Custom Data for the device.  By default, changing this attribute will cause the provider to destroy and recreate your device.  If `reinstall` is specified or `behavior.allow_changes` includes `\"custom_data\"`, the device will be updated in-place instead of recreated.",
 				Optional:    true,
 				Sensitive:   true,
 				ForceNew:    false, // Computed; see CustomizeDiff below

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -400,6 +400,87 @@ func TestAccMetalDevice_IPXEConfigMissing(t *testing.T) {
 	})
 }
 
+func TestAccMetalDevice_allowUserdataChanges(t *testing.T) {
+	var d1, d2 packngo.Device
+	rs := acctest.RandString(10)
+	rInt := acctest.RandInt()
+	r := "equinix_metal_device.test"
+
+	userdata1 := fmt.Sprintf("#!/usr/bin/env sh\necho 'Allow userdata changes %d'\n", rInt)
+	userdata2 := fmt.Sprintf("#!/usr/bin/env sh\necho 'Allow userdata changes %d'\n", rInt+1)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccMetalDeviceCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalDeviceConfig_allowAttributeChanges(rInt, rs, userdata1, "", "user_data"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalDeviceExists(r, &d1),
+					resource.TestCheckResourceAttr(r, "user_data", userdata1),
+				),
+			},
+			{
+				Config: testAccMetalDeviceConfig_allowAttributeChanges(rInt, rs, userdata2, "", "user_data"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalDeviceExists(r, &d2),
+					resource.TestCheckResourceAttr(r, "user_data", userdata2),
+					testAccMetalSameDevice(t, &d1, &d2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMetalDevice_allowCustomdataChanges(t *testing.T) {
+	var d1, d2 packngo.Device
+	rs := acctest.RandString(10)
+	rInt := acctest.RandInt()
+	r := "equinix_metal_device.test"
+
+	customdata1 := fmt.Sprintf(`{"message": "Allow customdata changes %d"}`, rInt)
+	customdata2 := fmt.Sprintf(`{"message": "Allow customdata changes %d"}`, rInt+1)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccMetalDeviceCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalDeviceConfig_allowAttributeChanges(rInt, rs, "", customdata1, "custom_data"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalDeviceExists(r, &d1),
+					resource.TestCheckResourceAttr(r, "custom_data", customdata1),
+				),
+			},
+			{
+				Config: testAccMetalDeviceConfig_allowAttributeChanges(rInt, rs, "", customdata2, "custom_data"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalDeviceExists(r, &d2),
+					resource.TestCheckResourceAttr(r, "custom_data", customdata2),
+					testAccMetalSameDevice(t, &d1, &d2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMetalDevice_allowChangesErrorOnUnsupportedAttribute(t *testing.T) {
+	rs := acctest.RandString(10)
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccMetalDeviceConfig_allowAttributeChanges(rInt, rs, "", "", "project_id"),
+				ExpectError: regexp.MustCompile(`Error: behavior.allow_changes was given project_id, but only supports \[.+\]`),
+			},
+		},
+	})
+}
+
 func testAccMetalDeviceCheckDestroyed(s *terraform.State) error {
 	client := testAccProvider.Meta().(*Config).metal
 
@@ -623,6 +704,41 @@ resource "equinix_metal_device" "test" {
   }
 }
 `, confAccMetalDevice_base(preferable_plans, preferable_metros, preferable_os), projSuffix, rInt, rInt, testDeviceTerminationTime())
+}
+
+func testAccMetalDeviceConfig_allowAttributeChanges(rInt int, projSuffix string, userdata string, customdata string, attributeName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "equinix_metal_project" "test" {
+    name = "tfacc-device-%s"
+}
+
+resource "equinix_metal_device" "test" {
+  hostname         = "tfacc-test-device-%d"
+  plan             = local.plan
+  metro            = local.metro
+  operating_system = local.os
+  billing_cycle    = "hourly"
+  project_id       = "${equinix_metal_project.test.id}"
+  tags             = ["%d"]
+  user_data        = %q
+  custom_data      = %q
+
+  behavior {
+    allow_changes = [
+      "%s"
+    ]
+  }
+
+  lifecycle {
+    ignore_changes = [
+      plan,
+      metro,
+    ]
+  }
+}
+`, confAccMetalDevice_base(preferable_plans, preferable_metros, preferable_os), projSuffix, rInt, rInt, userdata, customdata, attributeName)
 }
 
 func testAccMetalDeviceConfig_varname(rInt int, projSuffix string) string {

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -724,6 +724,7 @@ resource "equinix_metal_device" "test" {
   tags             = ["%d"]
   user_data        = %q
   custom_data      = %q
+  termination_time = "%s"
 
   behavior {
     allow_changes = [
@@ -738,7 +739,7 @@ resource "equinix_metal_device" "test" {
     ]
   }
 }
-`, confAccMetalDevice_base(preferable_plans, preferable_metros, preferable_os), projSuffix, rInt, rInt, userdata, customdata, attributeName)
+`, confAccMetalDevice_base(preferable_plans, preferable_metros, preferable_os), projSuffix, rInt, rInt, userdata, customdata, testDeviceTerminationTime(), attributeName)
 }
 
 func testAccMetalDeviceConfig_varname(rInt int, projSuffix string) string {


### PR DESCRIPTION
By default, we force recreation of Equinix Metal devices when the `user_data` or `custom_data` attributes change, but this decision only exists within the terraform provider; the Equinix Metal API will happily accept updates to those fields without deleting a device.

Previously we had narrow support to bypass this behavior with a `reinstall` block, but that still involves downtime.  This adds support for `behavior.allow_changes`, which is a list of attributes that are allowed to change _without_ forcing device recreation.

Closes #159