### PR TITLE
Deprecate facility/facilities

### DIFF
--- a/docs/data-sources/equinix_metal_connection.md
+++ b/docs/data-sources/equinix_metal_connection.md
@@ -28,7 +28,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `name` - Name of the connection resource.
 * `metro` - Slug of a metro to which the connection belongs.
-* `facility` - Slug of a facility to which the connection belongs.
+* `facility` - (**Deprecated**) Slug of a facility to which the connection belongs. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `redundancy` - Connection redundancy, reduntant or primary.
 * `type` - Connection type, dedicated or shared.
 * `project_id` - ID of project to which the connection belongs.

--- a/docs/data-sources/equinix_metal_device.md
+++ b/docs/data-sources/equinix_metal_device.md
@@ -54,7 +54,7 @@ In addition to all arguments above, the following attributes are exported:
 * `access_public_ipv4` - The ipv4 management IP assigned to the device.
 * `access_public_ipv6` - The ipv6 management IP assigned to the device.
 * `billing_cycle` - The billing cycle of the device (monthly or hourly).
-* `facility` - The facility where the device is deployed.
+* `facility` - (**Deprecated**) The facility where the device is deployed. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `description` - Description string for the device.
 * `hardware_reservation_id` - The id of hardware reservation which this device occupies.
 * `id` - The ID of the device.

--- a/docs/data-sources/equinix_metal_facility.md
+++ b/docs/data-sources/equinix_metal_facility.md
@@ -4,6 +4,8 @@ subcategory: "Metal"
 
 # equinix_metal_facility (Data Source)
 
+> **Deprecated** Use `equinix_metal_metro` instead.  For more information, refer to the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices).
+
 Provides an Equinix Metal facility datasource.
 
 ## Example Usage

--- a/docs/data-sources/equinix_metal_hardware_reservation.md
+++ b/docs/data-sources/equinix_metal_hardware_reservation.md
@@ -38,7 +38,7 @@ In addition to all arguments above, the following attributes are exported:
 * `project_id` - UUID of project this reservation is scoped to.
 * `device_id` - UUID of device occupying the reservation.
 * `plan` - Plan type for the reservation.
-* `facility` - Plan type for the reservation.
+* `facility` - (**Deprecated**) Facility for the reservation. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `provisionable` - Flag indicating whether the reserved server is provisionable or not. Spare
 devices can't be provisioned unless they are activated first.
 * `spare` - Flag indicating whether the Hardware Reservation is a spare. Spare Hardware

--- a/docs/data-sources/equinix_metal_ip_block_ranges.md
+++ b/docs/data-sources/equinix_metal_ip_block_ranges.md
@@ -34,8 +34,8 @@ output "out" {
 The following arguments are supported:
 
 * `project_id` - (Required) ID of the project from which to list the blocks.
-* `facility` - (Optional) Facility code filtering the IP blocks. Global IPv4 blocks will be listed
-anyway. If you omit this and metro, all the block from the project will be listed.
+* `facility` - (**Deprecated**) Facility code filtering the IP blocks. Global IPv4 blocks will be listed
+anyway. If you omit this and metro, all the block from the project will be listed.   Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `metro` - (Optional) Metro code filtering the IP blocks. Global IPv4 blocks will be listed
 anyway. If you omit this and facility, all the block from the project will be listed.
 

--- a/docs/data-sources/equinix_metal_metro.md
+++ b/docs/data-sources/equinix_metal_metro.md
@@ -25,7 +25,7 @@ output "id" {
   devices and 1 c3.medium.x86 device
 
 data "equinix_metal_metro" "test" {
-  code = "dc13"
+  code = "sv"
 
   capacity {
     plan = "c3.small.x86"
@@ -43,10 +43,10 @@ data "equinix_metal_metro" "test" {
 
 The following arguments are supported:
 
-* `code` - (Required) The facility code to search for facilities.
-* `capacity` - (Optional) One or more device plans for which the facility must have capacity.
+* `code` - (Required) The metro code to search for.
+* `capacity` - (Optional) One or more device plans for which the metro must have capacity.
   * `plan` - (Required) Device plan that must be available in selected location.
-  * `quantity` - (Optional) Minimun number of devices that must be available in selected location.
+  * `quantity` - (Optional) Minimum number of devices that must be available in selected location.
   Default is `1`.
 
 ## Attributes Reference

--- a/docs/data-sources/equinix_metal_operating_system.md
+++ b/docs/data-sources/equinix_metal_operating_system.md
@@ -18,7 +18,7 @@ data "equinix_metal_operating_system" "example" {
 resource "equinix_metal_device" "server" {
   hostname         = "tf.ubuntu"
   plan             = "c3.medium.x86"
-  facilities       = ["ny5"]
+  metro            = "ny"
   operating_system = data.equinix_metal_operating_system.example.id
   billing_cycle    = "hourly"
   project_id       = local.project_id

--- a/docs/data-sources/equinix_metal_plans.md
+++ b/docs/data-sources/equinix_metal_plans.md
@@ -57,13 +57,13 @@ output "plans" {
 }
 ```
 
-### Ignoring Changes to Plans/Facilities/Metro
+### Ignoring Changes to Plans/Metro
 
 Preserve deployed device plan, facility and metro when creating a new execution plan.
 
 As described in the [`data-resource-behavior`](https://www.terraform.io/language/data-sources#data-resource-behavior), terraform reads data resources during the planning phase in both the terraform plan and terraform apply commands. If the output from the data source is different to the prior state, it will propose changes to resources where there is a reference to their attributes.
 
-For `equinix_metal_plans`, it may happen that a device plan is no longer available in a facility/metro because there is no stock at that time or you were using a legacy server plan, and thus the returned list of plans matching your search criteria will be different from last `plan`/`apply`. Therefore, if a resource such as a `equinix_metal_device` uses the output of this data source to select a device plan or facility/metro, the Terraform plan will report that the `equinix_metal_device` needs to be recreated.
+For `equinix_metal_plans`, it may happen that a device plan is no longer available in a metro because there is no stock at that time or you were using a legacy server plan, and thus the returned list of plans matching your search criteria will be different from last `plan`/`apply`. Therefore, if a resource such as a `equinix_metal_device` uses the output of this data source to select a device plan or metro, the Terraform plan will report that the `equinix_metal_device` needs to be recreated.
 
 To prevent that you can take advantage of the Terraform [`lifecycle ignore_changes`](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) feature as shown in the example below.
 
@@ -84,12 +84,12 @@ data "equinix_metal_plans" "example" {
     }
 }
 
-# This equinix_metal_device will use the first returned plan and the list of facilities
-# It will ignore future changes on plan and facilities
+# This equinix_metal_device will use the first returned plan and the first metro in which that plan is available
+# It will ignore future changes on plan and metro
 resource "equinix_metal_device" "example" {
   hostname         = "example"
   plan             = data.equinix_metal_plans.example.plans[0].name
-  facilities       = data.equinix_metal_plans.example.plans[0].available_in
+  metro            = data.equinix_metal_plans.example.plans[0].available_in_metros[0]
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = var.project_id
@@ -97,19 +97,19 @@ resource "equinix_metal_device" "example" {
   lifecycle {
     ignore_changes = [
         plan,
-        facilities,
+        metro,
     ]
   }
 }
 ```
 
-If your use case requires dynamic changes of a device plan or metro/facility you can define the lifecycle with a condition.
+If your use case requires dynamic changes of a device plan or metro you can define the lifecycle with a condition.
 
 ```hcl
 # Following example uses a boolean variable that may eventually be set to you false when you update your equinix_metal_plans filter criteria because you need a device plan with a new feature.
-variable "ignore_plans_facilities_changes" {
+variable "ignore_plans_metros_changes" {
   type = bool
-  description = "If set to true, it will ignore plans or facilities changes"
+  description = "If set to true, it will ignore plans or metros changes"
   default = false
 }
 
@@ -121,9 +121,9 @@ resource "equinix_metal_device" "example" {
   // required device arguments
 
   lifecycle {
-    ignore_changes = var.ignore_plans_facilities_changes ? [
+    ignore_changes = var.ignore_plans_metros_changes ? [
         plan,
-        facilities,
+        metro,
     ] : []
   }
 }
@@ -149,7 +149,7 @@ All fields in the `plans` block defined below can be used as attribute for both 
 
 In addition to all arguments above, the following attributes are exported:
 
-* `plans` - The ID of the facility
+* `plans`
   - `id` - id of the plan
   - `name` - name of the plan
   - `slug`- plan slug
@@ -160,5 +160,5 @@ In addition to all arguments above, the following attributes are exported:
   - `pricing_hour`- plan hourly price
   - `pricing_month`- plan monthly price
   - `deployment_types`- list of deployment types, e.g. on_demand, spot_market
-  - `available_in`- list of facilities where the plan is available
-  - `available_in_metros`- list of facilities where the plan is available
+  - `available_in`- (**Deprecated**) list of facilities where the plan is available
+  - `available_in_metros`- list of metros where the plan is available

--- a/docs/data-sources/equinix_metal_port.md
+++ b/docs/data-sources/equinix_metal_port.md
@@ -19,7 +19,7 @@ locals {
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-test-device-port"
   plan             = "c3.medium.x86"
-  facilities       = ["sv15"]
+  metro            = "sv"
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id

--- a/docs/data-sources/equinix_metal_precreated_ip_block.md
+++ b/docs/data-sources/equinix_metal_precreated_ip_block.md
@@ -58,7 +58,7 @@ The following arguments are supported:
 * `address_family` - (Required) 4 or 6, depending on which block you are looking for.
 * `public` - (Required) Whether to look for public or private block.
 * `global` - (Optional) Whether to look for global block. Default is false for backward compatibility.
-* `facility` - (Optional) Facility of the searched block. (for non-global blocks).
+* `facility` - (**Deprecated**) Facility of the searched block. (for non-global blocks). Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `metro` - (Optional) Metro of the searched block (for non-global blocks).
 
 ## Attributes Reference

--- a/docs/data-sources/equinix_metal_spot_market_price.md
+++ b/docs/data-sources/equinix_metal_spot_market_price.md
@@ -8,15 +8,6 @@ Use this data source to get Equinix Metal Spot Market Price for a plan.
 
 ## Example Usage
 
-Lookup by facility:
-
-```hcl
-data "equinix_metal_spot_market_price" "example" {
-  facility = "ny5"
-  plan     = "c3.small.x86"
-}
-```
-
 Lookup by metro:
 
 ```hcl
@@ -31,7 +22,7 @@ data "equinix_metal_spot_market_price" "example" {
 The following arguments are supported:
 
 * `plan` - (Required) Name of the plan.
-* `facility` - (Optional) Name of the facility.
+* `facility` - (**Deprecated**) Name of the facility. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `metro` - (Optional) Name of the metro.
 
 ## Attributes Reference

--- a/docs/data-sources/equinix_metal_spot_market_request.md
+++ b/docs/data-sources/equinix_metal_spot_market_request.md
@@ -15,7 +15,7 @@ device IDs created by referenced Spot Market Request.
 resource "equinix_metal_spot_market_request" "req" {
   project_id       = local.project_id
   max_bid_price    = 0.1
-  facilities       = ["ny5"]
+  metro            = "ny"
   devices_min      = 2
   devices_max      = 2
   wait_for_devices = true
@@ -79,7 +79,7 @@ In addition to all arguments above, the following attributes are exported:
 * `devices_min` - Miniumum number devices to be created.
 * `devices_max` - Maximum number devices to be created.
 * `max_bid_price` - Maximum price user is willing to pay per hour per device.
-* `facilities` - Facility IDs where devices should be created.
+* `facilities` - (**Deprecated**) Facility IDs where devices should be created. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `metro` - Metro where devices should be created.
 * `project_id` - Project ID.
 * `plan` - The device plan slug.

--- a/docs/data-sources/equinix_metal_vlan.md
+++ b/docs/data-sources/equinix_metal_vlan.md
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `vlan_id` - (Optional) Metal UUID of the VLAN resource to look up.
 * `project_id` - (Optional) UUID of parent project of the VLAN. Use together with the vxlan number and metro or facility.
 * `vxlan` - (Optional) vxlan number of the VLAN to look up. Use together with the project_id and metro or facility.
-* `facility` - (Optional) Facility where the VLAN is deployed.
+* `facility` - (Optional) Facility where the VLAN is deployed. Deprecated, see https://feedback.equinixmetal.com/changelog/bye-facilities-hello-again-metros
 * `metro` - (Optional) Metro where the VLAN is deployed.
 
 -> **NOTE:** You must set either `vlan_id` or a combination of `vxlan`, `project_id`, and, `metro` or `facility`.

--- a/docs/resources/equinix_metal_bgp_session.md
+++ b/docs/resources/equinix_metal_bgp_session.md
@@ -38,14 +38,14 @@ locals {
 
 resource "equinix_metal_reserved_ip_block" "addr" {
   project_id = local.project_id
-  facility   = "ny5"
+  metro      = "ny"
   quantity   = 1
 }
 
 resource "equinix_metal_device" "test" {
   hostname         = "terraform-test-bgp-sesh"
   plan             = "c3.small.x86"
-  facilities       = ["ny5"]
+  metro            = ["ny"]
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id

--- a/docs/resources/equinix_metal_connection.md
+++ b/docs/resources/equinix_metal_connection.md
@@ -115,7 +115,7 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the connection resource
 * `metro` - (Optional) Metro where the connection will be created.
-* `facility` - (Optional) Facility where the connection will be created.
+* `facility` - (**Deprecated**) Facility where the connection will be created.   Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `redundancy` - (Required) Connection redundancy - redundant or primary.
 * `type` - (Required) Connection type - dedicated or shared.
 * `project_id` - (Optional) ID of the project where the connection is scoped to, must be set for.

--- a/docs/resources/equinix_metal_device.md
+++ b/docs/resources/equinix_metal_device.md
@@ -42,13 +42,13 @@ resource "equinix_metal_device" "pxe1" {
 }
 ```
 
-Create a device without a public IP address in facility ny5, with only a /30 private IPv4 subnet (4 IP addresses)
+Create a device without a public IP address in metro ny, with only a /30 private IPv4 subnet (4 IP addresses)
 
 ```hcl
 resource "equinix_metal_device" "web1" {
   hostname         = "tf.coreos2"
   plan             = "c3.small.x86"
-  facilities       = ["ny5"]
+  metro            = "ny"
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
@@ -65,7 +65,7 @@ Deploy device on next-available reserved hardware and do custom partitioning.
 resource "equinix_metal_device" "web1" {
   hostname                = "tftest"
   plan                    = "c3.small.x86"
-  facilities              = ["ny5"]
+  metro                   = "ny"
   operating_system        = "ubuntu_20_04"
   billing_cycle           = "hourly"
   project_id              = local.project_id
@@ -162,11 +162,11 @@ on reboots.
 * `billing_cycle` - (Optional) monthly or hourly
 * `custom_data` - (Optional) A string of the desired Custom Data for the device.  By default, changing this attribute will cause the provider to destroy and recreate your device.  If `reinstall` is specified or `behavior.allow_changes` includes `"custom_data"`, the device will be updated in-place instead of recreated.
 * `description` - (Optional) The device description.
-* `facilities` - (Optional) List of facility codes with deployment preferences. Equinix Metal API will go
+* `facilities` - (**Deprecated**) List of facility codes with deployment preferences. Equinix Metal API will go
 through the list and will deploy your device to first facility with free capacity. List items must
 be facility codes or `any` (a wildcard). To find the facility code, visit
 [Facilities API docs](https://metal.equinix.com/developers/api/facilities/), set your API auth
-token in the top of the page and see JSON from the API response. Conflicts with `metro`.
+token in the top of the page and see JSON from the API response. Conflicts with `metro`.  Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `force_detach_volumes` - (Optional) Delete device even if it has volumes attached. Only applies
 for destroy action.
 * `hardware_reservation_id` - (Optional) The UUID of the hardware reservation where you want this
@@ -265,7 +265,7 @@ In addition to all arguments above, the following attributes are exported:
 * `access_public_ipv6` - The ipv6 maintenance IP assigned to the device.
 * `billing_cycle` - The billing cycle of the device (monthly or hourly).
 * `created` - The timestamp for when the device was created.
-* `deployed_facility` - The facility where the device is deployed.
+* `deployed_facility` - (**Deprecated**) The facility where the device is deployed. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `deployed_hardware_reservation_id` - ID of hardware reservation where this device was deployed.
 It is useful when using the `next-available` hardware reservation.
 * `description` - Description string for the device.

--- a/docs/resources/equinix_metal_ip_attachment.md
+++ b/docs/resources/equinix_metal_ip_attachment.md
@@ -7,22 +7,22 @@ subcategory: "Metal"
 Provides a resource to attach elastic IP subnets to devices.
 
 To attach an IP subnet from a reserved block to a provisioned device, you must derive a subnet CIDR
-belonging to one of your reserved blocks in the same project and facility as the target device.
+belonging to one of your reserved blocks in the same project and metro as the target device.
 
 For example, you have reserved IPv4 address block `147.229.10.152/30`, you can choose to assign
 either the whole block as one subnet to a device; or 2 subnets with CIDRs `147.229.10.152/31` and
 `147.229.10.154/31`; or 4 subnets with mask prefix length `32`. More about the elastic IP subnets
 is [here](https://metal.equinix.com/developers/docs/networking/elastic-ips/).
 
-Device and reserved block must be in the same facility.
+Device and reserved block must be in the same metro.
 
 ## Example Usage
 
 ```hcl
-# Reserve /30 block of max 2 public IPv4 addresses in Parsippany, NJ (ny5) for myproject
+# Reserve /30 block of max 2 public IPv4 addresses in metro ny for myproject
 resource "equinix_metal_reserved_ip_block" "myblock" {
   project_id = local.project_id
-  facility   = "ny5"
+  metro      = "ny"
   quantity   = 2
 }
 
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `device_id` - (Required) ID of device to which to assign the subnet.
 * `cidr_notation` - (Required) CIDR notation of subnet from block reserved in the same project
-and facility as the device.
+and metro as the device.
 
 ## Attributes Reference
 

--- a/docs/resources/equinix_metal_port_vlan_attachment.md
+++ b/docs/resources/equinix_metal_port_vlan_attachment.md
@@ -6,7 +6,7 @@ subcategory: "Metal"
 
 Provides a resource to attach device ports to VLANs.
 
-Device and VLAN must be in the same facility.
+Device and VLAN must be in the same metro.
 
 If you need this resource to add the port back to bond on removal, set `force_bond = true`.
 
@@ -21,15 +21,15 @@ To learn more about Layer 2 networking in Equinix Metal, refer to
 
 ```hcl
 resource "equinix_metal_vlan" "test" {
-  description = "VLAN in New Jersey"
-  facility    = "ny5"
+  description = "VLAN in New York"
+  metro       = "ny"
   project_id  = local.project_id
 }
 
 resource "equinix_metal_device" "test" {
   hostname         = "test"
   plan             = "c3.small.x86"
-  facilities       = ["ny5"]
+  metro            = "ny"
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
@@ -54,7 +54,7 @@ resource "equinix_metal_port_vlan_attachment" "test" {
 resource "equinix_metal_device" "test" {
   hostname         = "test"
   plan             = "c3.small.x86"
-  facilities       = ["ny5"]
+  metro            = "ny"
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
@@ -66,14 +66,14 @@ resource "equinix_metal_device_network_type" "test" {
 }
 
 resource "equinix_metal_vlan" "test1" {
-  description = "VLAN in New Jersey"
-  facility    = "ny5"
+  description = "VLAN in New York"
+  metro       = "ny"
   project_id  = local.project_id
 }
 
 resource "equinix_metal_vlan" "test2" {
   description = "VLAN in New Jersey"
-  facility    = "ny5"
+  metro       = "ny"
   project_id  = local.project_id
 }
 

--- a/docs/resources/equinix_metal_project_ssh_key.md
+++ b/docs/resources/equinix_metal_project_ssh_key.md
@@ -24,7 +24,7 @@ resource "equinix_metal_project_ssh_key" "test" {
 resource "equinix_metal_device" "test" {
   hostname            = "test"
   plan                = "c3.medium.x86"
-  facilities          = ["ny5"]
+  metro               = "ny"
   operating_system    = "ubuntu_20_04"
   billing_cycle       = "hourly"
   project_ssh_key_ids = [equinix_metal_project_ssh_key.test.id]

--- a/docs/resources/equinix_metal_reserved_ip_block.md
+++ b/docs/resources/equinix_metal_reserved_ip_block.md
@@ -6,14 +6,14 @@ subcategory: "Metal"
 
 Provides a resource to create and manage blocks of reserved IP addresses in a project.
 
-When a user provisions first device in a facility, Equinix Metal API automatically allocates IPv6/56 and private IPv4/25 blocks.
+When a user provisions first device in a metro, Equinix Metal API automatically allocates IPv6/56 and private IPv4/25 blocks.
 The new device then gets IPv6 and private IPv4 addresses from those block. It also gets a public IPv4/31 address.
-Every new device in the project and facility will automatically get IPv6 and private IPv4 addresses from these pre-allocated blocks.
+Every new device in the project and metro will automatically get IPv6 and private IPv4 addresses from these pre-allocated blocks.
 The IPv6 and private IPv4 blocks can't be created, only imported. With this resource, it's possible to create either public IPv4 blocks or global IPv4 blocks.
 
-Public blocks are allocated in a facility. Addresses from public blocks can only be assigned to devices in the facility. Public blocks can have mask from /24 (256 addresses) to /32 (1 address). If you create public block with this resource, you must fill the facility argument.
+Public blocks are allocated in a metro. Addresses from public blocks can only be assigned to devices in the metro. Public blocks can have mask from /24 (256 addresses) to /32 (1 address). If you create public block with this resource, you must fill the metro argument.
 
-Addresses from global blocks can be assigned in any facility. Global blocks can have mask from /30 (4 addresses), to /32 (1 address). If you create global block with this resource, you must specify type = "global_ipv4" and you must omit the facility argument.
+Addresses from global blocks can be assigned in any metro. Global blocks can have mask from /30 (4 addresses), to /32 (1 address). If you create global block with this resource, you must specify type = "global_ipv4" and you must omit the metro argument.
 
 Once IP block is allocated or imported, an address from it can be assigned to device with the `equinix_metal_ip_attachment` resource.
 
@@ -24,15 +24,15 @@ Once IP block is allocated or imported, an address from it can be assigned to de
 Allocate reserved IP blocks:
 
 ```hcl
-# Allocate /31 block of max 2 public IPv4 addresses in Silicon Valley (sv15) facility for myproject
+# Allocate /31 block of max 2 public IPv4 addresses in Silicon Valley (sv) metro for myproject
 
 resource "equinix_metal_reserved_ip_block" "two_elastic_addresses" {
   project_id = local.project_id
-  facility   = "sv15"
+  metro      = "sv"
   quantity   = 2
 }
 
-# Allocate 1 floating IP in Sillicon Valley (sv) metro
+# Allocate 1 floating IP in Silicon Valley (sv) metro
 
 resource "equinix_metal_reserved_ip_block" "test" {
   project_id = local.project_id
@@ -41,7 +41,7 @@ resource "equinix_metal_reserved_ip_block" "test" {
   quantity   = 1
 }
 
-# Allocate 1 global floating IP, which can be assigned to device in any facility
+# Allocate 1 global floating IP, which can be assigned to device in any metro
 
 resource "equinix_metal_reserved_ip_block" "test" {
   project_id = local.project_id
@@ -53,10 +53,10 @@ resource "equinix_metal_reserved_ip_block" "test" {
 Allocate a block and run a device with public IPv4 from the block
 
 ```hcl
-# Allocate /31 block of max 2 public IPv4 addresses in Silicon Valley (sv15) facility
+# Allocate /31 block of max 2 public IPv4 addresses in Silicon Valley (sv) metro
 resource "equinix_metal_reserved_ip_block" "example" {
   project_id = local.project_id
-  facility   = "sv15"
+  metro      = "sv"
   quantity   = 2
 }
 
@@ -64,7 +64,7 @@ resource "equinix_metal_reserved_ip_block" "example" {
 
 resource "equinix_metal_device" "nodes" {
   project_id       = local.project_id
-  facilities       = ["sv15"]
+  metro            = "sv"
   plan             = "c3.small.x86"
   operating_system = "ubuntu_20_04"
   hostname         = "test"
@@ -90,8 +90,8 @@ The following arguments are supported:
 * `quantity` - (Optional) The number of allocated `/32` addresses, a power of 2. Required when `type` is not `vrf`.
 * `type` - (Optional) One of `global_ipv4`, `public_ipv4`, or `vrf`. Defaults to `public_ipv4` for backward
 compatibility.
-* `facility` - (Optional) Facility where to allocate the public IP address block, makes sense only
-if type is `public_ipv4` and must be empty if type is `global_ipv4`. Conflicts with `metro`.
+* `facility` - (**Deprecated**) Facility where to allocate the public IP address block, makes sense only
+if type is `public_ipv4` and must be empty if type is `global_ipv4`. Conflicts with `metro`. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `metro` - (Optional) Metro where to allocate the public IP address block, makes sense only
 if type is `public_ipv4` and must be empty if type is `global_ipv4`. Conflicts with `facility`.
 * `description` - (Optional) Arbitrary description.
@@ -114,7 +114,7 @@ In addition to all arguments above, the following attributes are exported:
 * `address_family` - Address family as integer. One of `4` or `6`.
 * `public` - Boolean flag whether addresses from a block are public.
 * `global` - Boolean flag whether addresses from a block are global (i.e. can be assigned in any
-facility).
+metro).
 * `vrf_id` - VRF ID of the block when type=vrf
 
 -> **NOTE:** Idempotent reference to a first `/32` address from a reserved block might look

--- a/docs/resources/equinix_metal_spot_market_request.md
+++ b/docs/resources/equinix_metal_spot_market_request.md
@@ -15,7 +15,7 @@ see [this article in Equinix Metal documentation](https://metal.equinix.com/deve
 resource "equinix_metal_spot_market_request" "req" {
   project_id    = local.project_id
   max_bid_price = 0.03
-  facilities    = ["ny5"]
+  metro         = "ny"
   devices_min   = 1
   devices_max   = 1
 
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `project_id` - (Required) Project ID.
 * `wait_for_devices` - (Optional) On resource creation wait until all desired devices are active.
 On resource destruction wait until devices are removed.
-* `facilities` - (Optional) Facility IDs where devices should be created.
+* `facilities` - (**Deprecated**) Facility IDs where devices should be created. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `metro` - (Optional) Metro where devices should be created.
 * `locked` - (Optional) Blocks deletion of the SpotMarketRequest device until the lock is disabled.
 * `instance_parameters` - (Required) Key/Value pairs of parameters for devices provisioned from

--- a/docs/resources/equinix_metal_vlan.md
+++ b/docs/resources/equinix_metal_vlan.md
@@ -14,13 +14,6 @@ To learn more about Layer 2 networking in Equinix Metal, refer to
 ## Example Usage
 
 ```hcl
-# Create a new VLAN in facility "sv15"
-resource "equinix_metal_vlan" "vlan1" {
-  description = "VLAN in New Jersey"
-  facility    = "sv15"
-  project_id  = local.project_id
-}
-
 # Create a new VLAN in metro "esv"
 resource "equinix_metal_vlan" "vlan1" {
   description = "VLAN in New Jersey"
@@ -35,7 +28,8 @@ resource "equinix_metal_vlan" "vlan1" {
 The following arguments are supported:
 
 * `project_id` - (Required) ID of parent project.
-* `facility` - (Required) Facility where to create the VLAN.
+* `metro` - (Optional) Metro in which to create the VLAN
+* `facility` - (**Deprecated**) Facility where to create the VLAN. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `description` - (Optional) Description string.
 * `vxlan` - (Optional) VLAN ID, must be unique in metro.
 

--- a/equinix/data_source_metal_connection.go
+++ b/equinix/data_source_metal_connection.go
@@ -111,6 +111,7 @@ func dataSourceMetalConnection() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Facility which the connection is scoped to",
+				Deprecated:  "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 			},
 			"metro": {
 				Type:        schema.TypeString,

--- a/equinix/data_source_metal_device.go
+++ b/equinix/data_source_metal_device.go
@@ -45,6 +45,7 @@ func dataSourceMetalDevice() *schema.Resource {
 			"facility": {
 				Type:        schema.TypeString,
 				Description: "The facility where the device is deployed",
+				Deprecated:  "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 				Computed:    true,
 			},
 			"metro": {

--- a/equinix/data_source_metal_facility.go
+++ b/equinix/data_source_metal_facility.go
@@ -76,6 +76,7 @@ func dataSourceMetalFacility() *schema.Resource {
 			},
 			"capacity": capacitySchema(),
 		},
+		DeprecationMessage: "Use data_source_metal_metro instead.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 	}
 }
 

--- a/equinix/data_source_metal_hardware_reservation.go
+++ b/equinix/data_source_metal_hardware_reservation.go
@@ -42,7 +42,8 @@ func dataSourceMetalHardwareReservation() *schema.Resource {
 			"facility": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Plan type for the reservation",
+				Description: "Facility for the reservation",
+				Deprecated:  "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 			},
 			"provisionable": {
 				Type:        schema.TypeBool,

--- a/equinix/data_source_metal_ip_block_ranges.go
+++ b/equinix/data_source_metal_ip_block_ranges.go
@@ -20,6 +20,7 @@ func dataSourceMetalIPBlockRanges() *schema.Resource {
 			"facility": {
 				Type:        schema.TypeString,
 				Description: "Facility code filtering the IP blocks. Global IPv4 blocks will be listed anyway. If you omit this and metro, all the block from the project will be listed",
+				Deprecated:  "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 				Optional:    true,
 			},
 			"metro": {

--- a/equinix/data_source_metal_plans.go
+++ b/equinix/data_source_metal_plans.go
@@ -79,6 +79,7 @@ func planSchema() map[string]*schema.Schema {
 		"available_in": {
 			Type:        schema.TypeSet,
 			Description: "list of facilities where the plan is available",
+			Deprecated:  "Use available_in_metros instead.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		"available_in_metros": {

--- a/equinix/data_source_metal_reserved_ip_block.go
+++ b/equinix/data_source_metal_reserved_ip_block.go
@@ -50,6 +50,7 @@ func dataSourceMetalReservedIPBlock() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Facility of the block. (for non-global blocks)",
+				Deprecated:  "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 			},
 			"metro": {
 				Type:        schema.TypeString,

--- a/equinix/data_source_metal_spot_market_price.go
+++ b/equinix/data_source_metal_spot_market_price.go
@@ -14,6 +14,7 @@ func dataSourceSpotMarketPrice() *schema.Resource {
 			"facility": {
 				Type:          schema.TypeString,
 				Description:   "Name of the facility",
+				Deprecated:    "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 				ConflictsWith: []string{"metro"},
 				Optional:      true,
 			},

--- a/equinix/data_source_metal_spot_market_request.go
+++ b/equinix/data_source_metal_spot_market_request.go
@@ -43,6 +43,7 @@ func dataSourceMetalSpotMarketRequest() *schema.Resource {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Facility IDs where devices should be created",
+				Deprecated:  "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 				Computed:    true,
 			},
 			"metro": {

--- a/equinix/data_source_metal_vlan.go
+++ b/equinix/data_source_metal_vlan.go
@@ -34,6 +34,7 @@ func dataSourceMetalVlan() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{"vlan_id", "metro"},
 				Description:   "Facility where the VLAN is deployed",
+				Deprecated:    "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 			},
 			"metro": {
 				Type:          schema.TypeString,

--- a/equinix/resource_metal_connection.go
+++ b/equinix/resource_metal_connection.go
@@ -78,6 +78,7 @@ func resourceMetalConnection() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				Description:   "Facility where the connection will be created",
+				Deprecated:    "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 				ConflictsWith: []string{"metro"},
 				ForceNew:      true,
 			},

--- a/equinix/resource_metal_device.go
+++ b/equinix/resource_metal_device.go
@@ -75,6 +75,7 @@ func resourceMetalDevice() *schema.Resource {
 			"deployed_facility": {
 				Type:        schema.TypeString,
 				Description: "The facility where the device is deployed",
+				Deprecated:  "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 				Computed:    true,
 			},
 
@@ -99,6 +100,7 @@ func resourceMetalDevice() *schema.Resource {
 			"facilities": {
 				Type:        schema.TypeList,
 				Description: "List of facility codes with deployment preferences. Equinix Metal API will go through the list and will deploy your device to first facility with free capacity. List items must be facility codes or any (a wildcard). To find the facility code, visit [Facilities API docs](https://metal.equinix.com/developers/api/facilities/), set your API auth token in the top of the page and see JSON from the API response. Conflicts with metro",
+				Deprecated:  "Use metro instead of facilities.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				ForceNew:    true,

--- a/equinix/resource_metal_spot_market_request.go
+++ b/equinix/resource_metal_spot_market_request.go
@@ -60,6 +60,7 @@ func resourceMetalSpotMarketRequest() *schema.Resource {
 			"facilities": {
 				Type:          schema.TypeList,
 				Description:   "Facility IDs where devices should be created",
+				Deprecated:    "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				Computed:      true,

--- a/equinix/resource_metal_vlan.go
+++ b/equinix/resource_metal_vlan.go
@@ -32,6 +32,7 @@ func resourceMetalVlan() *schema.Resource {
 			"facility": {
 				Type:          schema.TypeString,
 				Description:   "Facility where to create the VLAN",
+				Deprecated:    "Use metro instead of facility.  For more information, read the migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices",
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"metro"},
@@ -45,6 +46,7 @@ func resourceMetalVlan() *schema.Resource {
 			},
 			"metro": {
 				Type:          schema.TypeString,
+				Description:   "Metro in which to create the VLAN",
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"facility"},


### PR DESCRIPTION
This marks all `facility` and `facilities` properties as deprecated, and deprecates `data_source_equinix_metal_facility`.

Deprecation messages link to the facility-to-metro [migration guide]. That migration guide was updated in a separate PR to include a link to the [facilities deprecation announcement].

[migration guide]: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices
[facilities deprecation announcement]: https://feedback.equinixmetal.com/changelog/bye-facilities-hello-again-metros.

Closes #312 