### PR TITLE
NFV-23884: add public key type field in ssh key resource to onboard Arista device type

### DIFF
--- a/docs/resources/equinix_network_device.md
+++ b/docs/resources/equinix_network_device.md
@@ -47,7 +47,7 @@ resource "equinix_network_device" "csr1000v-ha" {
   package_code    = "SEC"
   notifications   = ["john@equinix.com", "marry@equinix.com", "fred@equinix.com"]
   hostname        = "csr1000v-p"
-  term_length     = 6
+  term_length     = 12
   account_number  = data.equinix_network_account.dc.number
   version         = "16.09.05"
   core_count      = 2
@@ -76,7 +76,7 @@ resource "equinix_network_device" "panw-cluster" {
   byol            = true
   package_code    = "VM100"
   notifications   = ["john@equinix.com", "marry@equinix.com", "fred@equinix.com"]
-  term_length     = 6
+  term_length     = 12
   account_number  = data.equinix_network_account.sv.number
   version         = "10.1.3"
   interface_count = 10
@@ -131,7 +131,7 @@ resource "equinix_network_device" "aviatrix-single" {
   byol            = true
   package_code    = "STD"
   notifications   = ["john@equinix.com"]
-  term_length     = 6
+  term_length     = 12
   account_number  = data.equinix_network_account.sv.number
   version         = "6.9"
   core_count      = 2
@@ -160,7 +160,7 @@ resource "equinix_network_device" "c8kv-single" {
   account_number  = data.equinix_network_account.sv.number
   version         = "17.06.01a"
   core_count      = 2
-  term_length     = 6
+  term_length     = 12
   license_token = "valid-license-token"
   additional_bandwidth = 5
   ssh_key {
@@ -168,6 +168,50 @@ resource "equinix_network_device" "c8kv-single" {
     key_name = "valid-key-name"
   }
   acl_template_id = "3e548c02-9164-4197-aa23-05b1f644883c"
+}
+```
+
+```hcl
+# Create self configured redundant Arista router with DSA key
+
+data "equinix_network_account" "sv" {
+  name = "account-name"
+  metro_code = "SV"
+}
+
+resource "equinix_network_ssh_key" "test-public-key" {
+  name = "key-name"
+  public_key = "ssh-dss key-value"
+  type = "DSA"
+}
+
+resource "equinix_network_device" "arista-ha" {
+  name            = "tf-arista-p"
+  metro_code      = data.equinix_network_account.sv.metro_code
+  type_code       = "ARISTA-ROUTER"
+  self_managed    = true
+  byol            = true
+  package_code    = "CloudEOS"
+  notifications   = ["test@equinix.com"]
+  hostname        = "arista-p"
+  account_number  = data.equinix_network_account.sv.number
+  version         = "4.29.0"
+  core_count      = 4
+  term_length     = 12
+  additional_bandwidth = 5
+  ssh_key {
+    username = "test-username"
+    key_name = equinix_network_ssh_key.test-public-key.name
+  }
+  acl_template_id = "c637a17b-7a6a-4486-924b-30e6c36904b0"
+  secondary_device {
+    name            = "tf-arista-s"
+    metro_code      = data.equinix_network_account.sv.metro_code
+    hostname        = "arista-s"
+    notifications   = ["test@eq.com"]
+    account_number  = data.equinix_network_account.sv.number
+    acl_template_id = "fee5e2c0-6198-4ce6-9cbd-bbe6c1dbe138"
+  }
 }
 ```
 

--- a/docs/resources/equinix_network_ssh_key.md
+++ b/docs/resources/equinix_network_ssh_key.md
@@ -13,7 +13,7 @@ resource "equinix_network_ssh_key" "john" {
   name       = "johnKent"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpXGdxljAyPp9vH97436U171cX
   2gRkfPnpL8ebrk7ZBeeIpdjtd8mYpXf6fOI0o91TQXZTYtjABzeRgg6/m9hsMOnTHjzWpFyuj/hiPu
-  iie1WtT4NffSH1ALQFX//zouBLmdNiYFMLfEVPZleergAqsYOHGCiQuR6Qh5j0yc5Wx+LKxiRZyjsS
+  iie1WtT4NffSH1ALQFX/azouBLmdNiYFMLfEVPZleergAqsYOHGCiQuR6Qh5j0yc5Wx+LKxiRZyjsS
   qo+EB8V6xBXi2i5PDJXK+dYG8YU9vdNeQdB84HvTWcGEnLR5w7pgC74pBVwzs3oWLy+3jWS0TKKtfl
   mryeFRufXq87gEkC1MOWX88uQgjyCsemuhPdN++2WS57gu7vcqCMwMDZa7dukRS3JANBtbs7qQhp9N
   w2PB4q6tohqUnSDxNjCqcoGeMNg/0kHeZcoVuznsjOrIDt0HgUApflkbtw1DP7Epfc2MJ0anf5GizM
@@ -21,6 +21,7 @@ resource "equinix_network_ssh_key" "john" {
   SPkAc8OqLrmIwf5jGoHGh6eUJy7AtMcwE3iUpbrLw8EEoZDoDXkzh+RbOtSNKXWV4EAXsIhjQusCOW
   WQnuAHCy9N4Td0Sntzu/xhCZ8xN0oO67Cqlsk98xSRLXeg21PuuhOYJw0DLF6L68zU2OO0RzqoNq/F
   jIsltSUJPAIfYKL0yEefeNWOXSrasI1ezw== John.Kent@company.com"
+  type       = "RSA"
 }
 ```
 
@@ -31,6 +32,7 @@ The following arguments are supported:
 * `name` - (Required) The name of SSH key used for identification.
 * `public_key` - (Required) The SSH public key. If this is a file, it can be read using the file
 interpolation function.
+* `type` - (Optional) The type of SSH key: `RSA` (default) or `DSA`.
 
 ## Attributes Reference
 

--- a/equinix/resource_network_ssh_key.go
+++ b/equinix/resource_network_ssh_key.go
@@ -17,12 +17,14 @@ var networkSSHKeySchemaNames = map[string]string{
 	"UUID":  "uuid",
 	"Name":  "name",
 	"Value": "public_key",
+	"Type":  "type",
 }
 
 var networkSSHKeyDescriptions = map[string]string{
 	"UUID":  "The unique identifier of the key",
 	"Name":  "The name of SSH key used for identification",
 	"Value": "The SSH public key. If this is a file, it can be read using the file interpolation function",
+	"Type":  "The type of SSH key: RSA (default) or DSA",
 }
 
 func resourceNetworkSSHKey() *schema.Resource {
@@ -61,6 +63,14 @@ func createNetworkSSHKeyResourceSchema() map[string]*schema.Schema {
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 			Description:  networkSSHKeyDescriptions["Value"],
+		},
+		networkSSHKeySchemaNames["Type"]: {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      "RSA",
+			ValidateFunc: validation.StringInSlice([]string{"RSA", "DSA"}, false),
+			Description:  networkSSHKeyDescriptions["Type"],
 		},
 	}
 }
@@ -124,6 +134,9 @@ func createNetworkSSHKey(d *schema.ResourceData) ne.SSHPublicKey {
 	if v, ok := d.GetOk(networkSSHKeySchemaNames["Value"]); ok {
 		key.Value = ne.String(v.(string))
 	}
+	if v, ok := d.GetOk(networkSSHKeySchemaNames["Type"]); ok {
+		key.Type = ne.String(v.(string))
+	}
 	return key
 }
 
@@ -136,6 +149,9 @@ func updateNetworkSSHKeyResource(key *ne.SSHPublicKey, d *schema.ResourceData) e
 	}
 	if err := d.Set(networkSSHKeySchemaNames["Value"], key.Value); err != nil {
 		return fmt.Errorf("error reading Value: %s", err)
+	}
+	if err := d.Set(networkSSHKeySchemaNames["Type"], key.Type); err != nil {
+		return fmt.Errorf("error reading Type: %s", err)
 	}
 	return nil
 }

--- a/equinix/resource_network_ssh_key_acc_test.go
+++ b/equinix/resource_network_ssh_key_acc_test.go
@@ -55,6 +55,7 @@ func TestAccNetworkSSHKey(t *testing.T) {
 		"resourceName": "test",
 		"name":         fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
 		"public_key":   "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXdzXBHaVpKpdO0udnB+4JOgUq7APO2rPXfrevvlZrps98AtlwXXVWZ5duRH5NFNfU4G9HCSiAPsebgjY0fG85tcShpXfHfACLt0tBW8XhfLQP2T6S50FQ1brBdURMDCMsD7duOXqvc0dlbs2/KcswHvuUmqVzob3bz7n1bQ48wIHsPg4ARqYhy5LN3OkllJH/6GEfqi8lKZx01/P/gmJMORcJujuOyXRB+F2iXBVYdhjML3Qg4+tEekBcVZOxUbERRZ0pvQ52Y6wUhn2VsjljixyqeOdmD0m6DayDQgSWms6bKPpBqN7zhXXk4qe8bXT4tQQba65b2CQ2A91jw2KgM/YZNmjyUJ+Rf1cQosJf9twqbAZDZ6rAEmj9zzvQ5vD/CGuzxdVMkePLlUK4VGjPu7cVzhXrnq4318WqZ5/lNiCST8NQ0fssChN8ANUzr/p/wwv3faFMVNmjxXTZMsbMFT/fbb2MVVuqNFN65drntlg6/xEao8gZROuRYiakBx8= user@host",
+		"type":         "RSA",
 	}
 	resourceName := fmt.Sprintf("equinix_network_ssh_key.%s", context["resourceName"].(string))
 	var key ne.SSHPublicKey
@@ -84,6 +85,7 @@ func testAccNetworkSSHKey(ctx map[string]interface{}) string {
 resource "equinix_network_ssh_key" "%{resourceName}" {
   name       = "%{name}"
   public_key = "%{public_key}"
+  type       = "%{type}"
 }
 `, ctx)
 }
@@ -114,6 +116,9 @@ func testAccNetworkSSHKeyAttributes(key *ne.SSHPublicKey, ctx map[string]interfa
 		}
 		if v, ok := ctx["public_key"]; ok && ne.StringValue(key.Value) != v.(string) {
 			return fmt.Errorf("public_key does not match %v - %v", ne.StringValue(key.Value), v)
+		}
+		if v, ok := ctx["type"]; ok && ne.StringValue(key.Type) != v.(string) {
+			return fmt.Errorf("type does not match %v - %v", ne.StringValue(key.Type), v)
 		}
 		return nil
 	}

--- a/equinix/resource_network_ssh_key_test.go
+++ b/equinix/resource_network_ssh_key_test.go
@@ -13,10 +13,12 @@ func TestNetworkSSHKey_createFromResourceData(t *testing.T) {
 	expected := ne.SSHPublicKey{
 		Name:  ne.String("testKey"),
 		Value: ne.String("testKeyValue"),
+		Type:  ne.String("RSA"),
 	}
 	rawData := map[string]interface{}{
 		networkSSHKeySchemaNames["Name"]:  ne.StringValue(expected.Name),
 		networkSSHKeySchemaNames["Value"]: ne.StringValue(expected.Value),
+		networkSSHKeySchemaNames["Type"]:  ne.StringValue(expected.Type),
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkSSHKeyResourceSchema(), rawData)
 	// when
@@ -31,6 +33,7 @@ func TestNetworkSSHKey_updateResourceData(t *testing.T) {
 		UUID:  ne.String("059c3020-aec5-44ca-816c-235435f16df9"),
 		Name:  ne.String("testKey"),
 		Value: ne.String("testKeyValue"),
+		Type:  ne.String("testKeyType"),
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkSSHKeyResourceSchema(), make(map[string]interface{}))
 	// when
@@ -40,4 +43,5 @@ func TestNetworkSSHKey_updateResourceData(t *testing.T) {
 	assert.Equal(t, ne.StringValue(input.UUID), d.Get(networkSSHKeySchemaNames["UUID"]), "UUID matches")
 	assert.Equal(t, ne.StringValue(input.Name), d.Get(networkSSHKeySchemaNames["Name"]), "Name matches")
 	assert.Equal(t, ne.StringValue(input.Value), d.Get(networkSSHKeySchemaNames["Value"]), "Value matches")
+	assert.Equal(t, ne.StringValue(input.Type), d.Get(networkSSHKeySchemaNames["Type"]), "Type matches")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/equinix-labs/fabric-go v0.4.0
 	github.com/equinix/ecx-go/v2 v2.3.0
-	github.com/equinix/ne-go v1.9.0
+	github.com/equinix/ne-go v1.10.0
 	github.com/equinix/oauth2-go v1.0.0
 	github.com/equinix/rest-go v1.3.0
 	github.com/gruntwork-io/terratest v0.40.22

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/equinix-labs/fabric-go v0.4.0 h1:YM6jkdPlYJrgUEfCqt1WpXe2gACM5EavRL26
 github.com/equinix-labs/fabric-go v0.4.0/go.mod h1:/0uePNYbhu/1qWrxhD011AjU6yjf7r0sZgTCn8TyitI=
 github.com/equinix/ecx-go/v2 v2.3.0 h1:SOABrI2TP073Mx3gVoWa4qGlot1Z2hECAOY8W4nYDPU=
 github.com/equinix/ecx-go/v2 v2.3.0/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
-github.com/equinix/ne-go v1.9.0 h1:fJhHTa276pwEdLtm4Lysz3Wby7ICKrAAVTW2UxCnx5Q=
-github.com/equinix/ne-go v1.9.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
+github.com/equinix/ne-go v1.10.0 h1:hy1umXQFPi1b3z/maZ8kqLRFlD1PXD4qp0cV8rnyL8k=
+github.com/equinix/ne-go v1.10.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=
 github.com/equinix/oauth2-go v1.0.0/go.mod h1:4pulXvUNMktJlewLPnUeJyMW52iCoF1aM+A/Z5xY1ws=
 github.com/equinix/rest-go v1.3.0 h1:m38scYTOfV6N+gcrwchgVDutDffYd+QoYCMm9Jn6jyk=


### PR DESCRIPTION
In Feb release, we onboarded Arista router in our market place, but only DSA public key is accepted for this vendor. To accommodate this, a new field keyType is introduced when creating a new public key. To support backward compatibility, this new field will be marked as optional and the default value would be RSA in this case. All existing public key that we have in production is RSA key and we migrate those keys to be RSA.
More details could be found in our API documentation.
reference: https://developer.equinix.com/docs?page=/dev-docs/ne/overview