### PR TITLE
Specify full import path to the ProviderVersion constant

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X version.ProviderVersion={{.Version}} -X main.version={{.Version}} -X main.commit={{.Commit}}"
+      - -s -w -X github.com/equinix/terraform-provider-equinix/version.ProviderVersion={{.Version}}
     goos:
       - freebsd
       - windows


### PR DESCRIPTION
We have not been properly injecting the release version into the ProviderVersion constant, so we cannot see terraform provider usage by version at the moment.  This updates the goreleaser config to specify the full import path to the ProviderVersion constant so that the release version ends up where we need it.