### PR TITLE
docs: update docs to clarify that the IDs in user_ssh_key_ids are user IDs

### DIFF
--- a/docs/resources/equinix_metal_device.md
+++ b/docs/resources/equinix_metal_device.md
@@ -195,11 +195,8 @@ API auth token in the top of the page and see JSON from the API response.
 [Device plans API docs](https://metal.equinix.com/developers/api/plans), set your auth token in the
 top of the page and see JSON from the API response.
 * `project_id` - (Required) The ID of the project in which to create the device
-* `project_ssh_key_ids` - (Optional) Array of IDs of the project SSH keys which should be added to the device.
-If you omit this, SSH keys of all the members of the parent project will be added to the device. If
-you specify this array, only the listed project SSH keys will be added. Project SSH keys can be
-created with the [equinix_metal_project_ssh_key](equinix_metal_project_ssh_key.md) resource.
-* `user_ssh_key_ids` - (Optional) Array of IDs of the user SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed user SSH keys (and any project_ssh_key_ids) will be added. User SSH keys can be created with the [equinix_metal_ssh_key](equinix_metal_ssh_key.md) resource
+* `project_ssh_key_ids` - (Optional) Array of IDs of the project SSH keys which should be added to the device. If you specify this array, only the listed project SSH keys (and any SSH keys for the users specified in user_ssh_key_ids) will be added. If no SSH keys are specified (both user_ssh_keys_ids and project_ssh_key_ids are empty lists or omitted), all parent project keys, parent project members keys and organization members keys will be included.  Project SSH keys can be created with the [equinix_metal_project_ssh_key](equinix_metal_project_ssh_key.md) resource.
+* `user_ssh_key_ids` - (Optional) Array of IDs of the users whose SSH keys should be added to the device. If you specify this array, only the listed users' SSH keys (and any project SSH keys specified in project_ssh_key_ids) will be added. If no SSH keys are specified (both user_ssh_keys_ids and project_ssh_key_ids are empty lists or omitted), all parent project keys, parent project members keys and organization members keys will be included. User SSH keys can be created with the [equinix_metal_ssh_key](equinix_metal_ssh_key.md) resource.
 * `reinstall` - (Optional) Whether the device should be reinstalled instead of destroyed when
 modifying user_data, custom_data, or operating system. See [Reinstall](#reinstall) below for more
 details.

--- a/equinix/resource_metal_device.go
+++ b/equinix/resource_metal_device.go
@@ -313,14 +313,14 @@ func resourceMetalDevice() *schema.Resource {
 			},
 			"project_ssh_key_ids": {
 				Type:        schema.TypeList,
-				Description: "Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys (and any user_ssh_key_ids) will be added. Project SSH keys can be created with the [equinix_metal_project_ssh_key](equinix_metal_project_ssh_key.md) resource",
+				Description: "Array of IDs of the project SSH keys which should be added to the device. If you specify this array, only the listed project SSH keys (and any SSH keys for the users specified in user_ssh_key_ids) will be added. If no SSH keys are specified (both user_ssh_keys_ids and project_ssh_key_ids are empty lists or omitted), all parent project keys, parent project members keys and organization members keys will be included.  Project SSH keys can be created with the [equinix_metal_project_ssh_key](equinix_metal_project_ssh_key.md) resource",
 				Optional:    true,
 				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"user_ssh_key_ids": {
 				Type:        schema.TypeList,
-				Description: "Array of IDs of the user SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed user SSH keys (and any project_ssh_key_ids) will be added. User SSH keys can be created with the [equinix_metal_ssh_key](equinix_metal_ssh_key.md) resource",
+				Description: "Array of IDs of the users whose SSH keys should be added to the device. If you specify this array, only the listed users' SSH keys (and any project SSH keys specified in project_ssh_key_ids) will be added. If no SSH keys are specified (both user_ssh_keys_ids and project_ssh_key_ids are empty lists or omitted), all parent project keys, parent project members keys and organization members keys will be included. User SSH keys can be created with the [equinix_metal_ssh_key](equinix_metal_ssh_key.md) resource",
 				Optional:    true,
 				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -190,8 +190,18 @@ func TestAccMetalDevice_sshConfig(t *testing.T) {
 			{
 				Config: testAccMetalDeviceConfig_ssh_key(rs, userSSHKey, projSSHKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						r, "ssh_key_ids.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(
+						r,
+						"ssh_key_ids.*",
+						"equinix_metal_ssh_key.test",
+						"id",
+					),
+					resource.TestCheckTypeSetElemAttrPair(
+						r,
+						"ssh_key_ids.*",
+						"equinix_metal_project_ssh_key.test",
+						"id",
+					),
 				),
 			},
 		},
@@ -906,7 +916,7 @@ resource "equinix_metal_device" "test" {
 	operating_system = local.os
 	billing_cycle    = "hourly"
 	project_id       = equinix_metal_project.test.id
-	user_ssh_key_ids = [equinix_metal_ssh_key.test.id]
+	user_ssh_key_ids = [equinix_metal_ssh_key.test.owner_id]
 	project_ssh_key_ids = [equinix_metal_project_ssh_key.test.id]
 
 	lifecycle {


### PR DESCRIPTION
Our documentation incorrectly stated that the IDs in `user_ssh_key_ids` for an `equinix_metal_device` were the IDs of the SSH keys that will be supported on the device; in reality they are the IDs of the _users_ whose SSH keys will be supported.

In addition to the documentation, our tests were incorrectly attempting to pass an SSH key ID as a user ID, resulting in test failures due to errors from the API.