### PR TITLE
ci: ignore missing termination_time since API doesn't provide it

### DIFF
--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -636,9 +636,10 @@ func TestAccMetalDevice_importBasic(t *testing.T) {
 				Config: testAccMetalDeviceConfig_basic(rs),
 			},
 			{
-				ResourceName:      "equinix_metal_device.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "equinix_metal_device.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"termination_time"}, // Remove when API returns termination_time for on-demand instances
 			},
 		},
 	})


### PR DESCRIPTION
While the `termination_time` attribute is supported for on-demand instances, the API currently cannot include that attribute in responses for on-demand devices (even with an `include` parameter, the API will not return that attribute).

This updates the failing device import test to ignore the `termination_time` attribute.  When the API adds support for this attribute in responses for on-demand devices, we can update the test to once again expect the imported `termination_time` attribute to match state.