### PR TITLE
fix: suppress spot market diff when order of facilities changes

### DIFF
--- a/equinix/data_source_metal_spot_market_request.go
+++ b/equinix/data_source_metal_spot_market_request.go
@@ -1,6 +1,7 @@
 package equinix
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -96,6 +97,7 @@ func dataSourceMetalSpotMarketRequestRead(d *schema.ResourceData, meta interface
 	for _, f := range facs {
 		facCodes = append(facCodes, f.Code)
 	}
+	sort.Strings(facCodes) // avoid changes if we get the same facilities in a different order
 
 	d.SetId(id)
 

--- a/equinix/data_source_metal_spot_market_request_acc_test.go
+++ b/equinix/data_source_metal_spot_market_request_acc_test.go
@@ -28,11 +28,6 @@ func TestAccDataSourceMetalSpotMarketRequest_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:             testAccDataSourceMetalSpotMarketRequestConfig_metro(projectName),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: true,
-			},
-			{
 				Config: testAccDataSourceMetalSpotMarketRequestConfig_metro(projectName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetalSpotMarketRequestExists("equinix_metal_spot_market_request.req", &metKey),


### PR DESCRIPTION
The spot market request resource sometimes fails tests because the `facilities` come back from the API in a different order than they appear in the terraform state.  This updates the resource to sort old and new facilities before comparing them so that we only trigger changes when absolutely necessary.

In addition, this sorts the facilities attribute in the spot market request data source to protect against potential reordering there; if the `facilities` come back in a different order from one terraform run to the next, it should not impact resources that reference the data source.