### PR TITLE
fix: do not include port when checking virtual circuit status

### DIFF
--- a/equinix/resource_metal_virtual_circuit.go
+++ b/equinix/resource_metal_virtual_circuit.go
@@ -269,7 +269,7 @@ func getVCStateWaiter(client *packngo.Client, id string, timeout time.Duration, 
 			vc, _, err := client.VirtualCircuits.Get(
 				id,
 				&packngo.GetOptions{Includes: []string{
-					"project", "port", "virtual_network",
+					"project", "virtual_network",
 					"vrf",
 				}}, // TODO: we are not using the returned VC. Remove the includes?
 			)


### PR DESCRIPTION
The virtual circuit resource includes a state waiter that periodically gets the data for the virtual circuit in order to monitor for changes in its status.

The state waiter sends an `include` parameter that has both `port` and `vrf` in it.  There appears to be an interaction between these two VC properties that causes a 500 response from the API.

We don't seem to use the response from the state waiter, and the main VC read function only includes `vrf`, not `port`, so it seems like we don't actually need to include both anyway.  This removes `port` from the VC state waiter to match the request sent by VC read.