### PR TITLE
ci: use spot market price as max bid in tests

### DIFF
--- a/equinix/resource_metal_spot_market_request_acc_test.go
+++ b/equinix/resource_metal_spot_market_request_acc_test.go
@@ -93,7 +93,7 @@ data "equinix_metal_spot_market_request" "dreq" {
 
 resource "equinix_metal_spot_market_request" "request" {
   project_id       = equinix_metal_project.test.id
-  max_bid_price    = data.equinix_metal_spot_market_price.test.price * 1.2
+  max_bid_price    = format("%%.2f", data.equinix_metal_spot_market_price.test.price)
   facilities       = [data.equinix_metal_spot_market_price.test.facility]
   devices_min      = 1
   devices_max      = 1
@@ -123,7 +123,7 @@ data "equinix_metal_spot_market_price" "test" {
 
 resource "equinix_metal_spot_market_request" "request" {
   project_id       = equinix_metal_project.test.id
-  max_bid_price    = data.equinix_metal_spot_market_price.test.price * 1.2
+  max_bid_price    = data.equinix_metal_spot_market_price.test.price
   facilities       = [data.equinix_metal_spot_market_price.test.facility]
   devices_min      = 1
   devices_max      = 1


### PR DESCRIPTION
The spot market resource tests use a data source to determine the spot market price, and then attempt to create a spot market request with a bid price that is 20% higher than the spot market price.

This introduces brittleness to our tests because the bid price may be higher than the maximum allowed bid price.  This change uses the spot market price as the max bid price, rather than setting a higher bid, in an attempt to reduce the chance of test failure due to a disallowed bid price.