### PR TITLE
feat: add optional metal_base (EQUINIX_API_METAL_BASE) provider config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -112,6 +112,10 @@ services, and `auth_token` to interact with Equinix Metal.
 
 * `max_retry_wait_seconds` (Optional) Maximum time to wait in case of network failure.
 
+* `metal_base` (Optional) The Equinix Metal API base path for the API `endpoint`.
+   This argument can also be specified with the `EQUINIX_API_METAL_BASE` shell environment
+   variable. (Defaults to `/metal/v1`)
+
 These parameters can be provided in [Terraform variable
 files](https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files)
 or as environment variables. Nevertheless, please note that it is [not

--- a/equinix/config.go
+++ b/equinix/config.go
@@ -72,6 +72,7 @@ var (
 // provider.
 type Config struct {
 	BaseURL        string
+	MetalBasePath  string
 	AuthToken      string
 	ClientID       string
 	ClientSecret   string
@@ -200,7 +201,7 @@ func (c *Config) NewMetalClient() *packngo.Client {
 	retryClient.CheckRetry = MetalRetryPolicy
 	standardClient := retryClient.StandardClient()
 	baseURL, _ := url.Parse(c.BaseURL)
-	baseURL.Path = path.Join(baseURL.Path, metalBasePath) + "/"
+	baseURL.Path = path.Join(baseURL.Path, c.MetalBasePath) + "/"
 	client, _ := packngo.NewClientWithBaseURL(consumerToken, c.AuthToken, standardClient, baseURL.String())
 	client.UserAgent = c.fullUserAgent(client.UserAgent)
 	c.metalUserAgent = client.UserAgent
@@ -220,7 +221,7 @@ func (c *Config) NewMetalGoClient() *metalv1.APIClient {
 	standardClient := retryClient.StandardClient()
 
 	baseURL, _ := url.Parse(c.BaseURL)
-	baseURL.Path = path.Join(baseURL.Path, metalBasePath) + "/"
+	baseURL.Path = path.Join(baseURL.Path, c.MetalBasePath) + "/"
 
 	configuration := metalv1.NewConfiguration()
 	configuration.Servers = metalv1.ServerConfigurations{

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -27,6 +27,7 @@ var (
 
 const (
 	endpointEnvVar       = "EQUINIX_API_ENDPOINT"
+	metalBaseEnvVar      = "EQUINIX_API_METAL_BASE"
 	clientIDEnvVar       = "EQUINIX_API_CLIENTID"
 	clientSecretEnvVar   = "EQUINIX_API_CLIENTSECRET"
 	clientTokenEnvVar    = "EQUINIX_API_TOKEN"
@@ -53,6 +54,12 @@ func Provider() *schema.Provider {
 				DefaultFunc:  schema.EnvDefaultFunc(endpointEnvVar, DefaultBaseURL),
 				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
 				Description:  fmt.Sprintf("The Equinix API base URL to point out desired environment. Defaults to %s", DefaultBaseURL),
+			},
+			"metal_base": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(metalBaseEnvVar, metalBasePath),
+				Description: fmt.Sprintf("The Equinix Metal API base path for the API `endpoint`. Defaults to %s", metalBasePath),
 			},
 			"client_id": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Adds support for alternate Equinix Metal Base Path. 
This is used in Prism spec validation: https://gist.github.com/displague/27363182851f0eab4b599401f83f4b1e. 

There may not be other real-world test scenarios today outside of the use-case described. If there were a `/metal/v1{suffix}`, this could be helpful.

An alternative to this base path variable would be one that replaces the full Metal URL. This would provide ways to test against the legacy api.packet.net path structure (and other environments) for example.