### PR TITLE
NFV-25324: add schema for cloudInitFileId in secondary device data source

### DIFF
--- a/equinix/data_source_network_device.go
+++ b/equinix/data_source_network_device.go
@@ -336,6 +336,11 @@ func createDataSourceNetworkDeviceSchema() map[string]*schema.Schema {
 						Computed:    true,
 						Description: neDeviceDescriptions["LicenseFileID"],
 					},
+					neDeviceSchemaNames["CloudInitFileID"]: {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: neDeviceDescriptions["CloudInitFileID"],
+					},
 					neDeviceSchemaNames["ACLTemplateUUID"]: {
 						Type:        schema.TypeString,
 						Computed:    true,


### PR DESCRIPTION
A patch for fixing issues when customers try to fetch redundant devices details in the data source.