### PR TITLE
Typo in spot_market_request argument name: termintation->termination

### DIFF
--- a/docs/resources/equinix_metal_spot_market_request.md
+++ b/docs/resources/equinix_metal_spot_market_request.md
@@ -43,7 +43,7 @@ On resource destruction wait until devices are removed.
 * `locked` - (Optional) Blocks deletion of the SpotMarketRequest device until the lock is disabled.
 * `instance_parameters` - (Required) Key/Value pairs of parameters for devices provisioned from
 this request. Valid keys are: `billing_cycle`, `plan`, `operating_system`, `hostname`,
-`termintation_time`, `always_pxe`, `description`, `features`, `locked`, `project_ssh_keys`,
+`termination_time`, `always_pxe`, `description`, `features`, `locked`, `project_ssh_keys`,
 `user_ssh_keys`, `userdata`, `customdata`, `ipxe_script_url`, `tags`. You can find each parameter
 description in [equinix_metal_device](equinix_metal_device.md) docs.
 

--- a/equinix/resource_metal_spot_market_request.go
+++ b/equinix/resource_metal_spot_market_request.go
@@ -135,6 +135,11 @@ func resourceMetalSpotMarketRequest() *schema.Resource {
 							Required: true,
 						},
 						"termintation_time": {
+							Type:       schema.TypeString,
+							Computed:   true,
+							Deprecated: "Use instance_parameters.termination_time instead",
+						},
+						"termination_time": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -449,6 +454,7 @@ func getInstanceParams(params *packngo.SpotMarketRequestInstanceParameters) Inst
 	}}
 	if params.TerminationTime != nil {
 		p[0]["termintation_time"] = params.TerminationTime.Time
+		p[0]["termination_time"] = params.TerminationTime.Time
 	}
 	return p
 }


### PR DESCRIPTION
Fixes #253 

This PR fixes typo in spot_market_request argument name, it was supposed to be "termination" but ended up being "termintation". I added a new arg with a correct name and made the old on deprecated. We can remove it later on.

Done according to
https://developer.hashicorp.com/terraform/plugin/sdkv2/best-practices/deprecations#renaming-an-optional-attribute