### PR TITLE
chore(ci): fix SSH key test and document project name max length

### DIFF
--- a/docs/resources/equinix_metal_project.md
+++ b/docs/resources/equinix_metal_project.md
@@ -67,7 +67,7 @@ template.
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the project.
+* `name` - (Required) The name of the project.  The maximum length is 80 characters
 * `organization_id` - (Required) The UUID of organization under which you want to create the project. If you
 leave it out, the project will be created under your the default organization of your account.
 * `payment_method_id` - The UUID of payment method for this project. The payment method and the

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -827,7 +827,7 @@ resource "equinix_metal_device" "test" {
 }`, confAccMetalDevice_base(preferable_plans, preferable_metros, preferable_os), projSuffix, testDeviceTerminationTime())
 }
 
-func testAccMetalDeviceConfig_ssh_key(projSuffix, userSSSHKey, projSSHKey string) string {
+func testAccMetalDeviceConfig_ssh_key(projSuffix, userSSHKey, projSSHKey string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -856,7 +856,7 @@ resource "equinix_metal_device" "test" {
 	user_ssh_key_ids = [equinix_metal_ssh_key.test.owner_id]
 	project_ssh_key_ids = [equinix_metal_project_ssh_key.test.id]
   }
-`, confAccMetalDevice_base(preferable_plans, preferable_metros, preferable_os), projSSHKey, projSSHKey, userSSSHKey, projSSHKey, projSSHKey)
+`, confAccMetalDevice_base(preferable_plans, preferable_metros, preferable_os), projSuffix, projSuffix, userSSHKey, projSSHKey, projSSHKey)
 }
 
 func testAccMetalDeviceConfig_facility_list(projSuffix string) string {

--- a/equinix/resource_metal_project.go
+++ b/equinix/resource_metal_project.go
@@ -25,7 +25,7 @@ func resourceMetalProject() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The name of the project",
+				Description: "The name of the project.  The maximum length is 80 characters.",
 				Required:    true,
 			},
 			"created": {


### PR DESCRIPTION
At some point, the Metal API introduced validation that rejects project names longer than 80 characters.  This broke one of our device tests, which was using the public SSH key contents as the project suffix instead of a random number.

This updates the broken test to use a random number suffix for project names so that the test can pass again.  The project resource docs are also updated to mention the 80-character limit.