### PR TITLE
feat: introduce metal-go client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/antihax/optional v1.0.0
 	github.com/equinix-labs/fabric-go v0.4.0
+	github.com/equinix-labs/metal-go v0.16.0
 	github.com/equinix/ecx-go/v2 v2.3.1
 	github.com/equinix/ne-go v1.10.0
 	github.com/equinix/oauth2-go v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/equinix-labs/fabric-go v0.4.0 h1:YM6jkdPlYJrgUEfCqt1WpXe2gACM5EavRL26ocIMM9c=
 github.com/equinix-labs/fabric-go v0.4.0/go.mod h1:/0uePNYbhu/1qWrxhD011AjU6yjf7r0sZgTCn8TyitI=
+github.com/equinix-labs/metal-go v0.16.0 h1:4YmGx9SRFkDtHiEqRsSjlgJDztV6NHqH1eeaOZcK7d4=
+github.com/equinix-labs/metal-go v0.16.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
 github.com/equinix/ecx-go/v2 v2.3.1 h1:gFcAIeyaEUw7S8ebqApmT7E/S7pC7Ac3wgScp89fkPU=
 github.com/equinix/ecx-go/v2 v2.3.1/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
 github.com/equinix/ne-go v1.10.0 h1:hy1umXQFPi1b3z/maZ8kqLRFlD1PXD4qp0cV8rnyL8k=


### PR DESCRIPTION
This adds a metal-go client to the terraform provider.  The metal-go client can be gradually adopted by Metal resources and data sources in this provider to enable the eventual deprecation of packngo.

An example of using this client to interact with the Metal API can be found in #291.