### PR TITLE
Fabric Port Data Source Bug Fix

### DIFF
--- a/equinix/fabric_port_read_schema.go
+++ b/equinix/fabric_port_read_schema.go
@@ -148,7 +148,7 @@ func readPortsRedundancySch() map[string]*schema.Schema {
 			Description: "Access point redundancy",
 		},
 		"group": {
-			Type:        schema.TypeInt,
+			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "Port redundancy group",
 		},

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/go-retryablehttp v0.7.2
+	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/packethost/packngo v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.4.8 h1:CHGwpxYDOttQOY7HOWgETU9dyVjOXzniXDqJcYJE1zM=
 github.com/hashicorp/go-plugin v1.4.8/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
-github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
-github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
+github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
+github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=


### PR DESCRIPTION
The Fabric V4 API Spec was updated in version 4.4 for the /fabric/v4/ports endpoint to return the redundancy.group property as a string instead of an integer. Only recently that change was actually implemented in the backend API and is causing a data source error in the Equinix Terraform Provider for Port2Port Connections.

The Terraform Provider does type assertions on the underlying Data Response Schema during Serialization of Resources for a Hash. If the schema does not match the returned types from API it will cause the plugin to crash without a helpful error message.

This change introduces the following updates:
1. Fix the schema type for the Port API response to TypeString from TypeInt
2. Add a recovery defer method in the data source resource for Port Retrieval to allow the provider to crash smoothly with valuable error output

Schema Changes: 
Fabric OAS v4.3 (Port redundancy.group == integer)
![GetPorts_v4 3_PortRedundancyGroup_as_integer](https://github.com/equinix/terraform-provider-equinix/assets/139183873/efc0c8e2-06da-4512-b0de-e45fa6b845c2)

Fabric OAS v4.4 (Port redundancy.group == string)
![GetPorts_v4 4_PortRedundancyGroup_as_string](https://github.com/equinix/terraform-provider-equinix/assets/139183873/d139c6f9-c166-4550-a5c9-bf539a586aef)


BEFORE Provider Error Output before change:
```
thogarty ~/workspace/terraform-provider-equinix/examples/connectivity/v4/port2portself [main] $ terraform apply
data.equinix_fabric_ports.aside: Reading...
data.equinix_fabric_ports.zside: Reading...
╷
│ Error: Plugin did not respond
│ 
│   with data.equinix_fabric_ports.aside,
│   on main.tf line 6, in data "equinix_fabric_ports" "aside":
│    6: data "equinix_fabric_ports" "aside" {
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadDataSource call. The plugin logs may contain more details.
╵
╷
│ Error: Plugin did not respond
│ 
│   with data.equinix_fabric_ports.zside,
│   on main.tf line 12, in data "equinix_fabric_ports" "zside":
│   12: data "equinix_fabric_ports" "zside" {
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadDataSource call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-equinix plugin:

panic: interface conversion: interface {} is string, not int

goroutine 87 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.SerializeValueForHash(0x195cf80?, {0x191c9c0?, 0xc0002c7150?}, 0x5?)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:24 +0x2cc
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.SerializeResourceForHash(0xc000944e78?, {0x195cf80?, 0xc000822390}, 0x1071e26?)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:115 +0x2d4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.HashResource.func1({0x195cf80?, 0xc000822390?})
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:33 +0x4b
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).hash(0x100d62a?, {0x195cf80?, 0xc000822390?})
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:218 +0x2c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).add(0xc000818b40, {0x195cf80?, 0xc000822390}, 0x0)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:198 +0x96
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).Add(...)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:76
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.NewSet(0xc0002c7180, {0xc0002c7170, 0x1, 0x8?})
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:63 +0x7b
github.com/equinix/terraform-provider-equinix/equinix.portApiPortRedundancyToTerr(0x195cf80?)
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/fabric_port_mapping_helper.go:21 +0x245
github.com/equinix/terraform-provider-equinix/equinix.fabricPortsListToTerra({0xc000822240?, {0xc00094e700?, 0x0?, 0xc000945260?}})
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/fabric_port_mapping_helper.go:147 +0x525
github.com/equinix/terraform-provider-equinix/equinix.setPortsListMap(0xc000262f80?, {0xc000822240?, {0xc00094e700?, 0xc0004c5430?, 0x191c9c0?}})
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/resource_fabric_port.go:60 +0xc5
github.com/equinix/terraform-provider-equinix/equinix.resourceFabricPortGetByPortName({0x1bd7128, 0xc000801920}, 0x1176592e000?, {0x19f9de0?, 0xc00023a960})
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/resource_fabric_port.go:88 +0x3da
github.com/equinix/terraform-provider-equinix/equinix.dataSourceFabricGetPortsByNameResponseRead({0x1bd7128?, 0xc000801920?}, 0x0?, {0x19f9de0?, 0xc00023a960?})
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/data_source_fabric_port.go:33 +0x2d
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc0003fad20, {0x1bd7160, 0xc00059e930}, 0xd?, {0x19f9de0, 0xc00023a960})
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:724 +0x12e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc0003fad20, {0x1bd7160, 0xc00059e930}, 0xc000262e80, {0x19f9de0, 0xc00023a960})
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:943 +0x145
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc0003c4e70, {0x1bd7160?, 0xc00059e810?}, 0xc000527160)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/grpc_provider.go:1195 +0x38f
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadDataSource(0xc0003d01e0, {0x1bd7160?, 0xc000316ff0?}, 0xc0002018b0)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/tf5server/server.go:658 +0x403
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler({0x1a31940?, 0xc0003d01e0}, {0x1bd7160, 0xc000316ff0}, 0xc000654d20, 0x0)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:421 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000365a0, {0x1bdb418, 0xc0001029c0}, 0xc000804120, 0xc0005aeb10, 0x21542d0, 0x0)
	/Users/thogarty/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:1340 +0xd33
google.golang.org/grpc.(*Server).handleStream(0xc0000365a0, {0x1bdb418, 0xc0001029c0}, 0xc000804120, 0x0)
	/Users/thogarty/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:1713 +0xa36
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/Users/thogarty/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:965 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/thogarty/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:963 +0x28a

Error: The terraform-provider-equinix plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

AFTER Provider Error Output after change without TF_LOG=DEBUG:
```
thogarty ~/workspace/terraform-provider-equinix/examples/connectivity/v4/port2portself [thogarty_port_data_source_bug_fix] $ terraform apply
data.equinix_fabric_ports.aside: Reading...
data.equinix_fabric_ports.zside: Reading...
╷
│ Error: 
│ 				there is a schema error in the return value from the GET /fabric/v4/ports endpoint.
│ 				Set the following env variable TF_LOG=DEBUG and rerun the apply.
│ 				Capture the log output and open an issue in the Github for the Equinix Terraform Provider.
│ 				We will review and correct as soon as possible.
│ 				Thank you!
│ 			
│ 
│   with data.equinix_fabric_ports.aside,
│   on main.tf line 6, in data "equinix_fabric_ports" "aside":
│    6: data "equinix_fabric_ports" "aside" {
│ 
╵
╷
│ Error: 
│ 				there is a schema error in the return value from the GET /fabric/v4/ports endpoint.
│ 				Set the following env variable TF_LOG=DEBUG and rerun the apply.
│ 				Capture the log output and open an issue in the Github for the Equinix Terraform Provider.
│ 				We will review and correct as soon as possible.
│ 				Thank you!
│ 			
│ 
│   with data.equinix_fabric_ports.zside,
│   on main.tf line 12, in data "equinix_fabric_ports" "zside":
│   12: data "equinix_fabric_ports" "zside" {
```

AFTER Provider Error Output after change with TF_LOG=DEBUG:
```
2023-08-11T16:15:34.916-0700 [INFO]  provider.terraform-provider-equinix: 2023/08/11 16:15:34 [ERROR] Panic occurred during GET /fabric/v4/ports: interface conversion: interface {} is string, not int: timestamp=2023-08-11T16:15:34.916-0700
2023-08-11T16:15:34.917-0700 [INFO]  provider.terraform-provider-equinix: 2023/08/11 16:15:34 [ERROR] Stack Trace from Panic: goroutine 69 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
github.com/equinix/terraform-provider-equinix/equinix.resourceFabricPortGetByPortName.func1()
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/resource_fabric_port.go:74 +0x6a
panic({0x196f2c0, 0xc0007b8120})
	/usr/local/go/src/runtime/panic.go:884 +0x213
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.SerializeValueForHash(0x195d240?, {0x191cc80?, 0xc0002f41d0?}, 0x5?)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:24 +0x2cc
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.SerializeResourceForHash(0xc0000b6e40?, {0x195d240?, 0xc00078ffb0}, 0x1071e26?)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:115 +0x2d4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.HashResource.func1({0x195d240?, 0xc00078ffb0?})
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:33 +0x4b
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).hash(0x100d62a?, {0x195d240?, 0xc00078ffb0?})
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:218 +0x2c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).add(0xc0005a4ac0, {0x195d240?, 0xc00078ffb0}, 0x0)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:198 +0x96
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).Add(...)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:76
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.NewSet(0xc0002f4200, {0xc0002f41f0, 0x1, 0x8?})
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:63 +0x7b
github.com/equinix/terraform-provider-equinix/equinix.portApiPortRedundancyToTerr(0x195d240?)
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/fabric_port_mapping_helper.go:21 +0x245
github.com/equinix/terraform-provider-equinix/equinix.fabricPortsListToTerra({0xc00078fe60?, {0xc000281500?, 0x0?, 0xc0000b7228?}})
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/fabric_port_mapping_helper.go:147 +0x525
github.com/equinix/terraform-provider-equinix/equinix.setPortsListMap(0xc0005a9c00?, {0xc00078fe60?, {0xc000281500?, 0xc0000b7410?, 0x191cc80?}})
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/resource_fabric_port.go:62 +0xc5
github.com/equinix/terraform-provider-equinix/equinix.resourceFabricPortGetByPortName({0x1bd7608, 0xc0007ab770}, 0x1176592e000?, {0x19fa0a0?, 0xc000228960})
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/resource_fabric_port.go:104 +0x4b9
github.com/equinix/terraform-provider-equinix/equinix.dataSourceFabricGetPortsByNameResponseRead({0x1bd7608?, 0xc0007ab770?}, 0x0?, {0x19fa0a0?, 0xc000228960?})
	/Users/thogarty/workspace/terraform-provider-equinix/equinix/data_source_fabric_port.go:33 +0x2d
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc0003ead20, {0x1bd7640, 0xc000305bf0}, 0xd?, {0x19fa0a0, 0xc000228960})
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:724 +0x12e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc0003ead20, {0x1bd7640, 0xc000305bf0}, 0xc0005a9b00, {0x19fa0a0, 0xc000228960})
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:943 +0x145
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc0003b4e70, {0x1bd7640?, 0xc000305ad0?}, 0xc0007d0fc0)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/grpc_provider.go:1195 +0x38f
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadDataSource(0xc0004385a0, {0x1bd7640?, 0xc000305320?}, 0xc00057a190)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/tf5server/server.go:658 +0x403
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler({0x1a31c00?, 0xc0004385a0}, {0x1bd7640, 0xc000305320}, 0xc0005652d0, 0x0)
	/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:421 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00022e1e0, {0x1bdb8f8, 0xc00008a9c0}, 0xc0001b4fc0, 0xc00042e900, 0x21552d0, 0x0)
	/Users/thogarty/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:1340 +0xd33
google.golang.org/grpc.(*Server).handleStream(0xc00022e1e0, {0x1bdb8f8, 0xc00008a9c0}, 0xc0001b4fc0, 0x0)
	/Users/thogarty/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:1713 +0xa36
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/Users/thogarty/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:965 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/thogarty/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:963 +0x28a: timestamp=2023-08-11T16:15:34.917-0700
2023-08-11T16:15:34.917-0700 [ERROR] provider.terraform-provider-equinix: Response contains error diagnostic: diagnostic_severity=ERROR tf_proto_version=5.3 tf_req_id=eec9e592-fd4b-395b-e07b-607b4e723837 tf_rpc=ReadDataSource @module=sdk.proto diagnostic_detail= diagnostic_summary="
				there is a schema error in the return value from the GET /fabric/v4/ports endpoint.
				Set the following env variable TF_LOG=DEBUG and rerun the apply.
				Capture the log output and open an issue in the Github for the Equinix Terraform Provider.
				We will review and correct as soon as possible.
				Thank you!
			" tf_data_source_type=equinix_fabric_ports tf_provider_addr=provider @caller=/Users/thogarty/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/internal/diag/diagnostics.go:55 timestamp=2023-08-11T16:15:34.917-0700
2023-08-11T16:15:34.918-0700 [ERROR] vertex "data.equinix_fabric_ports.zside" error: 
				there is a schema error in the return value from the GET /fabric/v4/ports endpoint.
				Set the following env variable TF_LOG=DEBUG and rerun the apply.
				Capture the log output and open an issue in the Github for the Equinix Terraform Provider.
				We will review and correct as soon as possible.
				Thank you!
2023-08-11T16:15:34.918-0700 [ERROR] vertex "data.equinix_fabric_ports.zside (expand)" error: 
				there is a schema error in the return value from the GET /fabric/v4/ports endpoint.
				Set the following env variable TF_LOG=DEBUG and rerun the apply.
				Capture the log output and open an issue in the Github for the Equinix Terraform Provider.
				We will review and correct as soon as possible.
				Thank you!
╷
│ Error: 
│ 				there is a schema error in the return value from the GET /fabric/v4/ports endpoint.
│ 				Set the following env variable TF_LOG=DEBUG and rerun the apply.
│ 				Capture the log output and open an issue in the Github for the Equinix Terraform Provider.
│ 				We will review and correct as soon as possible.
│ 				Thank you!
│ 			
│ 
│   with data.equinix_fabric_ports.aside,
│   on main.tf line 6, in data "equinix_fabric_ports" "aside":
│    6: data "equinix_fabric_ports" "aside" {
│ 
╵
╷
│ Error: 
│ 				there is a schema error in the return value from the GET /fabric/v4/ports endpoint.
│ 				Set the following env variable TF_LOG=DEBUG and rerun the apply.
│ 				Capture the log output and open an issue in the Github for the Equinix Terraform Provider.
│ 				We will review and correct as soon as possible.
│ 				Thank you!
│ 			
│ 
│   with data.equinix_fabric_ports.zside,
│   on main.tf line 12, in data "equinix_fabric_ports" "zside":
│   12: data "equinix_fabric_ports" "zside" {
│ 
╵
2023-08-11T16:15:34.925-0700 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2023-08-11T16:15:34.932-0700 [DEBUG] provider: plugin process exited: path=.terraform/providers/developer.equinix.com/terraform/equinix/9.0.0/darwin_arm64/terraform-provider-equinix pid=54048
2023-08-11T16:15:34.932-0700 [DEBUG] provider: plugin exited
```
