### PR TITLE
Upgrade metal device resource and data source to use timeouts

### DIFF
--- a/equinix/data_source_metal_device.go
+++ b/equinix/data_source_metal_device.go
@@ -1,6 +1,7 @@
 package equinix
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -14,7 +15,7 @@ import (
 
 func dataSourceMetalDevice() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalDeviceRead,
+		ReadWithoutTimeout: diagnosticsWrapper(dataSourceMetalDeviceRead),
 		Schema: map[string]*schema.Schema{
 			"hostname": {
 				Type:          schema.TypeString,
@@ -201,7 +202,7 @@ func dataSourceMetalDevice() *schema.Resource {
 	}
 }
 
-func dataSourceMetalDeviceRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Config).metal
 
 	hostnameRaw, hostnameOK := d.GetOk("hostname")

--- a/equinix/helpers_device_test.go
+++ b/equinix/helpers_device_test.go
@@ -1,6 +1,7 @@
 package equinix
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -149,7 +150,7 @@ func Test_waitUntilReservationProvisionable(t *testing.T) {
 	// timeout * number of tests that reach timeout must be less than 30s (default go test timeout).
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := waitUntilReservationProvisionable(tt.args.meta, tt.args.reservationId, tt.args.instanceId, 50*time.Millisecond, 1*time.Second, 50*time.Millisecond); (err != nil) != tt.wantErr {
+			if err := waitUntilReservationProvisionable(context.Background(), tt.args.meta, tt.args.reservationId, tt.args.instanceId, 50*time.Millisecond, 1*time.Second, 50*time.Millisecond); (err != nil) != tt.wantErr {
 				t.Errorf("waitUntilReservationProvisionable() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -448,3 +448,13 @@ func schemaSetToMap(set *schema.Set) map[int]interface{} {
 	}
 	return transformed
 }
+
+func diagnosticsWrapper(fn func(ctx context.Context, d *schema.ResourceData, meta interface{}) error) func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		if err := fn(ctx, d, meta); err != nil {
+			return diag.FromErr(err)
+		}
+
+		return nil
+	}
+}

--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -18,9 +18,10 @@ import (
 )
 
 var (
-	testAccProviders      map[string]*schema.Provider
-	testAccProvider       *schema.Provider
-	testExternalProviders map[string]resource.ExternalProvider
+	testAccProviders         map[string]*schema.Provider
+	testAccProviderFactories map[string]func() (*schema.Provider, error)
+	testAccProvider          *schema.Provider
+	testExternalProviders    map[string]resource.ExternalProvider
 )
 
 type mockedResourceDataProvider struct {
@@ -126,6 +127,11 @@ func init() {
 	testAccProvider = Provider()
 	testAccProviders = map[string]*schema.Provider{
 		"equinix": testAccProvider,
+	}
+	testAccProviderFactories = map[string]func() (*schema.Provider, error){
+		"equinix": func() (*schema.Provider, error) {
+			return testAccProvider, nil
+		},
 	}
 	testExternalProviders = map[string]resource.ExternalProvider{
 		"random": {

--- a/equinix/resource_metal_device.go
+++ b/equinix/resource_metal_device.go
@@ -597,7 +597,7 @@ func resourceMetalDeviceCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(newDevice.ID)
 
-	createTimeout := d.Timeout(schema.TimeoutCreate) - time.Minute - time.Since(start)
+	createTimeout := d.Timeout(schema.TimeoutCreate) - 30*time.Second - time.Since(start)
 	if err = waitForActiveDevice(ctx, d, meta, createTimeout); err != nil {
 		return err
 	}
@@ -806,7 +806,7 @@ func doReinstall(ctx context.Context, client *packngo.Client, d *schema.Resource
 			return friendlyError(err)
 		}
 
-		deleteTimeout := d.Timeout(schema.TimeoutUpdate) - time.Minute - time.Since(start)
+		deleteTimeout := d.Timeout(schema.TimeoutUpdate) - 30*time.Second - time.Since(start)
 		if err := waitForActiveDevice(ctx, d, meta, deleteTimeout); err != nil {
 			return err
 		}
@@ -837,7 +837,7 @@ func resourceMetalDeviceDelete(ctx context.Context, d *schema.ResourceData, meta
 		wfrd, wfrdOK := d.GetOk("wait_for_reservation_deprovision")
 		if wfrdOK && wfrd.(bool) {
 			// avoid "context: deadline exceeded"
-			timeout := d.Timeout(schema.TimeoutDelete) - time.Minute - time.Since(start)
+			timeout := d.Timeout(schema.TimeoutDelete) - 30*time.Second - time.Since(start)
 
 			err := waitUntilReservationProvisionable(ctx, client, resId.(string), d.Id(), 10*time.Second, timeout, 3*time.Second)
 			if err != nil {

--- a/equinix/resource_metal_device.go
+++ b/equinix/resource_metal_device.go
@@ -806,8 +806,8 @@ func doReinstall(ctx context.Context, client *packngo.Client, d *schema.Resource
 			return friendlyError(err)
 		}
 
-		deleteTimeout := d.Timeout(schema.TimeoutUpdate) - 30*time.Second - time.Since(start)
-		if err := waitForActiveDevice(ctx, d, meta, deleteTimeout); err != nil {
+		updateTimeout := d.Timeout(schema.TimeoutUpdate) - 30*time.Second - time.Since(start)
+		if err := waitForActiveDevice(ctx, d, meta, updateTimeout); err != nil {
 			return err
 		}
 	}

--- a/equinix/resource_network_bgp_test.go
+++ b/equinix/resource_network_bgp_test.go
@@ -2,6 +2,7 @@ package equinix
 
 import (
 	"context"
+	"github.com/packethost/packngo"
 	"testing"
 	"time"
 
@@ -98,6 +99,20 @@ func (r *mockedBGPUpdateRequest) WithAuthenticationKey(v string) ne.BGPUpdateReq
 
 func (r *mockedBGPUpdateRequest) Execute() error {
 	return nil
+}
+
+var _ packngo.BGPConfigService = &mockBgpConfigService{}
+
+type mockBgpConfigService struct {
+	GetFn    func(projectID string, getOpt *packngo.GetOptions) (*packngo.BGPConfig, *packngo.Response, error)
+	CreateFn func(projectID string, request packngo.CreateBGPConfigRequest) (*packngo.Response, error)
+}
+
+func (s *mockBgpConfigService) Get(projectID string, getOpt *packngo.GetOptions) (*packngo.BGPConfig, *packngo.Response, error) {
+	return s.GetFn(projectID, getOpt)
+}
+func (s *mockBgpConfigService) Create(projectID string, request packngo.CreateBGPConfigRequest) (*packngo.Response, error) {
+	return s.CreateFn(projectID, request)
 }
 
 func TestNetworkBGP_createUpdateRequest(t *testing.T) {

--- a/equinix/resource_network_bgp_test.go
+++ b/equinix/resource_network_bgp_test.go
@@ -2,7 +2,6 @@ package equinix
 
 import (
 	"context"
-	"github.com/packethost/packngo"
 	"testing"
 	"time"
 
@@ -99,20 +98,6 @@ func (r *mockedBGPUpdateRequest) WithAuthenticationKey(v string) ne.BGPUpdateReq
 
 func (r *mockedBGPUpdateRequest) Execute() error {
 	return nil
-}
-
-var _ packngo.BGPConfigService = &mockBgpConfigService{}
-
-type mockBgpConfigService struct {
-	GetFn    func(projectID string, getOpt *packngo.GetOptions) (*packngo.BGPConfig, *packngo.Response, error)
-	CreateFn func(projectID string, request packngo.CreateBGPConfigRequest) (*packngo.Response, error)
-}
-
-func (s *mockBgpConfigService) Get(projectID string, getOpt *packngo.GetOptions) (*packngo.BGPConfig, *packngo.Response, error) {
-	return s.GetFn(projectID, getOpt)
-}
-func (s *mockBgpConfigService) Create(projectID string, request packngo.CreateBGPConfigRequest) (*packngo.Response, error) {
-	return s.CreateFn(projectID, request)
 }
 
 func TestNetworkBGP_createUpdateRequest(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/equinix/oauth2-go v1.0.0
 	github.com/equinix/rest-go v1.3.0
 	github.com/gruntwork-io/terratest v0.43.0
-	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.4
@@ -48,6 +47,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.11.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter v1.7.1 // indirect


### PR DESCRIPTION
Provides support for timeouts in Create, Update and Delete for Metal Device as already mentioned in the documents
#357 