### PR TITLE
Add Fabric Cloud Router connections(AWS and GCP)

### DIFF
--- a/examples/fabric-cloud-router/fcr/terraform.tf
+++ b/examples/fabric-cloud-router/fcr/terraform.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     equinix = {
-      source="developer.equinix.com/terraform/equinix"
-      version = "9.0.0"
+      source = "equinix/equinix"
     }
   }
 }

--- a/examples/fabric-cloud-router/fcr2aws/README.md
+++ b/examples/fabric-cloud-router/fcr2aws/README.md
@@ -1,0 +1,38 @@
+# ECX Fabric Layer2 Connection between two own ports
+
+This example shows how create layer 2 connection between two, own ECX Fabric ports.
+
+## Adjust variables
+At minimum, you must set below variables in `terraform.tfvars` file:
+
+* `equinix_client_id` - Equinix client ID (consumer key), obtained after
+  registering app in the developer platform
+* `equinix_client_secret` - Equinix client secret ID (consumer secret),
+  obtained same way as above
+
+`aside_port_name` - Name of ECX Fabric a-side port i.e. ops-user100-CX-SV5-NL-Qinq-STD-1G-SEC-JP-111
+`zside_port_name` -  Name of ECX Fabric z-side port , i.e. ops-user100-CX-SV5-NL-Qinq-BO-10G-SEC-JP-000
+
+`connection_name` - the name of the connection
+`connection_type` - connection type, please refer schema
+`notifications_type` - notification type
+`notifications_emails` - List of emails
+`bandwidth` - bandwidth in MBs
+`redundancy` - Port redundancy
+`aside_ap_type` - Access point type
+`aside_port_uuid` - Port uuid, fetched based on port call using Port resource
+`aside_link_protocol_type` - link protocol type
+`aside_link_protocol_stag` - a-side s tag number
+`zside_ap_type` - Z side access point type
+`aside_link_protocol_stag` - z-side s tag number
+`zside_location` - Seller location
+
+## Initialize
+
+Change directory to project root to run terra test or change to example directory and initialize Terraform plugins
+by running `terraform init`.
+
+## Deploy template
+
+Apply changes by running `terraform apply`, then **inspect proposed plan**
+and approve it.

--- a/examples/fabric-cloud-router/fcr2aws/main.tf
+++ b/examples/fabric-cloud-router/fcr2aws/main.tf
@@ -1,0 +1,54 @@
+provider "equinix" {
+  client_id     = var.equinix_client_id
+  client_secret = var.equinix_client_secret
+}
+data "equinix_fabric_service_profiles" "aws" {
+  filter {
+    property = "/name"
+    operator = "="
+    values = [var.fabric_sp_name]
+  }
+}
+
+
+resource "equinix_fabric_connection" "fcr2aws"{
+  name = var.connection_name
+  type = var.connection_type
+  notifications{
+    type=var.notifications_type
+    emails=var.notifications_emails
+  }
+  bandwidth = var.bandwidth
+  redundancy {priority= var.redundancy}
+
+  order {
+    purchase_order_number= var.purchase_order_number
+  }
+  a_side {
+    access_point {
+      type= var.aside_ap_type
+      router {
+        uuid= var.fcr_uuid
+      }
+    }
+  }
+  z_side {
+    access_point {
+      type= var.zside_ap_type
+      authentication_key= var.zside_ap_authentication_key
+      seller_region = var.seller_region
+      profile {
+        type= var.zside_ap_profile_type
+        uuid= data.equinix_fabric_service_profiles.aws.data.0.uuid
+      }
+      location {
+        metro_code= var.zside_location
+      }
+    }
+  }
+}
+
+output "connection_result" {
+  value = equinix_fabric_connection.fcr2aws.id
+}
+

--- a/examples/fabric-cloud-router/fcr2aws/terraform.tf
+++ b/examples/fabric-cloud-router/fcr2aws/terraform.tf
@@ -3,6 +3,6 @@ terraform {
     equinix = {
       source = "developer.equinix.com/terraform/equinix"
       version = "9.0.0"
-     }
+    }
   }
 }

--- a/examples/fabric-cloud-router/fcr2aws/terraform.tf
+++ b/examples/fabric-cloud-router/fcr2aws/terraform.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     equinix = {
-      source = "developer.equinix.com/terraform/equinix"
-      version = "9.0.0"
+      source = "equinix/equinix"
     }
   }
 }

--- a/examples/fabric-cloud-router/fcr2aws/terraform.tfvars
+++ b/examples/fabric-cloud-router/fcr2aws/terraform.tfvars
@@ -1,0 +1,19 @@
+equinix_client_id      = ""
+equinix_client_secret  = ""
+
+notifications_type = "ALL"
+notifications_emails = ["example@equinix.com","test1@equinix.com"]
+purchase_order_number = "1-323292"
+fcr_uuid = "3d8ec863-06b4-4887-9feb-ccacb82923d5"
+connection_name = "terra_fcr2aws-2"
+connection_type = "IP_VC"
+bandwidth = 50
+redundancy = "SECONDARY"
+aside_ap_type = "CLOUD_ROUTER"
+
+zside_ap_type = "SP"
+zside_ap_authentication_key = ""
+zside_ap_profile_type = "L2_PROFILE"
+zside_location = "SV"
+seller_region = "us-west-1"
+fabric_sp_name = "AWS Direct Connect"

--- a/examples/fabric-cloud-router/fcr2aws/variables.tf
+++ b/examples/fabric-cloud-router/fcr2aws/variables.tf
@@ -1,0 +1,21 @@
+variable "equinix_client_id" {}
+variable "equinix_client_secret" {}
+
+variable "fcr_uuid" {}
+variable "notifications_type" {}
+variable "notifications_emails" {}
+variable "purchase_order_number" {}
+
+variable "connection_name" {}
+variable "connection_type" {}
+variable "bandwidth" {}
+variable "redundancy" {}
+
+variable "aside_ap_type" {}
+variable "zside_ap_type" {}
+variable "zside_ap_authentication_key" {}
+
+variable "zside_ap_profile_type" {}
+variable "fabric_sp_name" {}
+variable "zside_location" {}
+variable "seller_region" {}

--- a/examples/fabric-cloud-router/fcr2gcp/README.md
+++ b/examples/fabric-cloud-router/fcr2gcp/README.md
@@ -1,6 +1,6 @@
-# ECX Fabric Layer2 Connection from fabric cloud router to AWS
+# ECX Fabric Layer2 Connection from fabric cloud router to google
 
-This example shows how create connection from Fabric Cloud Router to AWS, on ECX Fabric ports.
+This example shows how create connection from Fabric Cloud Router to google, on ECX Fabric ports.
 
 ## Adjust variables
 At minimum, you must set below variables in `terraform.tfvars` file:
@@ -20,21 +20,16 @@ At minimum, you must set below variables in `terraform.tfvars` file:
 `redundancy` - Port redundancy
 `aside_ap_type` - Fabric Cloud Router type
 `zside_ap_type` - Z side access point type
-`zside_ap_authentication_key` - AWS authorization key, account number like 357848912121
+`zside_ap_authentication_key` - Google authorization key following a pattern, like **9da09fe8-a33b-4457-ab7d-d91f83152276/us-west1/1**
 `zside_ap_profile_type` - Service profile type
-`fabric_sp_name` - Service profile name, fetched based on Service Profile get call using Service Profile search schema
 `zside_location` - Seller location
 `seller_region` - Seller region code
-
-## AWS login
-
-Log in to AWS portal use account that has permission to create necessary resources.
 
 ## Initialize
 - First step is to initialize the terraform directory/resource we are going to work on.
   In the given example, the folder to perform CRUD operations on a fcr2port connection can be found at examples/fcr2port/.
 
-- Change directory into - `CD fcr2aws/`
+- Change directory into - `CD fcr2gcp/`
 - Initialize Terraform plugins - `terraform init`
 
 ## Fabric Cloud Router to port connection : Create, Read, Update and Delete(CRUD) operations

--- a/examples/fabric-cloud-router/fcr2gcp/main.tf
+++ b/examples/fabric-cloud-router/fcr2gcp/main.tf
@@ -1,0 +1,56 @@
+provider "equinix" {
+  client_id     = var.equinix_client_id
+  client_secret = var.equinix_client_secret
+}
+
+data "equinix_fabric_service_profiles" "gcp" {
+  filter {
+    property = "/name"
+    operator = "="
+    values = [var.fabric_sp_name]
+  }
+}
+
+resource "equinix_fabric_connection" "fcr2gcp"{
+  name = var.connection_name
+  type = var.connection_type
+  notifications{
+    type=var.notifications_type
+    emails=var.notifications_emails
+  }
+  bandwidth = var.bandwidth
+  redundancy {priority= var.redundancy}
+
+  order {
+    purchase_order_number= var.purchase_order_number
+  }
+  a_side {
+    access_point {
+      type= var.aside_ap_type
+      router {
+        uuid= var.fcr_uuid
+      }
+    }
+  }
+
+    z_side {
+      access_point {
+        type = var.zside_ap_type
+        authentication_key = var.zside_ap_authentication_key
+        seller_region = var.zside_seller_region
+        profile {
+          type = var.zside_ap_profile_type
+          uuid = data.equinix_fabric_service_profiles.gcp.data.0.uuid
+        }
+        location {
+          metro_code = var.zside_location
+        }
+      }
+    }
+
+}
+
+output "connection_result" {
+  value = equinix_fabric_connection.fcr2gcp.id
+}
+

--- a/examples/fabric-cloud-router/fcr2gcp/terraform.tf
+++ b/examples/fabric-cloud-router/fcr2gcp/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    equinix = {
+      source = "developer.equinix.com/terraform/equinix"
+      version = "9.0.0"
+    }
+  }
+}

--- a/examples/fabric-cloud-router/fcr2gcp/terraform.tfvars
+++ b/examples/fabric-cloud-router/fcr2gcp/terraform.tfvars
@@ -1,0 +1,19 @@
+equinix_client_id      = ""
+equinix_client_secret  = ""
+
+notifications_type = "ALL"
+notifications_emails = ["example@equinix.com","test1@equinix.com"]
+purchase_order_number = "1-323292"
+fcr_uuid = "3d8ec863-06b4-4887-9feb-ccacb82923d5"
+connection_name = "conn-terra_gcp2"
+connection_type = "IP_VC"
+bandwidth = 50
+redundancy = "SECONDARY"
+aside_ap_type = "CLOUD_ROUTER"
+
+zside_ap_type = "SP"
+zside_ap_authentication_key = "<gcp-key>/us-west1/2"
+zside_ap_profile_type = "L2_PROFILE"
+zside_location = "SV"
+zside_seller_region="us-west1"
+fabric_sp_name = "Google Cloud Partner Interconnect Zone 1"

--- a/examples/fabric-cloud-router/fcr2gcp/variables.tf
+++ b/examples/fabric-cloud-router/fcr2gcp/variables.tf
@@ -1,0 +1,21 @@
+variable "equinix_client_id" {}
+variable "equinix_client_secret" {}
+
+variable "fcr_uuid" {}
+variable "notifications_type" {}
+variable "notifications_emails" {}
+variable "purchase_order_number" {}
+
+variable "connection_name" {}
+variable "connection_type" {}
+variable "bandwidth" {}
+variable "redundancy" {}
+
+variable "aside_ap_type" {}
+variable "zside_ap_type" {}
+variable "zside_ap_authentication_key" {}
+
+variable "zside_ap_profile_type" {}
+variable "fabric_sp_name" {}
+variable "zside_location" {}
+variable "zside_seller_region" {}

--- a/examples/fabric-cloud-router/fcr2port/terraform.tf
+++ b/examples/fabric-cloud-router/fcr2port/terraform.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     equinix = {
-      source="developer.equinix.com/terraform/equinix"
-      version = "9.0.0"
+      source = "equinix/equinix"
     }
   }
 }

--- a/examples/fabric-cloud-router/routing-protocol-bgp/README.md
+++ b/examples/fabric-cloud-router/routing-protocol-bgp/README.md
@@ -1,5 +1,5 @@
 # ECX Fabric Cloud Router Connection BGP CRUD operations
-This example shows how to create Config BGP on FG connection .
+This example shows how to create Config BGP on FCR connection .
 
 Note: Each time you need to create a BGP resource add-on
 make a copy of the base folder - examples/routing-protocol-bgp/ and CD into this folder to perform all the CRUD operations.
@@ -14,7 +14,7 @@ At minimum, you must set below variables in `terraform.tfvars` file:
 - `rp_type`- Type of routing Protocol entity, "BGP"
 - connection_uuid = "d557cb4c-9052-4298-b5ca-8a9ed914cf03"
   rp_type = "DIRECT"
-  rp_name = "FG-RP"
+  rp_name = "FCR-RP"
   customer_peer_ipv4 = "192.1.1.2"
   customer_peer_ipv6 = "192::1:2"
   customer_asn = "100"
@@ -29,9 +29,9 @@ At minimum, you must set below variables in `terraform.tfvars` file:
 ## Routing-protocol BGP : Create, Read, Update and Delete(CRUD) operations
 Note: `–auto-approve` command does not prompt the user for validating the applying config. Remove it to get a prompt to confirm the operation.
 
-| Operation |              Command              |                                                               Description |
-|:----------|:---------------------------------:|--------------------------------------------------------------------------:|
-| CREATE    |  `terraform apply –auto-approve`  |                                                    Creates an FG resource |
-| READ      |         `terraform show`          |                          Reads/Shows the current state of the FG resource |
-| UPDATE    |    `terraform apply -refresh`     | Updates the FG resource with values provided in the terraform.tfvars file |
-| DELETE    | `terraform destroy –auto-approve` |                                           Deletes the created FG resource |
+| Operation |              Command              |                                                                Description |
+|:----------|:---------------------------------:|---------------------------------------------------------------------------:|
+| CREATE    |  `terraform apply –auto-approve`  |                                                    Creates an FCR resource |
+| READ      |         `terraform show`          |                          Reads/Shows the current state of the FCR resource |
+| UPDATE    |    `terraform apply -refresh`     | Updates the FCR resource with values provided in the terraform.tfvars file |
+| DELETE    | `terraform destroy –auto-approve` |                                           Deletes the created FCR resource |

--- a/examples/fabric-cloud-router/routing-protocol-direct/README.md
+++ b/examples/fabric-cloud-router/routing-protocol-direct/README.md
@@ -1,5 +1,5 @@
 # ECX Fabric Cloud Router Connection RP CRUD operations
-This example shows how to create Config Direct RP on FG connection .
+This example shows how to create Config Direct RP on FCR connection .
 
 Note: Each time you need to create a RP resource add-on
 make a copy of the base folder - examples/routing-protocol-direct/ and CD into this folder to perform all the CRUD operations.
@@ -14,7 +14,7 @@ At minimum, you must set below variables in `terraform.tfvars` file:
 - `rp_type`- Type of routing Protocol entity, "DIRECT" or "BGP"
 - connection_uuid = "d557cb4c-9052-4298-b5ca-8a9ed914cf03"
   rp_type = "DIRECT"
-  rp_name = "FG-RP"
+  rp_name = "FCR-RP"
   equinix_ipv4_ip = "192.1.1.1/30"
   equinix_ipv6_ip = "192::1:1/126"
 
@@ -29,9 +29,9 @@ At minimum, you must set below variables in `terraform.tfvars` file:
 ## Routing-protocol Direct IP : Create, Read, Update and Delete(CRUD) operations
 Note: `–auto-approve` command does not prompt the user for validating the applying config. Remove it to get a prompt to confirm the operation.
 
-| Operation |              Command              |                                                               Description |
-|:----------|:---------------------------------:|--------------------------------------------------------------------------:|
-| CREATE    |  `terraform apply –auto-approve`  |                                                    Creates an FG resource |
-| READ      |         `terraform show`          |                          Reads/Shows the current state of the FG resource |
-| UPDATE    |    `terraform apply -refresh`     | Updates the FG resource with values provided in the terraform.tfvars file |
-| DELETE    | `terraform destroy –auto-approve` |                                           Deletes the created FG resource |
+| Operation |              Command              |                                                                Description |
+|:----------|:---------------------------------:|---------------------------------------------------------------------------:|
+| CREATE    |  `terraform apply –auto-approve`  |                                                    Creates an FCR resource |
+| READ      |         `terraform show`          |                          Reads/Shows the current state of the FCR resource |
+| UPDATE    |    `terraform apply -refresh`     | Updates the FCR resource with values provided in the terraform.tfvars file |
+| DELETE    | `terraform destroy –auto-approve` |                                           Deletes the created FCR resource |

--- a/examples/fabric-cloud-router/routing-protocol-direct/terraform.tf
+++ b/examples/fabric-cloud-router/routing-protocol-direct/terraform.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     equinix = {
-      source = "developer.equinix.com/terraform/equinix"
-      version = "9.0.0"
-     }
+      source = "equinix/equinix"
+    }
   }
 }

--- a/examples/fabric-cloud-router/routing-protocol-direct/terraform.tfvars
+++ b/examples/fabric-cloud-router/routing-protocol-direct/terraform.tfvars
@@ -1,8 +1,8 @@
-equinix_client_id      = "MyEquinixClientId"
-equinix_client_secret  = "MyEquinixSecret"
+equinix_client_id      = ""
+equinix_client_secret  = ""
 
-connection_uuid = "bfa41c64-3720-4cef-88dd-ec795ba36800"
+connection_uuid = "72395965-f991-47b5-975d-9ec2bb981f18"
 rp_type = "DIRECT"
-rp_name = "FG-Con-IP"
+rp_name = "fcr-Con-IP"
 equinix_ipv4_ip = "190.1.1.1/30"
 equinix_ipv6_ip = "190::1:1/126"

--- a/tests/connection_e2e_fcr2aws_test.go
+++ b/tests/connection_e2e_fcr2aws_test.go
@@ -7,15 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCloudRouter2PortCreateConnection(t *testing.T) {
+func TestCloudRouter2AwsCreateConnection(t *testing.T) {
 	// retryable errors in terraform testing.
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "../examples/fg2port",
+		TerraformDir: "../examples/fabric-cloud-router/fg2aws",
 	})
 
 	defer terraform.Destroy(t, terraformOptions)
 
 	terraform.InitAndApply(t, terraformOptions)
-	output := terraform.Output(t, terraformOptions, "connection_result")
+	output := terraform.Output(t, terraformOptions, "fg2aws_connection_result")
 	assert.NotNil(t, output)
 }

--- a/tests/connection_e2e_fcr2gcp_test.go
+++ b/tests/connection_e2e_fcr2gcp_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudRouter2GcpCreateConnection(t *testing.T) {
+	// retryable errors in terraform testing.
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/fabric-cloud-router/fcr2gcp",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+	output := terraform.Output(t, terraformOptions, "fcr2gcp_connection_result")
+	assert.NotNil(t, output)
+}

--- a/tests/connection_e2e_fcr2port_test.go
+++ b/tests/connection_e2e_fcr2port_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudRouter2PortCreateConnection(t *testing.T) {
+	// retryable errors in terraform testing.
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/fabric-cloud-router/fcr2port",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+	output := terraform.Output(t, terraformOptions, "fcr2port_connection_result")
+	assert.NotNil(t, output)
+}

--- a/tests/connection_e2e_fcr_test.go
+++ b/tests/connection_e2e_fcr_test.go
@@ -14,17 +14,17 @@ func TestCloudRouterCreate(t *testing.T) {
 	})
 
 	terraform.InitAndApply(t, terraformOptions)
-	output := terraform.Output(t, terraformOptions, "fg_result")
+	output := terraform.Output(t, terraformOptions, "fcr_result")
 	assert.NotNil(t, output)
 
 	terraformOptions = terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "../examples/fg2port",
+		TerraformDir: "../examples/fabric-cloud-router/fcr",
 	})
 
 	defer terraform.Destroy(t, terraformOptions)
 
 	terraform.InitAndApply(t, terraformOptions)
-	output = terraform.Output(t, terraformOptions, "fg2port_result")
+	output = terraform.Output(t, terraformOptions, "fcr_result")
 
 	assert.NotNil(t, output)
 }


### PR DESCRIPTION
Adds the below Fabric cloud router(FCR) connections types and related tests and examples

- FCR to AWS
- FCR to GCP