### PR TITLE
ci: run acctest workflows 1 at a time and support external PRs

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -1,6 +1,14 @@
 name: Acceptance Tests
+# This workflow determines whether a PR comes from an external fork
+# (which requires approval from us) or from a branch on this repository
+# (which means it was made by us and can run immediately).  Once a PR
+# is approved, the PR code gains access to secrets referenced in this
+# workflow.
+# Any changes to this job, even from internal contributors, require
+# heavy scrutiny.
+
 on:
-  push:
+  pull_request_target:
     paths-ignore:
       - 'LICENSE'
       - '**.md'
@@ -8,10 +16,26 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents: read
+
 jobs:
+  authorize:
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.event_name == 'pull_request_target' && format('acctest-authorize-pr-{0}', github.event.pull_request.number) || 'acctest-authorize' }}
+      cancel-in-progress: true
+    steps:
+      - run: true
 
   build:
     name: Build
+    needs: authorize
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -36,6 +60,7 @@ jobs:
   test:
     name: Matrix Test
     needs: build
+    concurrency: acctest
     runs-on: ubuntu-latest
     timeout-minutes: 240
     strategy:


### PR DESCRIPTION
We don't need to hammer the API with end-to-end tests when the repo gets a flurry of activity.  This adds a concurrency setting to our acceptance test workflow with a hard-coded string value so that only one run of the acceptance tests can execute at any time.

This also updates the acceptance test workflow to replace the `pull` trigger with a `pull_request_target` trigger.  We've been using this for `metal-cli` and it has been a good experience thus far.  The new trigger allows us to manually run end-to-end tests for PRs from forks in order to build confidence in code changes before they are merged.