### PR TITLE
fix: Update CRUD for metal port to support timeouts

### DIFF
--- a/docs/resources/equinix_metal_port.md
+++ b/docs/resources/equinix_metal_port.md
@@ -30,6 +30,17 @@ ports.
 attached VLANs (from `vlan_ids` parameter).
 * `reset_on_delete` - (Optional) Behavioral setting to reset the port to default settings (layer3 bonded mode without any vlan attached) before delete/destroy.
 
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/configuration/resources#operation-timeouts) for certain actions:
+
+These timeout includes the time to disbond, convert to L2/L3, bond and update native vLAN.  
+
+* `create` - (Defaults to 30 mins) Used when creating the Port.
+* `update` - (Defaults to 30 mins) Used when updating the Port.
+* `delete` - (Defaults to 30 mins) Used when deleting the Port.
+
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/equinix/data_source_metal_port.go
+++ b/equinix/data_source_metal_port.go
@@ -6,7 +6,7 @@ import (
 
 func dataSourceMetalPort() *schema.Resource {
 	return &schema.Resource{
-		Read: resourceMetalPortRead,
+		ReadWithoutTimeout: diagnosticsWrapper(resourceMetalPortRead),
 
 		Schema: map[string]*schema.Schema{
 			"port_id": {

--- a/equinix/resource_metal_port.go
+++ b/equinix/resource_metal_port.go
@@ -22,9 +22,9 @@ var (
 func resourceMetalPort() *schema.Resource {
 	return &schema.Resource{
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 		ReadWithoutTimeout: diagnosticsWrapper(resourceMetalPortRead),
 		// Create and Update are the same func

--- a/equinix/resource_metal_port.go
+++ b/equinix/resource_metal_port.go
@@ -22,9 +22,9 @@ var (
 func resourceMetalPort() *schema.Resource {
 	return &schema.Resource{
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 		ReadWithoutTimeout: diagnosticsWrapper(resourceMetalPortRead),
 		// Create and Update are the same func

--- a/equinix/resource_metal_port.go
+++ b/equinix/resource_metal_port.go
@@ -1,6 +1,7 @@
 package equinix
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -25,13 +26,13 @@ func resourceMetalPort() *schema.Resource {
 			Update: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
-		Read: resourceMetalPortRead,
+		ReadWithoutTimeout: diagnosticsWrapper(resourceMetalPortRead),
 		// Create and Update are the same func
-		Create: resourceMetalPortUpdate,
-		Update: resourceMetalPortUpdate,
-		Delete: resourceMetalPortDelete,
+		CreateContext: diagnosticsWrapper(resourceMetalPortUpdate),
+		UpdateContext: diagnosticsWrapper(resourceMetalPortUpdate),
+		DeleteContext: diagnosticsWrapper(resourceMetalPortDelete),
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -116,7 +117,8 @@ func resourceMetalPort() *schema.Resource {
 	}
 }
 
-func resourceMetalPortUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceMetalPortUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+	start := time.Now()
 	cpr, _, err := getClientPortResource(d, meta)
 	if err != nil {
 		return friendlyError(err)
@@ -124,12 +126,12 @@ func resourceMetalPortUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	for _, f := range [](func(*ClientPortResource) error){
 		portSanityChecks,
-		batchVlans(true),
+		batchVlans(ctx, start, true),
 		makeDisbond,
 		convertToL2,
 		makeBond,
 		convertToL3,
-		batchVlans(false),
+		batchVlans(ctx, start, false),
 		updateNativeVlan,
 	} {
 		if err := f(cpr); err != nil {
@@ -137,10 +139,10 @@ func resourceMetalPortUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return resourceMetalPortRead(d, meta)
+	return resourceMetalPortRead(ctx, d, meta)
 }
 
-func resourceMetalPortRead(d *schema.ResourceData, meta interface{}) error {
+func resourceMetalPortRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	meta.(*Config).addModuleToMetalUserAgent(d)
 	client := meta.(*Config).metal
 
@@ -195,9 +197,10 @@ func resourceMetalPortRead(d *schema.ResourceData, meta interface{}) error {
 	return setMap(d, m)
 }
 
-func resourceMetalPortDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceMetalPortDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	resetRaw, resetOk := d.GetOk("reset_on_delete")
 	if resetOk && resetRaw.(bool) {
+		start := time.Now()
 		cpr, resp, err := getClientPortResource(d, meta)
 		if ignoreResponseErrors(httpForbidden, httpNotFound)(resp, err) != nil {
 			return err
@@ -219,7 +222,7 @@ func resourceMetalPortDelete(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		for _, f := range [](func(*ClientPortResource) error){
-			batchVlans(true),
+			batchVlans(ctx, start, true),
 			makeBond,
 			convertToL3,
 		} {

--- a/equinix/resource_metal_port_acc_test.go
+++ b/equinix/resource_metal_port_acc_test.go
@@ -439,6 +439,16 @@ func TestAccMetalPortCreate_hybridBonded_timeout(t *testing.T) {
 				ImportStatePersist: true,
 			},
 			{
+				ResourceName: "equinix_metal_port.bond0",
+				ImportState:  true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("equinix_metal_port.bond0", "network_type", "layer3"),
+				),
+			},
+			{
+				Config: confAccMetalPort_HybridBonded_timeout(rInt, rs, "5s", ""),
+			},
+			{
 				Config:  confAccMetalPort_HybridBonded_timeout(rInt, rs, "5s", ""),
 				Destroy: true,
 			},

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/packethost/packngo v0.30.0
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/oauth2 v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -532,6 +532,7 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/packethost/packngo v0.30.0 h1:JVeTwbXXETsLTDQncUbYwIFpkOp/xevXrffM2HrFECI=
 github.com/packethost/packngo v0.30.0/go.mod h1:BT/XcdwLVmeMtGPbovnxCpnI1s9ylSE1cs/7pq007NE=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
- Adds support for timeout in Create, update and delete operation.
- Adds acceptance tests

Fixes #357 