### PR TITLE
fix: wire up metal-go for HTTP debug logging

### DIFF
--- a/equinix/config.go
+++ b/equinix/config.go
@@ -210,7 +210,7 @@ func (c *Config) NewMetalClient() *packngo.Client {
 // NewMetalGoClient returns a new metal-go client for accessing Equinix Metal's API.
 func (c *Config) NewMetalGoClient() *metalv1.APIClient {
 	transport := http.DefaultTransport
-	transport = logging.NewSubsystemLoggingHTTPTransport("Equinix Metal (metal-go)", transport)
+	transport = logging.NewTransport("Equinix Metal (metal-go)", transport)
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient.Transport = transport
 	retryClient.RetryMax = c.MaxRetries


### PR DESCRIPTION
At some point I switched the metal-go client creation function to use `logging.NewSubsystemLoggingHTTPTransport` instead of the deprecated `logging.NewTransport` that is used elsewhere.

However, I missed that `logging.NewSubsystemLoggingHTTPTransport` requires creating a subsystem first; since I didn't create a new subsystem, the metal-go HTTP debug logs were silently dropped.

This reverts to the `logging.NewTransport` to fix logging and match how we set up other clients.  We can explicitly work on dropping use of the deprecated function at a later time.