### PR TITLE
chore(ci): check out PR code for acceptance testing

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -41,7 +41,9 @@ jobs:
     steps:
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
     - name: Set up Go
       uses: actions/setup-go@v4


### PR DESCRIPTION
When I updated the acceptance test workflow to allow them to run against external PRs (by using the `pull_request_target` trigger), I forgot to update the workflow to actually check out the PR.  The `pull_request_target` workflow runs in the context of the base branch, so if it isn't explicitly told to check out something else, it will check out and run the tests from `main` instead of from the PR.