### PR TITLE
chore: check out PR/branch code every time in acctest workflow

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -75,7 +75,9 @@ jobs:
     steps:
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
     - name: Set up Go
       uses: actions/setup-go@v4


### PR DESCRIPTION
In an earlier PR, I missed that the acctest workflow checks out code _both_ in the build job and in the test job.  I updated the build job to check out PR code, but the test job was still checking out code from the base branch.