### PR TITLE
fix: Remove timeout for metal vrf

### DIFF
--- a/equinix/data_source_metal_vrf.go
+++ b/equinix/data_source_metal_vrf.go
@@ -1,12 +1,14 @@
 package equinix
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMetalVRF() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalVRFRead,
+		ReadWithoutTimeout: diagnosticsWrapper(dataSourceMetalVRFRead),
 
 		Schema: map[string]*schema.Schema{
 			"vrf_id": {
@@ -49,9 +51,9 @@ func dataSourceMetalVRF() *schema.Resource {
 	}
 }
 
-func dataSourceMetalVRFRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceMetalVRFRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	vrfId, _ := d.Get("vrf_id").(string)
 
 	d.SetId(vrfId)
-	return resourceMetalVRFRead(d, meta)
+	return resourceMetalVRFRead(ctx, d, meta)
 }

--- a/equinix/resource_metal_vrf.go
+++ b/equinix/resource_metal_vrf.go
@@ -1,26 +1,20 @@
 package equinix
 
 import (
-	"log"
-	"time"
-
+	"context"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/packethost/packngo"
+	"log"
 )
 
 func resourceMetalVRF() *schema.Resource {
 	return &schema.Resource{
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
-		Read:   resourceMetalVRFRead,
-		Create: resourceMetalVRFCreate,
-		Update: resourceMetalVRFUpdate,
-		Delete: resourceMetalVRFDelete,
+		ReadWithoutTimeout:   diagnosticsWrapper(resourceMetalVRFRead),
+		CreateWithoutTimeout: diagnosticsWrapper(resourceMetalVRFCreate),
+		UpdateWithoutTimeout: diagnosticsWrapper(resourceMetalVRFUpdate),
+		DeleteWithoutTimeout: diagnosticsWrapper(resourceMetalVRFDelete),
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -61,7 +55,7 @@ func resourceMetalVRF() *schema.Resource {
 	}
 }
 
-func resourceMetalVRFCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceMetalVRFCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	meta.(*Config).addModuleToMetalUserAgent(d)
 	client := meta.(*Config).metal
 
@@ -81,10 +75,10 @@ func resourceMetalVRFCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(vrf.ID)
 
-	return resourceMetalVRFRead(d, meta)
+	return resourceMetalVRFRead(ctx, d, meta)
 }
 
-func resourceMetalVRFUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceMetalVRFUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	meta.(*Config).addModuleToMetalUserAgent(d)
 	client := meta.(*Config).metal
 
@@ -111,10 +105,10 @@ func resourceMetalVRFUpdate(d *schema.ResourceData, meta interface{}) error {
 		return friendlyError(err)
 	}
 
-	return resourceMetalVRFRead(d, meta)
+	return resourceMetalVRFRead(ctx, d, meta)
 }
 
-func resourceMetalVRFRead(d *schema.ResourceData, meta interface{}) error {
+func resourceMetalVRFRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	meta.(*Config).addModuleToMetalUserAgent(d)
 	client := meta.(*Config).metal
 
@@ -142,7 +136,7 @@ func resourceMetalVRFRead(d *schema.ResourceData, meta interface{}) error {
 	return setMap(d, m)
 }
 
-func resourceMetalVRFDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceMetalVRFDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	meta.(*Config).addModuleToMetalUserAgent(d)
 	client := meta.(*Config).metal
 

--- a/equinix/resource_network_bgp_test.go
+++ b/equinix/resource_network_bgp_test.go
@@ -2,6 +2,7 @@ package equinix
 
 import (
 	"context"
+	"github.com/packethost/packngo"
 	"testing"
 	"time"
 
@@ -98,6 +99,20 @@ func (r *mockedBGPUpdateRequest) WithAuthenticationKey(v string) ne.BGPUpdateReq
 
 func (r *mockedBGPUpdateRequest) Execute() error {
 	return nil
+}
+
+var _ packngo.BGPConfigService = &mockBgpConfigService{}
+
+type mockBgpConfigService struct {
+	GetFn    func(projectID string, getOpt *packngo.GetOptions) (*packngo.BGPConfig, *packngo.Response, error)
+	CreateFn func(projectID string, request packngo.CreateBGPConfigRequest) (*packngo.Response, error)
+}
+
+func (s *mockBgpConfigService) Get(projectID string, getOpt *packngo.GetOptions) (*packngo.BGPConfig, *packngo.Response, error) {
+	return s.GetFn(projectID, getOpt)
+}
+func (s *mockBgpConfigService) Create(projectID string, request packngo.CreateBGPConfigRequest) (*packngo.Response, error) {
+	return s.CreateFn(projectID, request)
 }
 
 func TestNetworkBGP_createUpdateRequest(t *testing.T) {

--- a/equinix/resource_network_bgp_test.go
+++ b/equinix/resource_network_bgp_test.go
@@ -2,7 +2,6 @@ package equinix
 
 import (
 	"context"
-	"github.com/packethost/packngo"
 	"testing"
 	"time"
 
@@ -99,20 +98,6 @@ func (r *mockedBGPUpdateRequest) WithAuthenticationKey(v string) ne.BGPUpdateReq
 
 func (r *mockedBGPUpdateRequest) Execute() error {
 	return nil
-}
-
-var _ packngo.BGPConfigService = &mockBgpConfigService{}
-
-type mockBgpConfigService struct {
-	GetFn    func(projectID string, getOpt *packngo.GetOptions) (*packngo.BGPConfig, *packngo.Response, error)
-	CreateFn func(projectID string, request packngo.CreateBGPConfigRequest) (*packngo.Response, error)
-}
-
-func (s *mockBgpConfigService) Get(projectID string, getOpt *packngo.GetOptions) (*packngo.BGPConfig, *packngo.Response, error) {
-	return s.GetFn(projectID, getOpt)
-}
-func (s *mockBgpConfigService) Create(projectID string, request packngo.CreateBGPConfigRequest) (*packngo.Response, error) {
-	return s.CreateFn(projectID, request)
 }
 
 func TestNetworkBGP_createUpdateRequest(t *testing.T) {


### PR DESCRIPTION
As part of fixing the timeouts for metal resources to actually comply with what is documented, it was found out that we donot document any timeout support for metal VRF whereas in the code we do have support for timeouts.

Since it has never been working due to the below issue, also not documented, it'll be ideal to remove it directly considering a code smell

Relates to: #357 