### PR TITLE
chore: Add CODEOWNERS mapped by filenames

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+#
+*                   @equinix/governor-metal-client-interfaces
+/cmd/migration-tool @equinix/governor-metal-client-interfaces
+*metal*             @t0mk @equinix/governor-metal-client-interfaces
+*fabric*            @equinix/governor-digin-fabric
+*ecx*               @equinix/governor-digin-fabric
+*connection_e2e*    @equinix/governor-digin-fabric
+*equinix_network*   @equinix/network-edge-team
+**/edge-networking  @equinix/network-edge-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,5 @@
 *fabric*            @equinix/governor-digin-fabric
 *ecx*               @equinix/governor-digin-fabric
 *connection_e2e*    @equinix/governor-digin-fabric
-*equinix_network*   @equinix/network-edge-team
-**/edge-networking  @equinix/network-edge-team
+*equinix_network*   @equinix/governor-ne-network-edge-engineering
+**/edge-networking  @equinix/governor-ne-network-edge-engineering


### PR DESCRIPTION
Adds a codeowners using existing reviewer patterns.

The OWNERS file was a loosely tied benefit of:
 https://github.com/equinix/terraform-provider-equinix/pull/142#issue-1237879622