### PR TITLE
chore: use terraform_data resource to stabilize test selections

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -71,7 +71,7 @@ jobs:
         version:
           - stable
         terraform:
-          - '1.1.5'
+          - '1.5'
     steps:
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
Occasionally, we see metro or facility selections change as a result of capacity changes on the Metal platform side; for example, step 1 of a test deploys to `da`, but when step 2 runs, there are no longer any available servers in `da`, so a different metro is selected and the test generates an unexpected plan.