### PR TITLE
feat: add contact_email to equinix_metal_connection datasource and resource

### DIFF
--- a/docs/data-sources/equinix_metal_connection.md
+++ b/docs/data-sources/equinix_metal_connection.md
@@ -29,7 +29,7 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Name of the connection resource.
 * `metro` - Slug of a metro to which the connection belongs.
 * `facility` - (**Deprecated**) Slug of a facility to which the connection belongs. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
-* `contact_email` * The preferred email used for communication and notifications about the Equinix Fabric interconnection.
+* `contact_email` - The preferred email used for communication and notifications about the Equinix Fabric interconnection.
 * `redundancy` - Connection redundancy, reduntant or primary.
 * `type` - Connection type, dedicated or shared.
 * `project_id` - ID of project to which the connection belongs.

--- a/docs/data-sources/equinix_metal_connection.md
+++ b/docs/data-sources/equinix_metal_connection.md
@@ -29,6 +29,7 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Name of the connection resource.
 * `metro` - Slug of a metro to which the connection belongs.
 * `facility` - (**Deprecated**) Slug of a facility to which the connection belongs. Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
+* `contact_email` * The preferred email used for communication and notifications about the Equinix Fabric interconnection.
 * `redundancy` - Connection redundancy, reduntant or primary.
 * `type` - Connection type, dedicated or shared.
 * `project_id` - ID of project to which the connection belongs.

--- a/docs/resources/equinix_metal_connection.md
+++ b/docs/resources/equinix_metal_connection.md
@@ -21,6 +21,7 @@ resource "equinix_metal_connection" "example" {
     metro              = "sv"
     speed              = "1000Mbps"
     service_token_type = "a_side"
+    contact_email      = "username@example.com"
 }
 
 data "equinix_ecx_l2_sellerprofile" "example" {
@@ -64,6 +65,7 @@ resource "equinix_metal_connection" "example" {
     metro              = "FR"
     speed              = "200Mbps"
     service_token_type = "z_side"
+    contact_email      = "username@example.com"
 }
 
 data "equinix_ecx_port" "example" {
@@ -92,6 +94,7 @@ resource "equinix_metal_connection" "example" {
     metro           = "SV"
     redundancy      = "redundant"
     type            = "shared"
+    contact_email   = "username@example.com"
 }
 
 data "equinix_ecx_port" "example" {
@@ -118,6 +121,7 @@ The following arguments are supported:
 * `facility` - (**Deprecated**) Facility where the connection will be created.   Use metro instead; read the [facility to metro migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_facilities_to_metros_devices)
 * `redundancy` - (Required) Connection redundancy - redundant or primary.
 * `type` - (Required) Connection type - dedicated or shared.
+* `contact_email` - (Required) The preferred email used for communication and notifications about the Equinix Fabric interconnection. Required when using a Project API key. Optional and defaults to the primary user email address when using a User API key.
 * `project_id` - (Optional) ID of the project where the connection is scoped to, must be set for.
 * `speed` - (Required) Connection speed - one of 50Mbps, 200Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps.
 * `description` - (Optional) Description for the connection resource.

--- a/equinix/data_source_metal_connection.go
+++ b/equinix/data_source_metal_connection.go
@@ -107,6 +107,11 @@ func dataSourceMetalConnection() *schema.Resource {
 				Computed:    true,
 				Description: "Name of the connection resource",
 			},
+			"contact_email": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The preferred email used for communication and notifications about the Equinix Fabric interconnection",
+			},
 			"facility": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/equinix/resource_metal_connection.go
+++ b/equinix/resource_metal_connection.go
@@ -105,7 +105,7 @@ func resourceMetalConnection() *schema.Resource {
 				Description: "The preferred email used for communication and notifications about the Equinix Fabric interconnection. Required when using a Project API key. Optional and defaults to the primary user email address when using a User API key",
 				Optional:    true,
 				Computed:    true,
-				ForceNew: true, // TODO(displague) packngo needs updating
+				ForceNew:    true, // TODO(displague) packngo needs updating
 			},
 			"type": {
 				Type:        schema.TypeString,

--- a/equinix/resource_metal_connection_acc_test.go
+++ b/equinix/resource_metal_connection_acc_test.go
@@ -70,6 +70,7 @@ func testAccMetalConnectionConfig_Shared(randstr string) string {
             metro              = "sv"
 			speed              = "50Mbps"
 			service_token_type = "a_side"
+			contact_email      = "tfacc@example.com"
         }`,
 		randstr, randstr)
 }
@@ -108,12 +109,12 @@ func TestAccMetalConnection_shared_zside(t *testing.T) {
 						"equinix_metal_connection.test", "service_tokens.0.type", "z_side"),
 					resource.TestCheckResourceAttr(
 						"equinix_metal_connection.test", "service_token_type", "z_side"),
+					resource.TestCheckResourceAttrSet(
+						"equinix_metal_connection.test", "contact_email"),
 				),
 			},
 		},
 	})
-
-
 }
 
 func TestAccMetalConnection_shared(t *testing.T) {
@@ -136,6 +137,8 @@ func TestAccMetalConnection_shared(t *testing.T) {
 						"equinix_metal_connection.test", "service_token_type", "a_side"),
 					resource.TestCheckResourceAttr(
 						"equinix_metal_connection.test", "service_tokens.0.max_allowed_speed", "50Mbps"),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_connection.test", "contact_email", "tfacc@example.com"),
 				),
 			},
 			{


### PR DESCRIPTION
fixes #340 

note:
- contact_email should be updatable but packngo does not offer the update field. Defining the field as ForceNew until this resource is rewritten with metal-go #402 
- e2e between the zside and shared test, we should have coverage that contact_email is optional and will be read back in as computed or as given. We are not adding a test that requires a project api key to trigger the backend *required* behavior.