### PR TITLE
chore(ci): avoid test changes due to plan facilities

### DIFF
--- a/equinix/data_source_metal_ip_block_ranges_acc_test.go
+++ b/equinix/data_source_metal_ip_block_ranges_acc_test.go
@@ -46,7 +46,7 @@ resource "equinix_metal_project" "test" {
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-ip-test"
   plan             = local.plan
-  facilities       = local.facilities
+  metro            = local.metro
   operating_system = local.os
   billing_cycle    = "hourly"
   project_id       = equinix_metal_project.test.id

--- a/equinix/resource_metal_bgp_setup_acc_test.go
+++ b/equinix/resource_metal_bgp_setup_acc_test.go
@@ -82,7 +82,7 @@ resource "equinix_metal_project" "test" {
 resource "equinix_metal_device" "test" {
     hostname         = "tfacc-test-bgp-sesh"
     plan             = local.plan
-    facilities       = local.facilities
+    metro            = local.metro
     operating_system = local.os
     billing_cycle    = "hourly"
     project_id       = "${equinix_metal_project.test.id}"

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -126,6 +126,14 @@ resource "terraform_data" "plan" {
   }
 }
 
+resource "terraform_data" "facilities" {
+  input = sort(tolist(setsubtract(terraform_data.plan.output.available_in, ["nrt1", "dfw2", "ewr1", "ams1", "sjc1", "ld7", "sy4", "ny6"])))
+
+  lifecycle {
+    ignore_changes = ["input"]
+  }
+}
+
 // Select a metal facility randomly and lock it in
 // so that we don't pick a different one for
 // every subsequent terraform plan
@@ -163,7 +171,7 @@ locals {
     plan              = terraform_data.plan.output.slug
 
     // Select a random facility from the facilities in which the selected plan is available, excluding decommed facilities
-    facilities             = sort(tolist(setsubtract(terraform_data.plan.output.available_in, ["nrt1", "dfw2", "ewr1", "ams1", "sjc1", "ld7", "sy4", "ny6"])))
+    facilities             = terraform_data.facilities.output
     facility               = terraform_data.facility.output
 
     // Select a random metro from the metros in which the selected plan is available

--- a/equinix/resource_metal_ip_attachment_acc_test.go
+++ b/equinix/resource_metal_ip_attachment_acc_test.go
@@ -48,7 +48,7 @@ resource "equinix_metal_project" "test" {
 resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-ip-attachment-test"
   plan             = local.plan
-  facilities       = local.facilities
+  metro            = local.metro
   operating_system = local.os
   billing_cycle    = "hourly"
   project_id       = equinix_metal_project.test.id

--- a/equinix/resource_metal_project_ssh_key_acc_test.go
+++ b/equinix/resource_metal_project_ssh_key_acc_test.go
@@ -27,7 +27,7 @@ resource "equinix_metal_project_ssh_key" "test" {
 resource "equinix_metal_device" "test" {
     hostname            = "tfacc-device-key-test"
     plan                = local.plan
-    facilities          = local.facilities
+    metro               = local.metro
     operating_system    = local.os
     billing_cycle       = "hourly"
     project_ssh_key_ids = ["${equinix_metal_project_ssh_key.test.id}"]


### PR DESCRIPTION
We still had some Metal test failures due to changes in the `facilities` list for a selected plan.  In these cases, the tests were directly referencing the full `facilities` list rather than the single, cached, `facility` value.

This updates the tests to also cache the `facilities` list in an attempt to further reduce flakiness.  In addition, some tests that were using `facilities` have been updated to use `metro` instead, since none of the functionality under test was reliant on using `facilities`.