### PR TITLE
feat: Add viewPoint parameter to Service Profiles Data Resource

### DIFF
--- a/equinix/fabric_service_profile_read_schema.go
+++ b/equinix/fabric_service_profile_read_schema.go
@@ -446,12 +446,18 @@ func readFabricServiceProfilesSearchSchema() map[string]*schema.Schema {
 				Schema: readFabricServiceProfileSchemaUpdated(),
 			},
 		},
+		"view_point": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "flips view between buyer and seller representation. Available values : aSide, zSide. Default value : aSide",
+		},
 		"filter": {
 			Type:        schema.TypeSet,
 			Optional:    true,
 			Description: "Service Profile Search Filter",
+			MaxItems:    1,
 			Elem: &schema.Resource{
-				Schema: createServiceProfilesSearchExpressionSch(),
+				Schema: createServiceProfilesSearchFilterSch(),
 			},
 		},
 		"sort": {

--- a/equinix/fabric_service_profile_search_schema.go
+++ b/equinix/fabric_service_profile_search_schema.go
@@ -5,7 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func createServiceProfilesSearchExpressionSch() map[string]*schema.Schema {
+func createServiceProfilesSearchFilterSch() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"property": {
 			Type:        schema.TypeString,

--- a/equinix/resource_fabric_service_profile.go
+++ b/equinix/resource_fabric_service_profile.go
@@ -283,7 +283,7 @@ func resourceServiceProfilesSearchRequest(ctx context.Context, d *schema.Resourc
 	sort := serviceProfilesSearchSortRequestToFabric(schemaSort)
 	schemaViewPoint := d.Get("view_point").(string)
 
-	if schemaViewPoint != "" && (schemaViewPoint != string(v4.A_SIDE_ViewPoint) || schemaViewPoint != string(v4.Z_SIDE_ViewPoint)) {
+	if schemaViewPoint != "" && schemaViewPoint != string(v4.A_SIDE_ViewPoint) && schemaViewPoint != string(v4.Z_SIDE_ViewPoint) {
 		return diag.FromErr(errors.New("view_point can only be set to aSide or zSide. Omitting it will default to aSide"))
 	}
 


### PR DESCRIPTION
* Fabric 4.10 added viewPoint query parameter to serviceProfilesSearch Endpoint
* Fabric-Go SDK upgrade to v0.7.0 included the update to the method
* Terraform data source updated to reflect the changes in Fabric OAS 4.10

Testing with the cloudRouter2azure/two-connections E2E example:

TF_LOG Output:

Value not in main.tf:
```
---[ REQUEST ]---------------------------------------
POST /fabric/v4/serviceProfiles/search HTTP/1.1
Host: uatapi.equinix.com
User-Agent: equinix/fabric-go
Content-Length: 79
Accept: application/json
Authorization: Bearer 132E2S7hPtnrsk1GswoyDNoffwkK
Content-Type: application/json
X-Correlation-Id: 2@884TGRom#Fs#Ike9&35xDdO
X-Source: API
Accept-Encoding: gzip

{
 "filter": {
  "property": "/name",
  "operator": "=",
  "values": [
   "Azure ExpressRoute"
  ]
 }
}
```

Value set to "":
```
---[ REQUEST ]---------------------------------------
POST /fabric/v4/serviceProfiles/search HTTP/1.1
Host: uatapi.equinix.com
User-Agent: equinix/fabric-go
Content-Length: 79
Accept: application/json
Authorization: Bearer 132E2S7hPtnrsk1GswoyDNoffwkK
Content-Type: application/json
X-Correlation-Id: 2@884TGRom#Fs#Ike9&35xDdO
X-Source: API
Accept-Encoding: gzip

{
 "filter": {
  "property": "/name",
  "operator": "=",
  "values": [
   "Azure ExpressRoute"
  ]
 }
}
```

Value set but not aSide or zSide:
```
Error: view_point can only be set to aSide or zSide. Omitting it will default to aSide
│ 
│   with data.equinix_fabric_service_profiles.azure,
│   on main.tf line 6, in data "equinix_fabric_service_profiles" "azure":
│    6: data "equinix_fabric_service_profiles" "azure" {
│ 
```

Value set to zSide:
```
---[ REQUEST ]---------------------------------------
POST /fabric/v4/serviceProfiles/search?viewPoint=zSide HTTP/1.1
Host: uatapi.equinix.com
User-Agent: equinix/fabric-go
Content-Length: 79
Accept: application/json
Authorization: Bearer 1pqZsRWG9HYtuTL2VGJ1V0Q7PA6C
Content-Type: application/json
X-Correlation-Id: os8YFHaIdXE6Aamj1LGgZFzh@
X-Source: API
Accept-Encoding: gzip

{
 "filter": {
  "property": "/name",
  "operator": "=",
  "values": [
   "Azure ExpressRoute"
  ]
 }
}
```

Value set to aSide:
```
---[ REQUEST ]---------------------------------------
POST /fabric/v4/serviceProfiles/search?viewPoint=aSide HTTP/1.1
Host: uatapi.equinix.com
User-Agent: equinix/fabric-go
Content-Length: 79
Accept: application/json
Authorization: Bearer dwr7wjdxVfT2weqzWZEQGX9xwh9G
Content-Type: application/json
X-Correlation-Id: zxcTgWhhQOtVYgGTPaPAMURtu
X-Source: API
Accept-Encoding: gzip

{
 "filter": {
  "property": "/name",
  "operator": "=",
  "values": [
   "Azure ExpressRoute"
  ]
 }
}
```