### PR TITLE
fix: `equinix_fabric_cloud_router` ignore empty order block and set max 1 for project block

### DIFF
--- a/equinix/fabric_cloud_router_schema.go
+++ b/equinix/fabric_cloud_router_schema.go
@@ -118,6 +118,7 @@ func createCloudRouterResourceSchema() map[string]*schema.Schema {
 			Type:        schema.TypeSet,
 			Optional:    true,
 			Description: "Fabric Cloud Router project",
+			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: createCloudRouterProjectSch(),
 			},

--- a/equinix/resource_fabric_cloud_router.go
+++ b/equinix/resource_fabric_cloud_router.go
@@ -39,8 +39,6 @@ func resourceCloudRouterCreate(ctx context.Context, d *schema.ResourceData, meta
 	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*Config).FabricAuthToken)
 	schemaNotifications := d.Get("notifications").([]interface{})
 	notifications := notificationToFabric(schemaNotifications)
-	schemaOrder := d.Get("order").(*schema.Set).List()
-	order := orderToFabric(schemaOrder)
 	schemaAccount := d.Get("account").(*schema.Set).List()
 	account := accountToCloudRouter(schemaAccount)
 	schemaLocation := d.Get("location").(*schema.Set).List()
@@ -56,12 +54,16 @@ func resourceCloudRouterCreate(ctx context.Context, d *schema.ResourceData, meta
 	createRequest := v4.CloudRouterPostRequest{
 		Name:          d.Get("name").(string),
 		Type_:         d.Get("type").(string),
-		Order:         &order,
 		Location:      &location,
 		Notifications: notifications,
 		Package_:      &packages,
 		Account:       &account,
 		Project:       &project,
+	}
+
+	if v, ok := d.GetOk("order"); ok {
+		order := orderToFabric(v.(*schema.Set).List())
+		createRequest.Order = &order
 	}
 
 	fcr, _, err := client.CloudRoutersApi.CreateCloudRouter(ctx, createRequest)


### PR DESCRIPTION
- fix #428
- Add `MaxItems:1` for `project` argument. Although this is generally not a problem in terraform, [it does affect the way the Pulumi bridged plugin is generated](https://github.com/equinix/pulumi-equinix/issues/28). All fields of the type `set` without a `MaxItems` or `MaxItems` different to 1 are generated with a plural noun: `project` --> `projects`