### PR TITLE
fix: use the correct base User-Agent for metal-go requests

### DIFF
--- a/equinix/config.go
+++ b/equinix/config.go
@@ -305,7 +305,7 @@ func (c *Config) addModuleToMetalUserAgent(d *schema.ResourceData) {
 }
 
 func (c *Config) addModuleToMetalGoUserAgent(d *schema.ResourceData) {
-	c.metalgo.GetConfig().UserAgent = generateModuleUserAgentString(d, c.metalUserAgent)
+	c.metalgo.GetConfig().UserAgent = generateModuleUserAgentString(d, c.metalGoUserAgent)
 }
 
 func generateModuleUserAgentString(d *schema.ResourceData, baseUserAgent string) string {


### PR DESCRIPTION
The code that injects terraform module information into the User-Agent string for the metal-go client was mis-wired; it was using the packngo User-Agent as a base instead of the metal-go User-Agent.  This change will correct the User-Agent so that requests made with metal-go will not appear to come from packngo.