### PR TITLE
fix: Add network body response in terraform errors for equinix_fabric_connection resource

### DIFF
--- a/equinix/resource_fabric_connection.go
+++ b/equinix/resource_fabric_connection.go
@@ -169,6 +169,10 @@ func resourceFabricConnectionRead(ctx context.Context, d *schema.ResourceData, m
 	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	conn, _, err := client.ConnectionsApi.GetConnectionByUuid(ctx, d.Id(), nil)
 	if err != nil {
+		log.Printf("[WARN] Connection %s not found , error %s", d.Id(), err)
+		if !strings.Contains(err.Error(), "500") {
+			d.SetId("")
+		}
 		return diag.FromErr(equinix_errors.FormatFabricError(err))
 	}
 	d.SetId(conn.Uuid)

--- a/equinix/resource_fabric_connection.go
+++ b/equinix/resource_fabric_connection.go
@@ -226,7 +226,7 @@ func resourceFabricConnectionUpdate(ctx context.Context, d *schema.ResourceData,
 	for _, update := range updateRequests {
 		_, httpResponse, err := client.ConnectionsApi.UpdateConnectionByUuid(ctx, update, d.Id())
 		if err != nil {
-			diags = append(diags, networkErrorOutput(fmt.Errorf("connectionn property update request error: %v [update payload: %v] (other updates will be successful if the payload is not shown)", err, update), httpResponse)...)
+			diags = append(diags, networkErrorOutput(fmt.Errorf("connection property update request error: %v [update payload: %v] (other updates will be successful if the payload is not shown)", err, update), httpResponse)...)
 			continue
 		}
 

--- a/equinix/resource_fabric_port.go
+++ b/equinix/resource_fabric_port.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
@@ -27,7 +28,7 @@ func resourceFabricPortRead(ctx context.Context, d *schema.ResourceData, meta in
 		if !strings.Contains(err.Error(), "500") {
 			d.SetId("")
 		}
-		return diag.FromErr(err)
+		return diag.FromErr(equinix_errors.FormatFabricError(err))
 	}
 	d.SetId(port.Uuid)
 	return setFabricPortMap(d, port)
@@ -97,7 +98,7 @@ func resourceFabricPortGetByPortName(ctx context.Context, d *schema.ResourceData
 		if !strings.Contains(err.Error(), "500") {
 			d.SetId("")
 		}
-		return diag.FromErr(err)
+		return diag.FromErr(equinix_errors.FormatFabricError(err))
 	}
 	if len(ports.Data) != 1 {
 		error := fmt.Errorf("incorrect # of records are found for the port name parameter criteria - %d , please change the criteria", len(ports.Data))

--- a/equinix/resource_fabric_service_profile.go
+++ b/equinix/resource_fabric_service_profile.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 
 	"github.com/antihax/optional"
@@ -46,11 +47,9 @@ func resourceFabricServiceProfileRead(ctx context.Context, d *schema.ResourceDat
 	serviceProfile, _, err := client.ServiceProfilesApi.GetServiceProfileByUuid(ctx, d.Id(), nil)
 	if err != nil {
 		if !strings.Contains(err.Error(), "500") {
-			error := v4.ModelError{}
 			d.SetId("")
-			log.Printf("Error Status Message: %s", error.ErrorMessage)
 		}
-		return diag.FromErr(err)
+		return diag.FromErr(equinix_errors.FormatFabricError(err))
 	}
 	d.SetId(serviceProfile.Uuid)
 	return setFabricServiceProfileMap(d, serviceProfile)
@@ -63,7 +62,7 @@ func resourceFabricServiceProfileCreate(ctx context.Context, d *schema.ResourceD
 	createRequest := getServiceProfileRequestPayload(d)
 	sp, _, err := client.ServiceProfilesApi.CreateServiceProfile(ctx, createRequest)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(equinix_errors.FormatFabricError(err))
 	}
 	d.SetId(sp.Uuid)
 	return resourceFabricServiceProfileRead(ctx, d, meta)
@@ -142,9 +141,9 @@ func resourceFabricServiceProfileUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("Either timed out or errored out while fetching service profile for uuid %s and error %v", uuid, err)
 	}
 
-	_, res, err := client.ServiceProfilesApi.PutServiceProfileByUuid(ctx, updateRequest, strconv.FormatInt(eTag, 10), uuid)
+	_, _, err = client.ServiceProfilesApi.PutServiceProfileByUuid(ctx, updateRequest, strconv.FormatInt(eTag, 10), uuid)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error response for the service profile update, response %v, error %v", res, err))
+		return diag.FromErr(equinix_errors.FormatFabricError(err))
 	}
 	updatedServiceProfile := v4.ServiceProfile{}
 	updatedServiceProfile, err = waitForServiceProfileUpdateCompletion(uuid, meta, ctx)
@@ -152,7 +151,7 @@ func resourceFabricServiceProfileUpdate(ctx context.Context, d *schema.ResourceD
 		if !strings.Contains(err.Error(), "500") {
 			d.SetId("")
 		}
-		return diag.FromErr(fmt.Errorf("errored while waiting for successful service profile update, response %v, error %v", res, err))
+		return diag.FromErr(fmt.Errorf("errored while waiting for successful service profile update, error %v", err))
 	}
 	d.SetId(updatedServiceProfile.Uuid)
 	return setFabricServiceProfileMap(d, updatedServiceProfile)
@@ -166,7 +165,7 @@ func waitForServiceProfileUpdateCompletion(uuid string, meta interface{}, ctx co
 			client := meta.(*config.Config).FabricClient
 			dbServiceProfile, _, err := client.ServiceProfilesApi.GetServiceProfileByUuid(ctx, uuid, nil)
 			if err != nil {
-				return "", "", err
+				return "", "", equinix_errors.FormatFabricError(err)
 			}
 			updatableState := "COMPLETED"
 			return dbServiceProfile, updatableState, nil
@@ -194,7 +193,7 @@ func waitForActiveServiceProfileAndPopulateETag(uuid string, meta interface{}, c
 			client := meta.(*config.Config).FabricClient
 			dbServiceProfile, res, err := client.ServiceProfilesApi.GetServiceProfileByUuid(ctx, uuid, nil)
 			if err != nil {
-				return nil, "", err
+				return nil, "", equinix_errors.FormatFabricError(err)
 			}
 
 			eTagStr := res.Header.Get("ETag")
@@ -229,9 +228,9 @@ func resourceFabricServiceProfileDelete(ctx context.Context, d *schema.ResourceD
 	if uuid == "" {
 		return diag.Errorf("No uuid found %v ", uuid)
 	}
-	_, resp, err := client.ServiceProfilesApi.DeleteServiceProfileByUuid(ctx, uuid)
+	_, _, err := client.ServiceProfilesApi.DeleteServiceProfileByUuid(ctx, uuid)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error response for the Service Profile delete error %v and response %v", err, resp))
+		return diag.FromErr(equinix_errors.FormatFabricError(err))
 	}
 	return diags
 }
@@ -306,11 +305,9 @@ func resourceServiceProfilesSearchRequest(ctx context.Context, d *schema.Resourc
 	serviceProfiles, _, err := client.ServiceProfilesApi.SearchServiceProfiles(ctx, createServiceProfilesSearchRequest, viewPoint)
 	if err != nil {
 		if !strings.Contains(err.Error(), "500") {
-			error := v4.ModelError{}
 			d.SetId("")
-			log.Printf("Error Status Message: %s", error.ErrorMessage)
 		}
-		return diag.FromErr(err)
+		return diag.FromErr(equinix_errors.FormatFabricError(err))
 	}
 
 	if len(serviceProfiles.Data) != 1 {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -69,20 +69,20 @@ func FormatFabricError(err error) error {
 	// If in future one would like to do something with the response body of the API request
 	// The line below is how to access it with the SwaggerCodegen Fabric Go 12/7/2023 - thogarty
 	// errors = append(errors, string(err.(fabric.GenericSwaggerError).Body()))
-	var errors []string
+	var errors Errors
 	errors = append(errors, err.Error())
 	if fabricErrs, ok := err.(fabric.GenericSwaggerError).Model().([]fabric.ModelError); ok {
 		for _, e := range fabricErrs {
+			errors = append(errors, fmt.Sprintf("Code: %s", e.ErrorCode))
 			errors = append(errors, fmt.Sprintf("Message: %s", e.ErrorMessage))
 			errors = append(errors, fmt.Sprintf("Details: %s", e.Details))
 			if additionalInfo := FormatFabricAdditionalInfo(e.AdditionalInfo); additionalInfo != "" {
 				errors = append(errors, fmt.Sprintf("AdditionalInfo: [%s]", additionalInfo))
 			}
-			errors = append(errors, fmt.Sprintf("Code: %s", e.ErrorCode))
 		}
 	}
 
-	return fmt.Errorf("%s", strings.Join(errors, ", "))
+	return errors
 }
 
 func IsForbidden(err error) bool {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -73,12 +73,12 @@ func FormatFabricError(err error) error {
 	errors = append(errors, err.Error())
 	if fabricErrs, ok := err.(fabric.GenericSwaggerError).Model().([]fabric.ModelError); ok {
 		for _, e := range fabricErrs {
-			errors = append(errors, fmt.Sprintf("Code: %s", e.ErrorCode))
 			errors = append(errors, fmt.Sprintf("Message: %s", e.ErrorMessage))
 			errors = append(errors, fmt.Sprintf("Details: %s", e.Details))
 			if additionalInfo := FormatFabricAdditionalInfo(e.AdditionalInfo); additionalInfo != "" {
 				errors = append(errors, fmt.Sprintf("AdditionalInfo: [%s]", additionalInfo))
 			}
+			errors = append(errors, fmt.Sprintf("Code: %s", e.ErrorCode))
 		}
 	}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -73,9 +73,9 @@ func FormatFabricError(err error) error {
 	errors = append(errors, err.Error())
 	if fabricErrs, ok := err.(v4.GenericSwaggerError).Model().([]v4.ModelError); ok {
 		for _, e := range fabricErrs {
-			errors = append(errors, fmt.Sprintf("ErrorCode: %s", e.ErrorCode))
-			errors = append(errors, fmt.Sprintf("ErrorMessage: %s", e.ErrorMessage))
-			errors = append(errors, fmt.Sprintf("ErrorDetails: %s", e.Details))
+			errors = append(errors, fmt.Sprintf("Code: %s", e.ErrorCode))
+			errors = append(errors, fmt.Sprintf("Message: %s", e.ErrorMessage))
+			errors = append(errors, fmt.Sprintf("Details: %s", e.Details))
 			if additionalInfo := FormatFabricAdditionalInfo(e.AdditionalInfo); additionalInfo != "" {
 				errors = append(errors, fmt.Sprintf("AdditionalInfo: [%s]", additionalInfo))
 			}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -2,11 +2,11 @@ package errors
 
 import (
 	"fmt"
-	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
-
-	"github.com/packethost/packngo"
 	"net/http"
 	"strings"
+
+	fabric "github.com/equinix-labs/fabric-go/fabric/v4"
+	"github.com/packethost/packngo"
 )
 
 // FriendlyError improves error messages when the API error is blank or in an
@@ -48,7 +48,7 @@ func convertToFriendlyError(errors Errors, resp *http.Response) error {
 	return er
 }
 
-func FormatFabricAdditionalInfo(additionalInfo []v4.PriceErrorAdditionalInfo) string {
+func FormatFabricAdditionalInfo(additionalInfo []fabric.PriceErrorAdditionalInfo) string {
 	var str []string
 	for _, addInfo := range additionalInfo {
 		property, reason := addInfo.Property, addInfo.Reason
@@ -68,10 +68,10 @@ func FormatFabricAdditionalInfo(additionalInfo []v4.PriceErrorAdditionalInfo) st
 func FormatFabricError(err error) error {
 	// If in future one would like to do something with the response body of the API request
 	// The line below is how to access it with the SwaggerCodegen Fabric Go 12/7/2023 - thogarty
-	// errors = append(errors, string(err.(v4.GenericSwaggerError).Body()))
+	// errors = append(errors, string(err.(fabric.GenericSwaggerError).Body()))
 	var errors []string
 	errors = append(errors, err.Error())
-	if fabricErrs, ok := err.(v4.GenericSwaggerError).Model().([]v4.ModelError); ok {
+	if fabricErrs, ok := err.(fabric.GenericSwaggerError).Model().([]fabric.ModelError); ok {
 		for _, e := range fabricErrs {
 			errors = append(errors, fmt.Sprintf("Code: %s", e.ErrorCode))
 			errors = append(errors, fmt.Sprintf("Message: %s", e.ErrorMessage))

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,11 +1,9 @@
 package errors
 
 import (
-	"fmt"
+	"github.com/packethost/packngo"
 	"net/http"
 	"strings"
-
-	"github.com/packethost/packngo"
 )
 
 // FriendlyError improves error messages when the API error is blank or in an


### PR DESCRIPTION
* Add errors method to output err and network response body together
* Update equinix_fabric_connection resource to include the errors method in response to errors on network requests

Part of https://github.com/equinix/terraform-provider-equinix/issues/124

Before:
```
equinix_fabric_connection.aws-qinq: Creating...
╷
│ Error: 400 Bad Request
│ 
│   with equinix_fabric_connection.aws-qinq,
│   on main.tf line 20, in resource "equinix_fabric_connection" "aws-qinq":
│   20: resource  "equinix_fabric_connection" "aws-qinq"{
```

After:
```
equinix_fabric_connection.aws-qinq: Creating...
╷
│ Error: 400 Bad Request; Code: EQ-3142501; Message: Invalid argument value passed; Details: Invalid notification emails; AdditionalInfo: [{Property: /notifications/emails, Reason: Not Provided}]
│ 
│   with equinix_fabric_connection.aws-qinq,
│   on main.tf line 20, in resource "equinix_fabric_connection" "aws-qinq":
│   20: resource "equinix_fabric_connection" "aws-qinq" {
│ 
```