### PR TITLE
fix: equinix_fabric_cloud_router provisioning state and read schema

### DIFF
--- a/equinix/fabric_cloud_router_read_schema.go
+++ b/equinix/fabric_cloud_router_read_schema.go
@@ -47,17 +47,17 @@ func readCloudRouterResourceSchema() map[string]*schema.Schema {
 		"bgp_ipv4_routes_count": {
 			Type:        schema.TypeInt,
 			Computed:    true,
-			Description: "",
+			Description: "Access point used and maximum number of IPv4 BGP routes",
 		},
 		"bgp_ipv6_routes_count": {
 			Type:        schema.TypeInt,
 			Computed:    true,
-			Description: "",
+			Description: "Access point used and maximum number of IPv6 BGP routes",
 		},
 		"connections_count": {
 			Type:        schema.TypeInt,
 			Computed:    true,
-			Description: "",
+			Description: "Number of connections associated with this Access point",
 		},
 		"package": {
 			Type:        schema.TypeSet,

--- a/equinix/fabric_cloud_router_schema.go
+++ b/equinix/fabric_cloud_router_schema.go
@@ -149,5 +149,20 @@ func createCloudRouterResourceSchema() map[string]*schema.Schema {
 				Schema: createNotificationSch(),
 			},
 		},
+		"bgp_ipv4_routes_count": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Access point used and maximum number of IPv4 BGP routes",
+		},
+		"bgp_ipv6_routes_count": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Access point used and maximum number of IPv6 BGP routes",
+		},
+		"connections_count": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Number of connections associated with this Access point",
+		},
 	}
 }

--- a/equinix/fabric_mapping_helper.go
+++ b/equinix/fabric_mapping_helper.go
@@ -619,7 +619,7 @@ func additionalInfoToTerra(additionalInfol []v4.ConnectionSideAdditionalInfo) []
 	return mappedadditionalInfol
 }
 
-func CloudRouterToTerra(cloudRouter *v4.CloudRouter) *schema.Set {
+func cloudRouterToTerra(cloudRouter *v4.CloudRouter) *schema.Set {
 	if cloudRouter == nil {
 		return nil
 	}
@@ -637,7 +637,7 @@ func CloudRouterToTerra(cloudRouter *v4.CloudRouter) *schema.Set {
 	return linkedProtocolSet
 }
 
-func CloudRouterPackageToTerra(packageType *v4.CloudRouterPackageType) *schema.Set {
+func cloudRouterPackageToTerra(packageType *v4.CloudRouterPackageType) *schema.Set {
 	packageTypes := []*v4.CloudRouterPackageType{packageType}
 	mappedPackages := make([]interface{}, len(packageTypes))
 	for i, packageType := range packageTypes {
@@ -650,6 +650,26 @@ func CloudRouterPackageToTerra(packageType *v4.CloudRouterPackageType) *schema.S
 		mappedPackages,
 	)
 	return packageSet
+}
+
+func orderToTerra(order *v4.Order) *schema.Set {
+	if order == nil {
+		return nil
+	}
+	orders := []*v4.Order{order}
+	mappedOrders := make([]interface{}, len(orders))
+	for _, order := range orders {
+		mappedOrder := make(map[string]interface{})
+		mappedOrder["purchase_order_number"] = order.PurchaseOrderNumber
+		mappedOrder["billing_tier"] = order.BillingTier
+		mappedOrder["order_id"] = order.OrderId
+		mappedOrder["order_number"] = order.OrderNumber
+		mappedOrders = append(mappedOrders, mappedOrder)
+	}
+	orderSet := schema.NewSet(
+		schema.HashResource(readOrderRes),
+		mappedOrders)
+	return orderSet
 }
 
 func projectToTerra(project *v4.Project) *schema.Set {
@@ -729,7 +749,7 @@ func accessPointToTerra(accessPoint *v4.AccessPoint) *schema.Set {
 			mappedAccessPoint["profile"] = simplifiedServiceProfileToTerra(accessPoint.Profile)
 		}
 		if accessPoint.Router != nil {
-			mappedAccessPoint["router"] = CloudRouterToTerra(accessPoint.Router)
+			mappedAccessPoint["router"] = cloudRouterToTerra(accessPoint.Router)
 		}
 		if accessPoint.LinkProtocol != nil {
 			mappedAccessPoint["link_protocol"] = linkedProtocolToTerra(*accessPoint.LinkProtocol)

--- a/equinix/resource_fabric_cloud_router.go
+++ b/equinix/resource_fabric_cloud_router.go
@@ -97,16 +97,21 @@ func resourceCloudRouterRead(ctx context.Context, d *schema.ResourceData, meta i
 func setCloudRouterMap(d *schema.ResourceData, fcr v4.CloudRouter) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 	err := setMap(d, map[string]interface{}{
-		"name":          fcr.Name,
-		"href":          fcr.Href,
-		"type":          fcr.Type_,
-		"state":         fcr.State,
-		"package":       CloudRouterPackageToTerra(fcr.Package_),
-		"location":      locationCloudRouterToTerra(fcr.Location),
-		"change_log":    changeLogToTerra(fcr.ChangeLog),
-		"account":       accountCloudRouterToTerra(fcr.Account),
-		"notifications": notificationToTerra(fcr.Notifications),
-		"project":       projectToTerra(fcr.Project),
+		"name":                  fcr.Name,
+		"href":                  fcr.Href,
+		"type":                  fcr.Type_,
+		"state":                 fcr.State,
+		"package":               cloudRouterPackageToTerra(fcr.Package_),
+		"location":              locationCloudRouterToTerra(fcr.Location),
+		"change_log":            changeLogToTerra(fcr.ChangeLog),
+		"account":               accountCloudRouterToTerra(fcr.Account),
+		"notifications":         notificationToTerra(fcr.Notifications),
+		"project":               projectToTerra(fcr.Project),
+		"equinix_asn":           fcr.EquinixAsn,
+		"bgp_ipv4_routes_count": fcr.BgpIpv4RoutesCount,
+		"bgp_ipv6_routes_count": fcr.BgpIpv6RoutesCount,
+		"connections_count":     fcr.ConnectionsCount,
+		"order":                 orderToTerra(fcr.Order),
 	})
 	if err != nil {
 		return diag.FromErr(err)

--- a/equinix/resource_fabric_cloud_router.go
+++ b/equinix/resource_fabric_cloud_router.go
@@ -183,10 +183,9 @@ func waitUntilCloudRouterIsProvisioned(uuid string, meta interface{}, ctx contex
 	log.Printf("Waiting for Cloud Router to be provisioned, uuid %s", uuid)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
-			string(v4.PROVISIONED_CloudRouterAccessPointState),
+			string(v4.PROVISIONING_CloudRouterAccessPointState),
 		},
 		Target: []string{
-			string(v4.PENDING_INTERFACE_CONFIGURATION_EquinixStatus),
 			string(v4.PROVISIONED_CloudRouterAccessPointState),
 		},
 		Refresh: func() (interface{}, string, error) {

--- a/equinix/resource_fabric_cloud_router_acc_test.go
+++ b/equinix/resource_fabric_cloud_router_acc_test.go
@@ -20,7 +20,7 @@ func TestAccCloudRouterCreate(t *testing.T) {
 				Config: testAccCloudRouterCreateConfig("fg_tf_acc_test"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"equinix_fabric_cloud_router.test", "name", fmt.Sprint("fg_tf_acc_test")),
+						"equinix_fabric_cloud_router.test", "name", "fg_tf_acc_test"),
 				),
 				ExpectNonEmptyPlan: false,
 			},
@@ -28,7 +28,7 @@ func TestAccCloudRouterCreate(t *testing.T) {
 				Config: testAccCloudRouterCreateConfig("fg_tf_acc_update"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"equinix_fabric_cloud_router.test", "name", fmt.Sprint("fg_tf_acc_update")),
+						"equinix_fabric_cloud_router.test", "name", "fg_tf_acc_update"),
 				),
 				ExpectNonEmptyPlan: false,
 			},
@@ -59,22 +59,22 @@ func testAccCloudRouterCreateConfig(name string) string {
 			  metro_code  = "SV"
 			}
 			package{
-				  code = "PRO"
+				code = "PRO"
 			}
 			order{
 				purchase_order_number = "1-234567"
 			}
-			   notifications{
-				  type = "ALL"
-				  emails = [
+			notifications{
+				type = "ALL"
+				emails = [
 					"test@equinix.com",
 					"test1@equinix.com"
 				]
 			}
-				project{
-				   project_id = "776847000642406"
+			project{
+				project_id = "776847000642406"
 			}
-			  account {
+			account {
 				account_number = 203612
 			}
 		}`, name)
@@ -89,7 +89,7 @@ func TestAccCloudRouterRead(t *testing.T) {
 				Config: testAccCloudRouterReadConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"equinix_fabric_cloud_router.test", "name", fmt.Sprint("fcr_tf_acc_test")),
+						"equinix_fabric_cloud_router.test", "name", "fcr_tf_acc_test"),
 				),
 			},
 		},
@@ -97,7 +97,7 @@ func TestAccCloudRouterRead(t *testing.T) {
 }
 
 func testAccCloudRouterReadConfig() string {
-	return fmt.Sprint(`data "equinix_fabric_cloud_router" "test" {
+	return `data "equinix_fabric_cloud_router" "test" {
 		uuid = "3e91216d-526a-45d2-9029-0c8c8ba48b60"
-	}`)
+	}`
 }


### PR DESCRIPTION
fix #455 - assign missed values in setMap:
```
		"equinix_asn":           fcr.EquinixAsn,
		"bgp_ipv4_routes_count": fcr.BgpIpv4RoutesCount,
		"bgp_ipv6_routes_count": fcr.BgpIpv6RoutesCount,
		"connections_count":     fcr.ConnectionsCount,
		"order":                 orderToTerra(fcr.Order),
```
fix #456 
Update `waitUntilCloudRouterIsProvisioned` with values included in https://app.swaggerhub.com/apis/equinix-api/fabric/4.10#/CloudRouterAccessPointState (LOCKED not included due to lack of information, I don't know the FCR life cycle