### PR TITLE
fix: make correrlationI() function private

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,7 +186,7 @@ func (c *Config) NewFabricClient() *v4.APIClient {
 	authClient.Timeout = c.requestTimeout()
 	fabricHeaderMap := map[string]string{
 		"X-SOURCE":         "API",
-		"X-CORRELATION-ID": CorrelationId(25),
+		"X-CORRELATION-ID": correlationId(25),
 	}
 	v4Configuration := v4.Configuration{
 		BasePath:      c.BaseURL,

--- a/internal/config/correlation_id.go
+++ b/internal/config/correlation_id.go
@@ -11,7 +11,7 @@ const allowed_charset = "abcdefghijklmnopqrstuvwxyz" +
 var seededRand = rand.New(
 	rand.NewSource(time.Now().UnixNano()))
 
-func CorrelationIdWithCharset(length int, charset string) string {
+func correlationIdWithCharset(length int, charset string) string {
 	b := make([]byte, length)
 	for i := range b {
 		b[i] = charset[seededRand.Intn(len(charset))]
@@ -19,6 +19,6 @@ func CorrelationIdWithCharset(length int, charset string) string {
 	return string(b)
 }
 
-func CorrelationId(length int) string {
-	return CorrelationIdWithCharset(length, allowed_charset)
+func correlationId(length int) string {
+	return correlationIdWithCharset(length, allowed_charset)
 }


### PR DESCRIPTION
CorrelationId was moved to internal/config and accidental made public. This PR makes it private.