### PR TITLE
refactor: remove unnecessary wrappers for getting a random string or int

### DIFF
--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -446,14 +446,6 @@ func nprintf(format string, params map[string]interface{}) string {
 	return format
 }
 
-func randInt(n int) int {
-	return acctest.RandIntRange(0, n)
-}
-
-func randString(length int) string {
-	return acctest.RandString(length)
-}
-
 func getFromEnv(varName string) (string, error) {
 	if v := os.Getenv(varName); v != "" {
 		return v, nil

--- a/equinix/resource_ecx_l2_connection_acc_test.go
+++ b/equinix/resource_ecx_l2_connection_acc_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/equinix/ecx-go/v2"
 	"github.com/equinix/rest-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -85,12 +86,12 @@ func TestAccFabricL2Connection_Port_Single_AWS(t *testing.T) {
 		"port-name":                        portName.(string),
 		"connection-resourceName":          "test",
 		"connection-profile_name":          spName.(string),
-		"connection-name":                  fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"connection-name":                  fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"connection-speed":                 50,
 		"connection-speed_unit":            "MB",
 		"connection-notifications":         []string{"marry@equinix.com", "john@equinix.com"},
-		"connection-purchase_order_number": randString(10),
-		"connection-vlan_stag":             randInt(2000),
+		"connection-purchase_order_number": acctest.RandString(10),
+		"connection-vlan_stag":             acctest.RandIntRange(0, 2000),
 		"connection-seller_region":         "us-west-1",
 		"connection-seller_metro_code":     "SV",
 		"connection-authorization_key":     authKey.(string),
@@ -135,21 +136,21 @@ func TestAccFabricL2Connection_Port_HA_Azure(t *testing.T) {
 		"port-secondary_name":              secPortName.(string),
 		"connection-resourceName":          "test",
 		"connection-profile_name":          spName.(string),
-		"connection-name":                  fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"connection-name":                  fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"connection-speed":                 50,
 		"connection-speed_unit":            "MB",
 		"connection-notifications":         []string{"marry@equinix.com", "john@equinix.com"},
-		"connection-purchase_order_number": randString(10),
-		"connection-vlan_stag":             randInt(2000),
+		"connection-purchase_order_number": acctest.RandString(10),
+		"connection-vlan_stag":             acctest.RandIntRange(0, 2000),
 		"connection-seller_metro_code":     "LD",
 		"connection-authorization_key":     serviceKey,
 		"connection-named_tag":             "PRIVATE",
-		"connection-secondary_name":        fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"connection-secondary_vlan_stag":   randInt(2000),
+		"connection-secondary_name":        fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"connection-secondary_vlan_stag":   acctest.RandIntRange(0, 2000),
 	}
 	contextWithChanges := copyMap(context)
-	contextWithChanges["connection-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
-	contextWithChanges["connection-secondary_name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
+	contextWithChanges["connection-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
+	contextWithChanges["connection-secondary_name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
 	resourceName := fmt.Sprintf("equinix_ecx_l2_connection.%s", context["connection-resourceName"].(string))
 	var primary, secondary ecx.L2Connection
 	resource.ParallelTest(t, resource.TestCase{
@@ -207,35 +208,35 @@ func TestAccFabricL2Connection_Device_HA_GCP(t *testing.T) {
 		"device-account_name":                      accountName.(string),
 		"device-self_managed":                      true,
 		"device-byol":                              true,
-		"device-name":                              fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                              fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-metro_code":                        deviceMetro.(string),
 		"device-type_code":                         "PA-VM",
 		"device-package_code":                      "VM100",
 		"device-notifications":                     []string{"marry@equinix.com", "john@equinix.com"},
-		"device-hostname":                          fmt.Sprintf("tf-%s", randString(6)),
+		"device-hostname":                          fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-term_length":                       1,
 		"device-version":                           "9.0.4",
 		"device-core_count":                        2,
-		"device-purchase_order_number":             randString(10),
-		"device-order_reference":                   randString(10),
-		"device-secondary_name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"device-secondary_hostname":                fmt.Sprintf("tf-%s", randString(6)),
+		"device-purchase_order_number":             acctest.RandString(10),
+		"device-order_reference":                   acctest.RandString(10),
+		"device-secondary_name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"device-secondary_hostname":                fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-secondary_notifications":           []string{"secondary@equinix.com"},
 		"sshkey-resourceName":                      "test",
-		"sshkey-name":                              fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"sshkey-name":                              fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"sshkey-public_key":                        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXdzXBHaVpKpdO0udnB+4JOgUq7APO2rPXfrevvlZrps98AtlwXXVWZ5duRH5NFNfU4G9HCSiAPsebgjY0fG85tcShpXfHfACLt0tBW8XhfLQP2T6S50FQ1brBdURMDCMsD7duOXqvc0dlbs2/KcswHvuUmqVzob3bz7n1bQ48wIHsPg4ARqYhy5LN3OkllJH/6GEfqi8lKZx01/P/gmJMORcJujuOyXRB+F2iXBVYdhjML3Qg4+tEekBcVZOxUbERRZ0pvQ52Y6wUhn2VsjljixyqeOdmD0m6DayDQgSWms6bKPpBqN7zhXXk4qe8bXT4tQQba65b2CQ2A91jw2KgM/YZNmjyUJ+Rf1cQosJf9twqbAZDZ6rAEmj9zzvQ5vD/CGuzxdVMkePLlUK4VGjPu7cVzhXrnq4318WqZ5/lNiCST8NQ0fssChN8ANUzr/p/wwv3faFMVNmjxXTZMsbMFT/fbb2MVVuqNFN65drntlg6/xEao8gZROuRYiakBx8= user@host",
 		"connection-resourceName":                  "test",
-		"connection-name":                          fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"connection-name":                          fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"connection-profile_name":                  priSPName.(string),
 		"connection-speed":                         50,
 		"connection-speed_unit":                    "MB",
 		"connection-notifications":                 []string{"marry@equinix.com", "john@equinix.com"},
-		"connection-purchase_order_number":         randString(10),
+		"connection-purchase_order_number":         acctest.RandString(10),
 		"connection-seller_metro_code":             "SV",
 		"connection-seller_region":                 "us-west2",
 		"connection-authorization_key":             priServiceKey.(string),
 		"connection-device_interface_id":           5,
-		"connection-secondary_name":                fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"connection-secondary_name":                fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"connection-secondary_profile_name":        secSPName.(string),
 		"connection-secondary_speed":               100,
 		"connection-secondary_speed_unit":          "MB",

--- a/equinix/resource_ecx_l2_connection_test.go
+++ b/equinix/resource_ecx_l2_connection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/equinix/ecx-go/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -69,34 +70,34 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 	// given
 	d := schema.TestResourceDataRaw(t, createECXL2ConnectionResourceSchema(), make(map[string]interface{}))
 	input := &ecx.L2Connection{
-		UUID:                ecx.String(randString(36)),
-		Name:                ecx.String(randString(36)),
-		ProfileUUID:         ecx.String(randString(36)),
+		UUID:                ecx.String(acctest.RandString(36)),
+		Name:                ecx.String(acctest.RandString(36)),
+		ProfileUUID:         ecx.String(acctest.RandString(36)),
 		Speed:               ecx.Int(50),
 		SpeedUnit:           ecx.String("MB"),
 		Status:              ecx.String(ecx.ConnectionStatusProvisioned),
 		ProviderStatus:      ecx.String(ecx.ConnectionStatusProvisioned),
 		Notifications:       []string{"bla@bla.com"},
-		PurchaseOrderNumber: ecx.String(randString(10)),
-		PortUUID:            ecx.String(randString(36)),
-		DeviceUUID:          ecx.String(randString(36)),
-		VendorToken:         ecx.String(randString(36)),
-		VlanSTag:            ecx.Int(randInt(2000)),
-		VlanCTag:            ecx.Int(randInt(2000)),
-		NamedTag:            ecx.String(randString(100)),
-		AdditionalInfo:      []ecx.L2ConnectionAdditionalInfo{{Name: ecx.String(randString(10)), Value: ecx.String(randString(10))}},
-		ZSidePortUUID:       ecx.String(randString(36)),
-		ZSideVlanCTag:       ecx.Int(randInt(2000)),
-		ZSideVlanSTag:       ecx.Int(randInt(2000)),
-		SellerRegion:        ecx.String(randString(10)),
-		SellerMetroCode:     ecx.String(randString(2)),
-		AuthorizationKey:    ecx.String(randString(10)),
-		RedundancyGroup:     ecx.String(randString(36)),
-		RedundancyType:      ecx.String(randString(10)),
+		PurchaseOrderNumber: ecx.String(acctest.RandString(10)),
+		PortUUID:            ecx.String(acctest.RandString(36)),
+		DeviceUUID:          ecx.String(acctest.RandString(36)),
+		VendorToken:         ecx.String(acctest.RandString(36)),
+		VlanSTag:            ecx.Int(acctest.RandIntRange(0, 2000)),
+		VlanCTag:            ecx.Int(acctest.RandIntRange(0, 2000)),
+		NamedTag:            ecx.String(acctest.RandString(100)),
+		AdditionalInfo:      []ecx.L2ConnectionAdditionalInfo{{Name: ecx.String(acctest.RandString(10)), Value: ecx.String(acctest.RandString(10))}},
+		ZSidePortUUID:       ecx.String(acctest.RandString(36)),
+		ZSideVlanCTag:       ecx.Int(acctest.RandIntRange(0, 2000)),
+		ZSideVlanSTag:       ecx.Int(acctest.RandIntRange(0, 2000)),
+		SellerRegion:        ecx.String(acctest.RandString(10)),
+		SellerMetroCode:     ecx.String(acctest.RandString(2)),
+		AuthorizationKey:    ecx.String(acctest.RandString(10)),
+		RedundancyGroup:     ecx.String(acctest.RandString(36)),
+		RedundancyType:      ecx.String(acctest.RandString(10)),
 	}
-	prevServiceToken := ecx.String(randString(20))
+	prevServiceToken := ecx.String(acctest.RandString(20))
 	d.Set(ecxL2ConnectionSchemaNames["ServiceToken"], prevServiceToken)
-	prevZsideServiceToken := ecx.String(randString(20))
+	prevZsideServiceToken := ecx.String(acctest.RandString(20))
 	d.Set(ecxL2ConnectionSchemaNames["ZSideServiceToken"], prevZsideServiceToken)
 
 	// when
@@ -138,30 +139,30 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 func TestFabricL2Connection_flattenSecondary(t *testing.T) {
 	// given
 	input := &ecx.L2Connection{
-		UUID:             ecx.String(randString(36)),
-		Name:             ecx.String(randString(36)),
-		ProfileUUID:      ecx.String(randString(36)),
+		UUID:             ecx.String(acctest.RandString(36)),
+		Name:             ecx.String(acctest.RandString(36)),
+		ProfileUUID:      ecx.String(acctest.RandString(36)),
 		Speed:            ecx.Int(50),
 		SpeedUnit:        ecx.String("MB"),
 		Status:           ecx.String(ecx.ConnectionStatusProvisioned),
 		ProviderStatus:   ecx.String(ecx.ConnectionStatusProvisioned),
-		PortUUID:         ecx.String(randString(36)),
-		DeviceUUID:       ecx.String(randString(36)),
-		VlanSTag:         ecx.Int(randInt(2000)),
-		VlanCTag:         ecx.Int(randInt(2000)),
-		ZSidePortUUID:    ecx.String(randString(36)),
-		ZSideVlanCTag:    ecx.Int(randInt(2000)),
-		ZSideVlanSTag:    ecx.Int(randInt(2000)),
-		SellerRegion:     ecx.String(randString(10)),
-		SellerMetroCode:  ecx.String(randString(2)),
-		AuthorizationKey: ecx.String(randString(10)),
-		RedundancyGroup:  ecx.String(randString(10)),
-		RedundancyType:   ecx.String(randString(10)),
-		VendorToken:      ecx.String(randString(36)),
+		PortUUID:         ecx.String(acctest.RandString(36)),
+		DeviceUUID:       ecx.String(acctest.RandString(36)),
+		VlanSTag:         ecx.Int(acctest.RandIntRange(0, 2000)),
+		VlanCTag:         ecx.Int(acctest.RandIntRange(0, 2000)),
+		ZSidePortUUID:    ecx.String(acctest.RandString(36)),
+		ZSideVlanCTag:    ecx.Int(acctest.RandIntRange(0, 2000)),
+		ZSideVlanSTag:    ecx.Int(acctest.RandIntRange(0, 2000)),
+		SellerRegion:     ecx.String(acctest.RandString(10)),
+		SellerMetroCode:  ecx.String(acctest.RandString(2)),
+		AuthorizationKey: ecx.String(acctest.RandString(10)),
+		RedundancyGroup:  ecx.String(acctest.RandString(10)),
+		RedundancyType:   ecx.String(acctest.RandString(10)),
+		VendorToken:      ecx.String(acctest.RandString(36)),
 	}
 	previousInput := &ecx.L2Connection{
-		DeviceInterfaceID: ecx.Int(randInt(10)),
-		ServiceToken:      ecx.String(randString(36)),
+		DeviceInterfaceID: ecx.Int(acctest.RandIntRange(0, 10)),
+		ServiceToken:      ecx.String(acctest.RandString(36)),
 	}
 	expected := []interface{}{
 		map[string]interface{}{
@@ -246,8 +247,8 @@ func TestFabricL2Connection_flattenAdditionalInfo(t *testing.T) {
 	// given
 	input := []ecx.L2ConnectionAdditionalInfo{
 		{
-			Name:  ecx.String(randString(32)),
-			Value: ecx.String(randString(32)),
+			Name:  ecx.String(acctest.RandString(32)),
+			Value: ecx.String(acctest.RandString(32)),
 		},
 	}
 	expected := []interface{}{
@@ -271,8 +272,8 @@ func TestFabricL2Connection_expandAdditionalInfo(t *testing.T) {
 	// given
 	input := schema.NewSet(f, []interface{}{
 		map[string]interface{}{
-			ecxL2ConnectionAdditionalInfoSchemaNames["Name"]:  randString(36),
-			ecxL2ConnectionAdditionalInfoSchemaNames["Value"]: randString(36),
+			ecxL2ConnectionAdditionalInfoSchemaNames["Name"]:  acctest.RandString(36),
+			ecxL2ConnectionAdditionalInfoSchemaNames["Value"]: acctest.RandString(36),
 		},
 	})
 	inputList := input.List()
@@ -293,16 +294,16 @@ func TestFabricL2Connection_flattenActions(t *testing.T) {
 	// given
 	input := []ecx.L2ConnectionAction{
 		{
-			Type:        ecx.String(randString(32)),
-			OperationID: ecx.String(randString(32)),
-			Message:     ecx.String(randString(32)),
+			Type:        ecx.String(acctest.RandString(32)),
+			OperationID: ecx.String(acctest.RandString(32)),
+			Message:     ecx.String(acctest.RandString(32)),
 			RequiredData: []ecx.L2ConnectionActionData{
 				{
-					Key:               ecx.String(randString(10)),
-					Label:             ecx.String(randString(10)),
-					Value:             ecx.String(randString(10)),
+					Key:               ecx.String(acctest.RandString(10)),
+					Label:             ecx.String(acctest.RandString(10)),
+					Value:             ecx.String(acctest.RandString(10)),
 					IsEditable:        ecx.Bool(true),
-					ValidationPattern: ecx.String(randString(10)),
+					ValidationPattern: ecx.String(acctest.RandString(10)),
 				},
 			},
 		},
@@ -365,7 +366,7 @@ func TestFabricL2Connection_fillUpdateRequest(t *testing.T) {
 	// given
 	updateReq := mockedL2ConnectionUpdateRequest{}
 	changes := map[string]interface{}{
-		ecxL2ConnectionSchemaNames["Name"]:      randString(32),
+		ecxL2ConnectionSchemaNames["Name"]:      acctest.RandString(32),
 		ecxL2ConnectionSchemaNames["Speed"]:     50,
 		ecxL2ConnectionSchemaNames["SpeedUnit"]: "MB",
 	}

--- a/equinix/resource_ecx_l2_serviceprofile_acc_test.go
+++ b/equinix/resource_ecx_l2_serviceprofile_acc_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/equinix/ecx-go/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -17,8 +18,8 @@ func TestAccFabricL2ServiceProfile_Private(t *testing.T) {
 	secPortName, _ := schema.EnvDefaultFunc(secPortEnvVar, "sit-001-CX-SV5-NL-Dot1q-BO-10G-SEC-JUN-36")()
 	context := map[string]interface{}{
 		"resourceName":                       "test",
-		"name":                               fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"description":                        randString(100),
+		"name":                               fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"description":                        acctest.RandString(100),
 		"bandwidth_threshold_notifications":  []string{"John.Doe@example.com", "Marry.Doe@example.com"},
 		"profile_statuschange_notifications": []string{"John.Doe@example.com", "Marry.Doe@example.com"},
 		"vc_statuschange_notifications":      []string{"John.Doe@example.com", "Marry.Doe@example.com"},

--- a/equinix/resource_network_acl_template_acc_test.go
+++ b/equinix/resource_network_acl_template_acc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/equinix/ne-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -55,13 +56,13 @@ func testSweepNetworkACLTemplate(region string) error {
 func TestAccNetworkACLTemplate(t *testing.T) {
 	context := map[string]interface{}{
 		"resourceName":               "test",
-		"name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"description":                randString(50),
+		"name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"description":                acctest.RandString(50),
 		"inbound_rule_1_subnet":      "10.0.0.0/16",
 		"inbound_rule_1_protocol":    "TCP",
 		"inbound_rule_1_src_port":    "any",
 		"inbound_rule_1_dst_port":    "22-23",
-		"inbound_rule_1_description": randString(50),
+		"inbound_rule_1_description": acctest.RandString(50),
 		"inbound_rule_2_subnet":      "192.168.16.0/24",
 		"inbound_rule_2_protocol":    "UDP",
 		"inbound_rule_2_src_port":    "any",
@@ -72,8 +73,8 @@ func TestAccNetworkACLTemplate(t *testing.T) {
 		"inbound_rule_3_dst_port":    "any",
 	}
 	contextWithChanges := copyMap(context)
-	contextWithChanges["description"] = randString(50)
-	contextWithChanges["inbound_rule_1_description"] = randString(50)
+	contextWithChanges["description"] = acctest.RandString(50)
+	contextWithChanges["inbound_rule_1_description"] = acctest.RandString(50)
 	contextWithChanges["inbound_rule_3_subnet"] = "4.4.4.4/32"
 	contextWithChanges["inbound_rule_3_protocol"] = "TCP"
 	contextWithChanges["inbound_rule_3_dst_port"] = "2048"

--- a/equinix/resource_network_bgp_acc_test.go
+++ b/equinix/resource_network_bgp_acc_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/equinix/ne-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -22,22 +23,22 @@ func TestAccNetworkBGP_CSR1000V_Single_AWS(t *testing.T) {
 		"device-account_name":          accountName.(string),
 		"device-self_managed":          false,
 		"device-byol":                  false,
-		"device-name":                  fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                  fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-throughput":            500,
 		"device-throughput_unit":       "Mbps",
 		"device-metro_code":            metro.(string),
 		"device-type_code":             "CSR1000V",
 		"device-package_code":          "SEC",
 		"device-notifications":         []string{"marry@equinix.com", "john@equinix.com"},
-		"device-hostname":              fmt.Sprintf("tf-%s", randString(6)),
+		"device-hostname":              fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-term_length":           1,
 		"device-version":               "16.09.05",
 		"device-core_count":            2,
 		"user-resourceName":            "test",
-		"user-username":                fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"user-password":                randString(10),
+		"user-username":                fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"user-password":                acctest.RandString(10),
 		"connection-resourceName":      "test",
-		"connection-name":              fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"connection-name":              fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"connection-profile_name":      spName.(string),
 		"connection-speed":             50,
 		"connection-speed_unit":        "MB",
@@ -52,7 +53,7 @@ func TestAccNetworkBGP_CSR1000V_Single_AWS(t *testing.T) {
 		"bgp-remote_asn":               22211,
 	}
 	contextWithChanges := copyMap(context)
-	contextWithChanges["bgp-authentication_key"] = randString(10)
+	contextWithChanges["bgp-authentication_key"] = acctest.RandString(10)
 	resourceName := fmt.Sprintf("equinix_network_bgp.%s", context["bgp-resourceName"].(string))
 	var bgpConfig ne.BGPConfiguration
 	resource.ParallelTest(t, resource.TestCase{

--- a/equinix/resource_network_device_acc_test.go
+++ b/equinix/resource_network_device_acc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/equinix/ne-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -90,36 +91,36 @@ func TestAccNetworkDevice_CSR1000V_HA_Managed_Sub(t *testing.T) {
 		"device-account_name":            accountName.(string),
 		"device-self_managed":            false,
 		"device-byol":                    false,
-		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-throughput":              500,
 		"device-throughput_unit":         "Mbps",
 		"device-metro_code":              metro.(string),
 		"device-type_code":               "CSR1000V",
 		"device-package_code":            "SEC",
 		"device-notifications":           []string{"marry@equinix.com", "john@equinix.com"},
-		"device-hostname":                fmt.Sprintf("tf-%s", randString(41)),
+		"device-hostname":                fmt.Sprintf("tf-%s", acctest.RandString(41)),
 		"device-term_length":             1,
 		"device-version":                 "16.09.05",
 		"device-core_count":              2,
-		"device-purchase_order_number":   randString(10),
-		"device-order_reference":         randString(10),
+		"device-purchase_order_number":   acctest.RandString(10),
+		"device-order_reference":         acctest.RandString(10),
 		"device-interface_count":         24,
 		"device-additional_bandwidth":    0,
-		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"device-secondary_hostname":      fmt.Sprintf("tf-%s", randString(6)),
+		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"device-secondary_hostname":      fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-secondary_notifications": []string{"secondary@equinix.com"},
 		"user-resourceName":              "tst-user",
-		"user-username":                  fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"user-password":                  randString(10),
+		"user-username":                  fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"user-password":                  acctest.RandString(10),
 	}
 
 	contextWithACLs := copyMap(context)
 	contextWithACLs["acl-resourceName"] = "acl-pri"
-	contextWithACLs["acl-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
-	contextWithACLs["acl-description"] = randString(50)
+	contextWithACLs["acl-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
+	contextWithACLs["acl-description"] = acctest.RandString(50)
 	contextWithACLs["acl-secondary_resourceName"] = "acl-sec"
-	contextWithACLs["acl-secondary_name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
-	contextWithACLs["acl-secondary_description"] = randString(50)
+	contextWithACLs["acl-secondary_name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
+	contextWithACLs["acl-secondary_description"] = acctest.RandString(50)
 	deviceResourceName := fmt.Sprintf("equinix_network_device.%s", context["device-resourceName"].(string))
 	userResourceName := fmt.Sprintf("equinix_network_ssh_user.%s", context["user-resourceName"].(string))
 	priACLResourceName := fmt.Sprintf("equinix_network_acl_template.%s", contextWithACLs["acl-resourceName"].(string))
@@ -178,34 +179,34 @@ func TestAccNetworkDevice_CSR1000V_HA_Self_BYOL(t *testing.T) {
 		"device-account_name":            accountName.(string),
 		"device-self_managed":            true,
 		"device-byol":                    true,
-		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-throughput":              500,
 		"device-throughput_unit":         "Mbps",
 		"device-metro_code":              metro.(string),
 		"device-type_code":               "CSR1000V",
 		"device-package_code":            "SEC",
 		"device-notifications":           []string{"marry@equinix.com", "john@equinix.com"},
-		"device-hostname":                fmt.Sprintf("tf-%s", randString(6)),
+		"device-hostname":                fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-term_length":             1,
 		"device-version":                 "16.09.05",
 		"device-core_count":              2,
-		"device-purchase_order_number":   randString(10),
-		"device-order_reference":         randString(10),
-		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"device-secondary_hostname":      fmt.Sprintf("tf-%s", randString(6)),
+		"device-purchase_order_number":   acctest.RandString(10),
+		"device-order_reference":         acctest.RandString(10),
+		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"device-secondary_hostname":      fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-secondary_notifications": []string{"secondary@equinix.com"},
 		"sshkey-resourceName":            "test",
-		"sshkey-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"sshkey-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"sshkey-public_key":              "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXdzXBHaVpKpdO0udnB+4JOgUq7APO2rPXfrevvlZrps98AtlwXXVWZ5duRH5NFNfU4G9HCSiAPsebgjY0fG85tcShpXfHfACLt0tBW8XhfLQP2T6S50FQ1brBdURMDCMsD7duOXqvc0dlbs2/KcswHvuUmqVzob3bz7n1bQ48wIHsPg4ARqYhy5LN3OkllJH/6GEfqi8lKZx01/P/gmJMORcJujuOyXRB+F2iXBVYdhjML3Qg4+tEekBcVZOxUbERRZ0pvQ52Y6wUhn2VsjljixyqeOdmD0m6DayDQgSWms6bKPpBqN7zhXXk4qe8bXT4tQQba65b2CQ2A91jw2KgM/YZNmjyUJ+Rf1cQosJf9twqbAZDZ6rAEmj9zzvQ5vD/CGuzxdVMkePLlUK4VGjPu7cVzhXrnq4318WqZ5/lNiCST8NQ0fssChN8ANUzr/p/wwv3faFMVNmjxXTZMsbMFT/fbb2MVVuqNFN65drntlg6/xEao8gZROuRYiakBx8= user@host",
 	}
 
 	contextWithACLs := copyMap(context)
 	contextWithACLs["acl-resourceName"] = "acl-pri"
-	contextWithACLs["acl-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
-	contextWithACLs["acl-description"] = randString(50)
+	contextWithACLs["acl-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
+	contextWithACLs["acl-description"] = acctest.RandString(50)
 	contextWithACLs["acl-secondary_resourceName"] = "acl-sec"
-	contextWithACLs["acl-secondary_name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
-	contextWithACLs["acl-secondary_description"] = randString(50)
+	contextWithACLs["acl-secondary_name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
+	contextWithACLs["acl-secondary_description"] = acctest.RandString(50)
 	deviceResourceName := fmt.Sprintf("equinix_network_device.%s", context["device-resourceName"].(string))
 	priACLResourceName := fmt.Sprintf("equinix_network_acl_template.%s", contextWithACLs["acl-resourceName"].(string))
 	secACLResourceName := fmt.Sprintf("equinix_network_acl_template.%s", contextWithACLs["acl-secondary_resourceName"].(string))
@@ -254,26 +255,26 @@ func TestAccNetworkDevice_vSRX_HA_Managed_Sub(t *testing.T) {
 		"device-account_name":            accountName.(string),
 		"device-self_managed":            false,
 		"device-byol":                    false,
-		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-metro_code":              metro.(string),
 		"device-type_code":               "VSRX",
 		"device-package_code":            "STD",
 		"device-notifications":           []string{"marry@equinix.com", "john@equinix.com"},
-		"device-hostname":                fmt.Sprintf("tf-%s", randString(6)),
+		"device-hostname":                fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-term_length":             1,
 		"device-version":                 "19.2R2.7",
 		"device-core_count":              2,
-		"device-purchase_order_number":   randString(10),
-		"device-order_reference":         randString(10),
-		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"device-secondary_hostname":      fmt.Sprintf("tf-%s", randString(6)),
+		"device-purchase_order_number":   acctest.RandString(10),
+		"device-order_reference":         acctest.RandString(10),
+		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"device-secondary_hostname":      fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-secondary_notifications": []string{"secondary@equinix.com"},
 	}
 
 	contextWithChanges := copyMap(context)
 	contextWithChanges["user-resourceName"] = "test"
-	contextWithChanges["user-username"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
-	contextWithChanges["user-password"] = randString(10)
+	contextWithChanges["user-username"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
+	contextWithChanges["user-password"] = acctest.RandString(10)
 	deviceResourceName := fmt.Sprintf("equinix_network_device.%s", context["device-resourceName"].(string))
 	userResourceName := fmt.Sprintf("equinix_network_ssh_user.%s", contextWithChanges["user-resourceName"].(string))
 	var primary, secondary ne.Device
@@ -324,40 +325,40 @@ func TestAccNetworkDevice_vSRX_HA_Managed_BYOL(t *testing.T) {
 		"device-account_name":            accountName.(string),
 		"device-self_managed":            false,
 		"device-byol":                    true,
-		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-license_file":            licenseFile.(string),
 		"device-metro_code":              metro.(string),
 		"device-type_code":               "VSRX",
 		"device-package_code":            "STD",
 		"device-notifications":           []string{"marry@equinix.com", "john@equinix.com"},
-		"device-hostname":                fmt.Sprintf("tf-%s", randString(6)),
+		"device-hostname":                fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-term_length":             1,
 		"device-version":                 "19.2R2.7",
 		"device-core_count":              2,
-		"device-purchase_order_number":   randString(10),
-		"device-order_reference":         randString(10),
-		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-purchase_order_number":   acctest.RandString(10),
+		"device-order_reference":         acctest.RandString(10),
+		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-secondary_license_file":  licenseFile.(string),
-		"device-secondary_hostname":      fmt.Sprintf("tf-%s", randString(6)),
+		"device-secondary_hostname":      fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-secondary_notifications": []string{"secondary@equinix.com"},
 		"acl-resourceName":               "acl-pri",
-		"acl-name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-description":                randString(50),
+		"acl-name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-description":                acctest.RandString(50),
 		"acl-secondary_resourceName":     "acl-sec",
-		"acl-secondary_name":             fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-secondary_description":      randString(50),
+		"acl-secondary_name":             fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-secondary_description":      acctest.RandString(50),
 	}
 
 	contextWithChanges := copyMap(context)
-	contextWithChanges["device-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
+	contextWithChanges["device-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
 	contextWithChanges["device-additional_bandwidth"] = 100
 	contextWithChanges["device-notifications"] = []string{"jerry@equinix.com", "tom@equinix.com"}
-	contextWithChanges["device-secondary_name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
+	contextWithChanges["device-secondary_name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
 	contextWithChanges["device-secondary_additional_bandwidth"] = 100
 	contextWithChanges["device-secondary_notifications"] = []string{"miki@equinix.com", "mini@equinix.com"}
 	contextWithChanges["user-resourceName"] = "test"
-	contextWithChanges["user-username"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
-	contextWithChanges["user-password"] = randString(10)
+	contextWithChanges["user-username"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
+	contextWithChanges["user-password"] = acctest.RandString(10)
 	deviceResourceName := fmt.Sprintf("equinix_network_device.%s", context["device-resourceName"].(string))
 	userResourceName := fmt.Sprintf("equinix_network_ssh_user.%s", contextWithChanges["user-resourceName"].(string))
 	var primary, secondary ne.Device
@@ -406,28 +407,28 @@ func TestAccNetworkDevice_vSRX_HA_Self_BYOL(t *testing.T) {
 		"device-account_name":            accountName.(string),
 		"device-self_managed":            true,
 		"device-byol":                    true,
-		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-metro_code":              metro.(string),
 		"device-type_code":               "VSRX",
 		"device-package_code":            "STD",
 		"device-notifications":           []string{"marry@equinix.com", "john@equinix.com"},
-		"device-hostname":                fmt.Sprintf("tf-%s", randString(6)),
+		"device-hostname":                fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-term_length":             1,
 		"device-version":                 "19.2R2.7",
 		"device-core_count":              2,
-		"device-purchase_order_number":   randString(10),
-		"device-order_reference":         randString(10),
-		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"device-secondary_hostname":      fmt.Sprintf("tf-%s", randString(6)),
+		"device-purchase_order_number":   acctest.RandString(10),
+		"device-order_reference":         acctest.RandString(10),
+		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"device-secondary_hostname":      fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-secondary_notifications": []string{"secondary@equinix.com"},
 		"acl-resourceName":               "acl-pri",
-		"acl-name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-description":                randString(50),
+		"acl-name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-description":                acctest.RandString(50),
 		"acl-secondary_resourceName":     "acl-sec",
-		"acl-secondary_name":             fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-secondary_description":      randString(50),
+		"acl-secondary_name":             fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-secondary_description":      acctest.RandString(50),
 		"sshkey-resourceName":            "test",
-		"sshkey-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"sshkey-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"sshkey-public_key":              "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXdzXBHaVpKpdO0udnB+4JOgUq7APO2rPXfrevvlZrps98AtlwXXVWZ5duRH5NFNfU4G9HCSiAPsebgjY0fG85tcShpXfHfACLt0tBW8XhfLQP2T6S50FQ1brBdURMDCMsD7duOXqvc0dlbs2/KcswHvuUmqVzob3bz7n1bQ48wIHsPg4ARqYhy5LN3OkllJH/6GEfqi8lKZx01/P/gmJMORcJujuOyXRB+F2iXBVYdhjML3Qg4+tEekBcVZOxUbERRZ0pvQ52Y6wUhn2VsjljixyqeOdmD0m6DayDQgSWms6bKPpBqN7zhXXk4qe8bXT4tQQba65b2CQ2A91jw2KgM/YZNmjyUJ+Rf1cQosJf9twqbAZDZ6rAEmj9zzvQ5vD/CGuzxdVMkePLlUK4VGjPu7cVzhXrnq4318WqZ5/lNiCST8NQ0fssChN8ANUzr/p/wwv3faFMVNmjxXTZMsbMFT/fbb2MVVuqNFN65drntlg6/xEao8gZROuRYiakBx8= user@host",
 	}
 
@@ -462,34 +463,34 @@ func TestAccNetworkDevice_PaloAlto_HA_Managed_Sub(t *testing.T) {
 		"device-account_name":            accountName.(string),
 		"device-self_managed":            false,
 		"device-byol":                    false,
-		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-metro_code":              metro.(string),
 		"device-type_code":               "PA-VM",
 		"device-package_code":            "VM100",
 		"device-notifications":           []string{"marry@equinix.com", "john@equinix.com"},
-		"device-hostname":                fmt.Sprintf("tf-%s", randString(6)),
+		"device-hostname":                fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-term_length":             1,
 		"device-version":                 "9.0.4",
 		"device-core_count":              2,
-		"device-purchase_order_number":   randString(10),
-		"device-order_reference":         randString(10),
-		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"device-secondary_hostname":      fmt.Sprintf("tf-%s", randString(6)),
+		"device-purchase_order_number":   acctest.RandString(10),
+		"device-order_reference":         acctest.RandString(10),
+		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"device-secondary_hostname":      fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-secondary_notifications": []string{"secondary@equinix.com"},
 		"acl-resourceName":               "acl-pri",
-		"acl-name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-description":                randString(50),
+		"acl-name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-description":                acctest.RandString(50),
 		"acl-secondary_resourceName":     "acl-sec",
-		"acl-secondary_name":             fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-secondary_description":      randString(50),
+		"acl-secondary_name":             fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-secondary_description":      acctest.RandString(50),
 	}
 
 	contextWithChanges := copyMap(context)
 	contextWithChanges["device-additional_bandwidth"] = 50
 	contextWithChanges["device-secondary_additional_bandwidth"] = 50
 	contextWithChanges["user-resourceName"] = "tst-user"
-	contextWithChanges["user-username"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
-	contextWithChanges["user-password"] = randString(10)
+	contextWithChanges["user-username"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
+	contextWithChanges["user-password"] = acctest.RandString(10)
 	var primary, secondary ne.Device
 	var primaryACL, secondaryACL ne.ACLTemplate
 	var user ne.SSHUser
@@ -546,32 +547,32 @@ func TestAccNetworkDevice_PaloAlto_HA_Self_BYOL(t *testing.T) {
 		"device-self_managed":            true,
 		"connectivity":                   "PRIVATE",
 		"device-byol":                    true,
-		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-metro_code":              metro.(string),
 		"device-type_code":               "PA-VM",
 		"device-package_code":            "VM100",
 		"device-notifications":           []string{"marry@equinix.com", "john@equinix.com"},
-		"device-hostname":                fmt.Sprintf("tf-%s", randString(6)),
+		"device-hostname":                fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-term_length":             1,
 		"device-version":                 "9.0.4",
 		"device-core_count":              2,
-		"device-purchase_order_number":   randString(10),
-		"device-order_reference":         randString(10),
-		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"device-secondary_hostname":      fmt.Sprintf("tf-%s", randString(6)),
+		"device-purchase_order_number":   acctest.RandString(10),
+		"device-order_reference":         acctest.RandString(10),
+		"device-secondary_name":          fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"device-secondary_hostname":      fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-secondary_notifications": []string{"secondary@equinix.com"},
 		"sshkey-resourceName":            "test",
-		"sshkey-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"sshkey-name":                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"sshkey-public_key":              "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXdzXBHaVpKpdO0udnB+4JOgUq7APO2rPXfrevvlZrps98AtlwXXVWZ5duRH5NFNfU4G9HCSiAPsebgjY0fG85tcShpXfHfACLt0tBW8XhfLQP2T6S50FQ1brBdURMDCMsD7duOXqvc0dlbs2/KcswHvuUmqVzob3bz7n1bQ48wIHsPg4ARqYhy5LN3OkllJH/6GEfqi8lKZx01/P/gmJMORcJujuOyXRB+F2iXBVYdhjML3Qg4+tEekBcVZOxUbERRZ0pvQ52Y6wUhn2VsjljixyqeOdmD0m6DayDQgSWms6bKPpBqN7zhXXk4qe8bXT4tQQba65b2CQ2A91jw2KgM/YZNmjyUJ+Rf1cQosJf9twqbAZDZ6rAEmj9zzvQ5vD/CGuzxdVMkePLlUK4VGjPu7cVzhXrnq4318WqZ5/lNiCST8NQ0fssChN8ANUzr/p/wwv3faFMVNmjxXTZMsbMFT/fbb2MVVuqNFN65drntlg6/xEao8gZROuRYiakBx8= user@host",
 	}
 
 	contextWithACLs := copyMap(context)
 	contextWithACLs["acl-resourceName"] = "acl-pri"
-	contextWithACLs["acl-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
-	contextWithACLs["acl-description"] = randString(50)
+	contextWithACLs["acl-name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
+	contextWithACLs["acl-description"] = acctest.RandString(50)
 	contextWithACLs["acl-secondary_resourceName"] = "acl-sec"
-	contextWithACLs["acl-secondary_name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6))
-	contextWithACLs["acl-secondary_description"] = randString(50)
+	contextWithACLs["acl-secondary_name"] = fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6))
+	contextWithACLs["acl-secondary_description"] = acctest.RandString(50)
 	deviceResourceName := fmt.Sprintf("equinix_network_device.%s", context["device-resourceName"].(string))
 	priACLResourceName := fmt.Sprintf("equinix_network_acl_template.%s", contextWithACLs["acl-resourceName"].(string))
 	secACLResourceName := fmt.Sprintf("equinix_network_acl_template.%s", contextWithACLs["acl-secondary_resourceName"].(string))
@@ -620,7 +621,7 @@ func TestAccNetworkDevice_CSRSDWAN_HA_Self_BYOL(t *testing.T) {
 		"device-account_name":                           accountName.(string),
 		"device-self_managed":                           true,
 		"device-byol":                                   true,
-		"device-name":                                   fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                                   fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-metro_code":                             metro.(string),
 		"device-license_file":                           licFile.(string),
 		"device-throughput":                             250,
@@ -631,23 +632,23 @@ func TestAccNetworkDevice_CSRSDWAN_HA_Self_BYOL(t *testing.T) {
 		"device-term_length":                            1,
 		"device-version":                                "16.12.3",
 		"device-core_count":                             2,
-		"device-purchase_order_number":                  randString(10),
-		"device-order_reference":                        randString(10),
+		"device-purchase_order_number":                  acctest.RandString(10),
+		"device-order_reference":                        acctest.RandString(10),
 		"device-vendorConfig_enabled":                   true,
 		"device-vendorConfig_siteId":                    "10",
 		"device-vendorConfig_systemIpAddress":           "1.1.1.1",
-		"device-secondary_name":                         fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-secondary_name":                         fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-secondary_license_file":                 licFile.(string),
 		"device-secondary_notifications":                []string{"secondary@equinix.com"},
 		"device-secondary_vendorConfig_enabled":         true,
 		"device-secondary_vendorConfig_siteId":          "20",
 		"device-secondary_vendorConfig_systemIpAddress": "2.2.2.2",
 		"acl-resourceName":                              "acl-pri",
-		"acl-name":                                      fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-description":                               randString(50),
+		"acl-name":                                      fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-description":                               acctest.RandString(50),
 		"acl-secondary_resourceName":                    "acl-sec",
-		"acl-secondary_name":                            fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-secondary_description":                     randString(50),
+		"acl-secondary_name":                            fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-secondary_description":                     acctest.RandString(50),
 	}
 
 	deviceResourceName := fmt.Sprintf("equinix_network_device.%s", context["device-resourceName"].(string))
@@ -697,7 +698,7 @@ func TestAccNetworkDevice_Versa_HA_Self_BYOL(t *testing.T) {
 		"device-account_name":                        accountName.(string),
 		"device-self_managed":                        true,
 		"device-byol":                                true,
-		"device-name":                                fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                                fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-metro_code":                          metro.(string),
 		"device-type_code":                           "VERSA_SDWAN",
 		"device-package_code":                        "FLEX_VNF_2",
@@ -705,15 +706,15 @@ func TestAccNetworkDevice_Versa_HA_Self_BYOL(t *testing.T) {
 		"device-term_length":                         1,
 		"device-version":                             "16.1R2S8",
 		"device-core_count":                          2,
-		"device-purchase_order_number":               randString(10),
-		"device-order_reference":                     randString(10),
+		"device-purchase_order_number":               acctest.RandString(10),
+		"device-order_reference":                     acctest.RandString(10),
 		"device-vendorConfig_enabled":                true,
 		"device-vendorConfig_controller1":            controller1.(string),
 		"device-vendorConfig_controller2":            controller2.(string),
 		"device-vendorConfig_localId":                localID.(string),
 		"device-vendorConfig_remoteId":               remoteID.(string),
 		"device-vendorConfig_serialNumber":           serialNumber.(string),
-		"device-secondary_name":                      fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-secondary_name":                      fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-secondary_notifications":             []string{"secondary@equinix.com"},
 		"device-secondary_vendorConfig_enabled":      true,
 		"device-secondary_vendorConfig_controller1":  controller1.(string),
@@ -722,11 +723,11 @@ func TestAccNetworkDevice_Versa_HA_Self_BYOL(t *testing.T) {
 		"device-secondary_vendorConfig_remoteId":     remoteID.(string),
 		"device-secondary_vendorConfig_serialNumber": serialNumber.(string),
 		"acl-resourceName":                           "acl-pri",
-		"acl-name":                                   fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-description":                            randString(50),
+		"acl-name":                                   fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-description":                            acctest.RandString(50),
 		"acl-secondary_resourceName":                 "acl-sec",
-		"acl-secondary_name":                         fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-secondary_description":                  randString(50),
+		"acl-secondary_name":                         fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-secondary_description":                  acctest.RandString(50),
 	}
 
 	deviceResourceName := fmt.Sprintf("equinix_network_device.%s", context["device-resourceName"].(string))
@@ -764,14 +765,14 @@ func TestAccNetworkDevice_Versa_HA_Self_BYOL(t *testing.T) {
 func TestAccNetworkDevice_CGENIX_HA_Self_BYOL(t *testing.T) {
 	metro, _ := schema.EnvDefaultFunc(networkDeviceMetroEnvVar, "SV")()
 	accountName, _ := schema.EnvDefaultFunc(networkDeviceAccountNameEnvVar, "")()
-	licenseKey, _ := schema.EnvDefaultFunc(networkDeviceCGENIXLicenseKeyEnvVar, randString(10))()
-	licenseSecret, _ := schema.EnvDefaultFunc(networkDeviceCGENIXLicenseSecretEnvVar, randString(10))()
+	licenseKey, _ := schema.EnvDefaultFunc(networkDeviceCGENIXLicenseKeyEnvVar, acctest.RandString(10))()
+	licenseSecret, _ := schema.EnvDefaultFunc(networkDeviceCGENIXLicenseSecretEnvVar, acctest.RandString(10))()
 	context := map[string]interface{}{
 		"device-resourceName":                         "test",
 		"device-account_name":                         accountName.(string),
 		"device-self_managed":                         true,
 		"device-byol":                                 true,
-		"device-name":                                 fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                                 fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-metro_code":                           metro.(string),
 		"device-type_code":                            "CGENIXSDWAN",
 		"device-package_code":                         "3102V",
@@ -779,22 +780,22 @@ func TestAccNetworkDevice_CGENIX_HA_Self_BYOL(t *testing.T) {
 		"device-term_length":                          1,
 		"device-version":                              "5.2.1-b11",
 		"device-core_count":                           2,
-		"device-purchase_order_number":                randString(10),
-		"device-order_reference":                      randString(10),
+		"device-purchase_order_number":                acctest.RandString(10),
+		"device-order_reference":                      acctest.RandString(10),
 		"device-vendorConfig_enabled":                 true,
 		"device-vendorConfig_licenseKey":              licenseKey.(string),
 		"device-vendorConfig_licenseSecret":           licenseSecret.(string),
-		"device-secondary_name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-secondary_name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-secondary_notifications":              []string{"secondary@equinix.com"},
 		"device-secondary_vendorConfig_enabled":       true,
 		"device-secondary_vendorConfig_licenseKey":    licenseKey.(string),
 		"device-secondary_vendorConfig_licenseSecret": licenseSecret.(string),
 		"acl-resourceName":                            "acl-pri",
-		"acl-name":                                    fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-description":                             randString(50),
+		"acl-name":                                    fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-description":                             acctest.RandString(50),
 		"acl-secondary_resourceName":                  "acl-sec",
-		"acl-secondary_name":                          fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-secondary_description":                   randString(50),
+		"acl-secondary_name":                          fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-secondary_description":                   acctest.RandString(50),
 	}
 
 	deviceResourceName := fmt.Sprintf("equinix_network_device.%s", context["device-resourceName"].(string))
@@ -838,7 +839,7 @@ func TestAccNetworkDevice_PaloAlto_Cluster_Self_BYOL(t *testing.T) {
 		"device-account_name":                accountName.(string),
 		"device-self_managed":                true,
 		"device-byol":                        true,
-		"device-name":                        fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                        fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-metro_code":                  metro.(string),
 		"device-type_code":                   "PA-VM",
 		"device-package_code":                "VM100",
@@ -847,22 +848,22 @@ func TestAccNetworkDevice_PaloAlto_Cluster_Self_BYOL(t *testing.T) {
 		"device-version":                     "10.1.3",
 		"device-interface_count":             10,
 		"device-core_count":                  2,
-		"device-cluster_name":                fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-cluster_name":                fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-node0_vendorConfig_enabled":  true,
-		"device-node0_vendorConfig_hostname": fmt.Sprintf("tf-%s", randString(6)),
+		"device-node0_vendorConfig_hostname": fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-node0_license_token":         licenseToken.(string),
 		"device-node1_vendorConfig_enabled":  true,
-		"device-node1_vendorConfig_hostname": fmt.Sprintf("tf-%s", randString(6)),
+		"device-node1_vendorConfig_hostname": fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-node1_license_token":         licenseToken.(string),
 		"sshkey-resourceName":                "test",
-		"sshkey-name":                        fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"sshkey-name":                        fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"sshkey-public_key":                  "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXdzXBHaVpKpdO0udnB+4JOgUq7APO2rPXfrevvlZrps98AtlwXXVWZ5duRH5NFNfU4G9HCSiAPsebgjY0fG85tcShpXfHfACLt0tBW8XhfLQP2T6S50FQ1brBdURMDCMsD7duOXqvc0dlbs2/KcswHvuUmqVzob3bz7n1bQ48wIHsPg4ARqYhy5LN3OkllJH/6GEfqi8lKZx01/P/gmJMORcJujuOyXRB+F2iXBVYdhjML3Qg4+tEekBcVZOxUbERRZ0pvQ52Y6wUhn2VsjljixyqeOdmD0m6DayDQgSWms6bKPpBqN7zhXXk4qe8bXT4tQQba65b2CQ2A91jw2KgM/YZNmjyUJ+Rf1cQosJf9twqbAZDZ6rAEmj9zzvQ5vD/CGuzxdVMkePLlUK4VGjPu7cVzhXrnq4318WqZ5/lNiCST8NQ0fssChN8ANUzr/p/wwv3faFMVNmjxXTZMsbMFT/fbb2MVVuqNFN65drntlg6/xEao8gZROuRYiakBx8= user@host",
 		"acl-resourceName":                   "acl-cluster",
-		"acl-name":                           fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"acl-description":                    randString(50),
+		"acl-name":                           fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"acl-description":                    acctest.RandString(50),
 		"mgmtAcl-resourceName":               "mgmtAcl-cluster",
-		"mgmtAcl-name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
-		"mgmtAcl-description":                randString(50),
+		"mgmtAcl-name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
+		"mgmtAcl-description":                acctest.RandString(50),
 	}
 
 	deviceResourceName := fmt.Sprintf("equinix_network_device.%s", context["device-resourceName"].(string))

--- a/equinix/resource_network_device_link_acc_test.go
+++ b/equinix/resource_network_device_link_acc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/equinix/ne-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -63,24 +64,24 @@ func TestAccNetworkDeviceLink(t *testing.T) {
 		"device-account_name":               accountName.(string),
 		"device-self_managed":               false,
 		"device-byol":                       false,
-		"device-name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-name":                       fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-throughput":                 500,
 		"device-throughput_unit":            "Mbps",
 		"device-metro_code":                 metro.(string),
 		"device-type_code":                  "CSR1000V",
 		"device-package_code":               "SEC",
 		"device-notifications":              []string{"test@equinix.com"},
-		"device-hostname":                   fmt.Sprintf("tf-%s", randString(6)),
+		"device-hostname":                   fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-term_length":                1,
 		"device-version":                    "16.09.05",
 		"device-core_count":                 2,
-		"device-secondary_name":             fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"device-secondary_name":             fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"device-secondary_account_name":     accountNameSecondary.(string),
 		"device-secondary_metro_code":       metroSecondary.(string),
-		"device-secondary_hostname":         fmt.Sprintf("tf-%s", randString(6)),
+		"device-secondary_hostname":         fmt.Sprintf("tf-%s", acctest.RandString(6)),
 		"device-secondary_notifications":    []string{"test@equinix.com"},
 		"link-resourceName":                 "test",
-		"link-name":                         fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"link-name":                         fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"link-subnet":                       "10.69.1.0/24",
 		"link-device_1_asn":                 23404,
 		"link-device_1_interface_id":        6,

--- a/equinix/resource_network_file_acc_test.go
+++ b/equinix/resource_network_file_acc_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/equinix/ne-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -14,8 +15,8 @@ import (
 func TestAccNetworkFile_VSRX(t *testing.T) {
 	context := map[string]interface{}{
 		"resourceName":   "test",
-		"fileName":       fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)) + ".lic",
-		"content":        randString(50),
+		"fileName":       fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)) + ".lic",
+		"content":        acctest.RandString(50),
 		"metroCode":      "SV",
 		"deviceTypeCode": "VSRX",
 		"processType":    "LICENSE",

--- a/equinix/resource_network_ssh_key_acc_test.go
+++ b/equinix/resource_network_ssh_key_acc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/equinix/ne-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -55,7 +56,7 @@ func testSweepNetworkSSHKey(region string) error {
 func TestAccNetworkSSHKey(t *testing.T) {
 	context := map[string]interface{}{
 		"resourceName": "test",
-		"name":         fmt.Sprintf("%s-%s", tstResourcePrefix, randString(6)),
+		"name":         fmt.Sprintf("%s-%s", tstResourcePrefix, acctest.RandString(6)),
 		"public_key":   "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCXdzXBHaVpKpdO0udnB+4JOgUq7APO2rPXfrevvlZrps98AtlwXXVWZ5duRH5NFNfU4G9HCSiAPsebgjY0fG85tcShpXfHfACLt0tBW8XhfLQP2T6S50FQ1brBdURMDCMsD7duOXqvc0dlbs2/KcswHvuUmqVzob3bz7n1bQ48wIHsPg4ARqYhy5LN3OkllJH/6GEfqi8lKZx01/P/gmJMORcJujuOyXRB+F2iXBVYdhjML3Qg4+tEekBcVZOxUbERRZ0pvQ52Y6wUhn2VsjljixyqeOdmD0m6DayDQgSWms6bKPpBqN7zhXXk4qe8bXT4tQQba65b2CQ2A91jw2KgM/YZNmjyUJ+Rf1cQosJf9twqbAZDZ6rAEmj9zzvQ5vD/CGuzxdVMkePLlUK4VGjPu7cVzhXrnq4318WqZ5/lNiCST8NQ0fssChN8ANUzr/p/wwv3faFMVNmjxXTZMsbMFT/fbb2MVVuqNFN65drntlg6/xEao8gZROuRYiakBx8= user@host",
 		"type":         "RSA",
 	}


### PR DESCRIPTION
Some of the Network Edge tests were using `randInt` and `randString` to generate random integers and strings.  The only thing each function does is call an upstream function; this replaces all calls to those functions with direct calls to the upstream (which matches what we do in other tests) and removes the unnecessary wrappers.