### PR TITLE
refactor: remove diagnostics wrapper

### DIFF
--- a/equinix/data_source_metal_device.go
+++ b/equinix/data_source_metal_device.go
@@ -11,13 +11,14 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 )
 
 func dataSourceMetalDevice() *schema.Resource {
 	return &schema.Resource{
-		ReadWithoutTimeout: diagnosticsWrapper(dataSourceMetalDeviceRead),
+		ReadWithoutTimeout: dataSourceMetalDeviceRead,
 		Schema: map[string]*schema.Schema{
 			"hostname": {
 				Type:          schema.TypeString,
@@ -209,7 +210,7 @@ func dataSourceMetalDevice() *schema.Resource {
 	}
 }
 
-func dataSourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).Metalgo
 
 	hostnameRaw, hostnameOK := d.GetOk("hostname")
@@ -217,32 +218,32 @@ func dataSourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta
 	deviceIdRaw, deviceIdOK := d.GetOk("device_id")
 
 	if !deviceIdOK && !hostnameOK {
-		return fmt.Errorf("You must supply device_id or hostname")
+		return diag.Errorf("You must supply device_id or hostname")
 	}
 	var device *metalv1.Device
 
 	if hostnameOK {
 		if !projectIdOK {
-			return fmt.Errorf("If you lookup via hostname, you must supply project_id")
+			return diag.Errorf("If you lookup via hostname, you must supply project_id")
 		}
 		hostname := hostnameRaw.(string)
 		projectId := projectIdRaw.(string)
 
 		ds, _, err := client.DevicesApi.FindProjectDevices(ctx, projectId).Hostname(hostname).Include(deviceCommonIncludes).Execute()
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 
 		device, err = findDeviceByHostname(ds, hostname)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	} else {
 		deviceId := deviceIdRaw.(string)
 		var err error
 		device, _, err = client.DevicesApi.FindDeviceById(ctx, deviceId).Include(deviceCommonIncludes).Execute()
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
@@ -265,12 +266,12 @@ func dataSourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta
 	if device.Storage != nil {
 		rawStorageBytes, err := json.Marshal(device.Storage)
 		if err != nil {
-			return fmt.Errorf("[ERR] Error getting storage JSON string for device (%s): %s", d.Id(), err)
+			return diag.Errorf("[ERR] Error getting storage JSON string for device (%s): %s", d.Id(), err)
 		}
 
 		storageString, err := structure.NormalizeJsonString(string(rawStorageBytes))
 		if err != nil {
-			return fmt.Errorf("[ERR] Error normalizing storage JSON string for device (%s): %s", d.Id(), err)
+			return diag.Errorf("[ERR] Error normalizing storage JSON string for device (%s): %s", d.Id(), err)
 		}
 		d.Set("storage", storageString)
 	}
@@ -280,7 +281,7 @@ func dataSourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 	networkType, err := getNetworkType(device)
 	if err != nil {
-		return fmt.Errorf("[ERR] Error computing network type for device (%s): %s", d.Id(), err)
+		return diag.Errorf("[ERR] Error computing network type for device (%s): %s", d.Id(), err)
 	}
 
 	d.Set("network_type", networkType)

--- a/equinix/data_source_metal_port.go
+++ b/equinix/data_source_metal_port.go
@@ -6,7 +6,7 @@ import (
 
 func dataSourceMetalPort() *schema.Resource {
 	return &schema.Resource{
-		ReadWithoutTimeout: diagnosticsWrapper(resourceMetalPortRead),
+		ReadWithoutTimeout: resourceMetalPortRead,
 
 		Schema: map[string]*schema.Schema{
 			"port_id": {

--- a/equinix/data_source_metal_virtual_circuit.go
+++ b/equinix/data_source_metal_virtual_circuit.go
@@ -3,12 +3,13 @@ package equinix
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMetalVirtualCircuit() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: diagnosticsWrapper(dataSourceMetalVirtualCircuitRead),
+		ReadContext: dataSourceMetalVirtualCircuitRead,
 
 		Schema: map[string]*schema.Schema{
 			"virtual_circuit_id": {
@@ -114,7 +115,7 @@ func dataSourceMetalVirtualCircuit() *schema.Resource {
 	}
 }
 
-func dataSourceMetalVirtualCircuitRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceMetalVirtualCircuitRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcId := d.Get("virtual_circuit_id").(string)
 	d.SetId(vcId)
 	return resourceMetalVirtualCircuitRead(ctx, d, meta)

--- a/equinix/data_source_metal_vrf.go
+++ b/equinix/data_source_metal_vrf.go
@@ -3,12 +3,13 @@ package equinix
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceMetalVRF() *schema.Resource {
 	return &schema.Resource{
-		ReadWithoutTimeout: diagnosticsWrapper(dataSourceMetalVRFRead),
+		ReadWithoutTimeout: dataSourceMetalVRFRead,
 
 		Schema: map[string]*schema.Schema{
 			"vrf_id": {
@@ -51,7 +52,7 @@ func dataSourceMetalVRF() *schema.Resource {
 	}
 }
 
-func dataSourceMetalVRFRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func dataSourceMetalVRFRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vrfId, _ := d.Get("vrf_id").(string)
 
 	d.SetId(vrfId)

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -443,13 +443,3 @@ func schemaSetToMap(set *schema.Set) map[int]interface{} {
 	}
 	return transformed
 }
-
-func diagnosticsWrapper(fn func(ctx context.Context, d *schema.ResourceData, meta interface{}) error) func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-		if err := fn(ctx, d, meta); err != nil {
-			return diag.FromErr(err)
-		}
-
-		return nil
-	}
-}

--- a/equinix/resource_metal_vrf.go
+++ b/equinix/resource_metal_vrf.go
@@ -8,16 +8,17 @@ import (
 	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/packethost/packngo"
 )
 
 func resourceMetalVRF() *schema.Resource {
 	return &schema.Resource{
-		ReadWithoutTimeout:   diagnosticsWrapper(resourceMetalVRFRead),
-		CreateWithoutTimeout: diagnosticsWrapper(resourceMetalVRFCreate),
-		UpdateWithoutTimeout: diagnosticsWrapper(resourceMetalVRFUpdate),
-		DeleteWithoutTimeout: diagnosticsWrapper(resourceMetalVRFDelete),
+		ReadWithoutTimeout:   resourceMetalVRFRead,
+		CreateWithoutTimeout: resourceMetalVRFCreate,
+		UpdateWithoutTimeout: resourceMetalVRFUpdate,
+		DeleteWithoutTimeout: resourceMetalVRFDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -60,7 +61,7 @@ func resourceMetalVRF() *schema.Resource {
 	}
 }
 
-func resourceMetalVRFCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceMetalVRFCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	meta.(*config.Config).AddModuleToMetalUserAgent(d)
 	client := meta.(*config.Config).Metal
 
@@ -75,7 +76,7 @@ func resourceMetalVRFCreate(ctx context.Context, d *schema.ResourceData, meta in
 	projectId := d.Get("project_id").(string)
 	vrf, _, err := client.VRFs.Create(projectId, createRequest)
 	if err != nil {
-		return equinix_errors.FriendlyError(err)
+		return diag.FromErr(equinix_errors.FriendlyError(err))
 	}
 
 	d.SetId(vrf.ID)
@@ -83,7 +84,7 @@ func resourceMetalVRFCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return resourceMetalVRFRead(ctx, d, meta)
 }
 
-func resourceMetalVRFUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceMetalVRFUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	meta.(*config.Config).AddModuleToMetalUserAgent(d)
 	client := meta.(*config.Config).Metal
 
@@ -107,13 +108,13 @@ func resourceMetalVRFUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	_, _, err := client.VRFs.Update(d.Id(), updateRequest)
 	if err != nil {
-		return equinix_errors.FriendlyError(err)
+		return diag.FromErr(equinix_errors.FriendlyError(err))
 	}
 
 	return resourceMetalVRFRead(ctx, d, meta)
 }
 
-func resourceMetalVRFRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceMetalVRFRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	meta.(*config.Config).AddModuleToMetalUserAgent(d)
 	client := meta.(*config.Config).Metal
 
@@ -127,7 +128,7 @@ func resourceMetalVRFRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 			return nil
 		}
-		return err
+		return diag.FromErr(err)
 	}
 	m := map[string]interface{}{
 		"name":        vrf.Name,
@@ -138,10 +139,10 @@ func resourceMetalVRFRead(ctx context.Context, d *schema.ResourceData, meta inte
 		"project_id":  vrf.Project.ID,
 	}
 
-	return equinix_schema.SetMap(d, m)
+	return diag.FromErr(equinix_schema.SetMap(d, m))
 }
 
-func resourceMetalVRFDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func resourceMetalVRFDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	meta.(*config.Config).AddModuleToMetalUserAgent(d)
 	client := meta.(*config.Config).Metal
 
@@ -150,5 +151,5 @@ func resourceMetalVRFDelete(ctx context.Context, d *schema.ResourceData, meta in
 		d.SetId("")
 	}
 
-	return equinix_errors.FriendlyError(err)
+	return diag.FromErr(equinix_errors.FriendlyError(err))
 }


### PR DESCRIPTION
While fixing timeout support in some of our resources, we introduced a private `diagnosticsWrapper` function to act as a shim between the context-aware resource lifecycle hooks and our pre-existing, non-context-aware resource lifecycle functions.  This shim was useful for gradual migration, but now it adds an unnecessary dependency between certain resources/datasources and the code in `provider.go`.

This removes the `diagnosticsWrapper` in favor of updating the resource lifecycle functions directly so that they have the correct function signature.  This work uncovered some places where we were needlessly calling `equinix_errors.FriendlyError`, so those are cleaned up here as well.