### PR TITLE
docs: update community link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Terraform Equinix Provider Questions
-    url: https://community.equinix.com/t5/forums/filteredbylabelpage/board-id/OR/label-name/Developer
+    url: https://community.equinix.com/developers
     about: GitHub issues in this repository are only intended for bug reports and feature requests. Other issues will be closed. Please ask and answer questions through the Equinix Community Forum.
 
   - name: Terraform Core Bug Reports and Feature Requests


### PR DESCRIPTION
Update the community link in the GitHub Issue template so that it hits a Community landing page with a prominant button for starting new conversations. The previous link was to a listing page that did not offer a way to contribute until after login.

Instead of https://community.equinix.com/t5/forums/filteredbylabelpage/board-id/OR/label-name/Developer, go to https://community.equinix.com/developers