### PR TITLE
docs: link to product documentation for Equinix Fabric Cloud Router

### DIFF
--- a/docs/resources/equinix_fabric_cloud_router.md
+++ b/docs/resources/equinix_fabric_cloud_router.md
@@ -13,7 +13,7 @@ Fabric V4 API compatible resource allows creation and management of [Equinix Fab
 ~> **Note** Equinix Fabric v4 resources and datasources are currently in Beta. The interfaces related to `equinix_fabric_` resources and datasources may change ahead of general availability. Please, do not hesitate to report any problems that you experience by opening a new [issue](https://github.com/equinix/terraform-provider-equinix/issues/new?template=bug.md)
 
 Additional Fabric Cloud Router documentation:
-* Getting Starts: <https://docs.equinix.com/en-us/Content/Interconnection/FCR/FCR-intro.htm#HowItWorks>
+* Getting Started: <https://docs.equinix.com/en-us/Content/Interconnection/FCR/FCR-intro.htm#HowItWorks>
 * API: <https://developer.equinix.com/dev-docs/fabric/api-reference/fabric-v4-apis#fabric-cloud-routers>
 
 ## Example Usage

--- a/docs/resources/equinix_fabric_cloud_router.md
+++ b/docs/resources/equinix_fabric_cloud_router.md
@@ -8,9 +8,13 @@ description: |-
 
 # equinix_fabric_cloud_router (Resource)
 
-Fabric V4 API compatible resource allows creation and management of Equinix Fabric Cloud Router
+Fabric V4 API compatible resource allows creation and management of [Equinix Fabric Cloud Router](https://docs.equinix.com/en-us/Content/Interconnection/FCR/FCR-intro.htm#HowItWorks).
 
-API documentation can be found here - https://developer.equinix.com/dev-docs/fabric/api-reference/fabric-v4-apis#fabric-cloud-routers
+~> **Note** Equinix Fabric v4 resources and datasources are currently in Beta. The interfaces related to `equinix_fabric_` resources and datasources may change ahead of general availability. Please, do not hesitate to report any problems that you experience by opening a new [issue](https://github.com/equinix/terraform-provider-equinix/issues/new?template=bug.md)
+
+Additional Fabric Cloud Router documentation:
+* Getting Starts: <https://docs.equinix.com/en-us/Content/Interconnection/FCR/FCR-intro.htm#HowItWorks>
+* API: <https://developer.equinix.com/dev-docs/fabric/api-reference/fabric-v4-apis#fabric-cloud-routers>
 
 ## Example Usage
 


### PR DESCRIPTION
The resource documentation should link to the product documentation. API documentation helps explain how the Terraform attributes map to the API, but it doesn't help a user understand what the underlying service is or why and where it should be used.