### PR TITLE
refactor: move validators out of provider.go

### DIFF
--- a/equinix/data_source_ecx_l2_sellerprofiles.go
+++ b/equinix/data_source_ecx_l2_sellerprofiles.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ecx-go/v2"
 	"github.com/hashicorp/go-cty/cty"
@@ -52,7 +53,7 @@ func dataSourceECXL2SellerProfiles() *schema.Resource {
 				Description: ecxL2SellerProfilesDescriptions["Metros"],
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: stringIsMetroCode(),
+					ValidateFunc: equinix_validation.StringIsMetroCode,
 				},
 			},
 			ecxL2SellerProfilesSchemaNames["SpeedBands"]: {
@@ -62,7 +63,7 @@ func dataSourceECXL2SellerProfiles() *schema.Resource {
 				Description: ecxL2SellerProfilesDescriptions["SpeedBands"],
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: stringIsSpeedBand(),
+					ValidateFunc: equinix_validation.StringIsSpeedBand,
 				},
 			},
 			ecxL2SellerProfilesSchemaNames["OrganizationName"]: {

--- a/equinix/data_source_network_account.go
+++ b/equinix/data_source_network_account.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -61,7 +62,7 @@ func dataSourceNetworkAccount() *schema.Resource {
 			networkAccountSchemaNames["MetroCode"]: {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: stringIsMetroCode(),
+				ValidateFunc: equinix_validation.StringIsMetroCode,
 				Description:  networkAccountDescriptions["MetroCode"],
 			},
 		},

--- a/equinix/data_source_network_device_type.go
+++ b/equinix/data_source_network_device_type.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -74,7 +75,7 @@ func dataSourceNetworkDeviceType() *schema.Resource {
 				MinItems: 1,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: stringIsMetroCode(),
+					ValidateFunc: equinix_validation.StringIsMetroCode,
 				},
 				Description: networkDeviceTypeDescriptions["MetroCodes"],
 			},

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"regexp"
 	"strings"
 	"time"
 
@@ -272,24 +271,6 @@ func hasModelErrorCode(errors []v4.ModelError, code string) bool {
 		}
 	}
 	return false
-}
-
-func stringIsMetroCode() schema.SchemaValidateFunc {
-	return validation.StringMatch(regexp.MustCompile("^[A-Z]{2}$"), "MetroCode must consist of two capital letters")
-}
-
-func stringIsEmailAddress() schema.SchemaValidateFunc {
-	return validation.StringMatch(regexp.MustCompile("^[^ @]+@[^ @]+$"), "not valid email address")
-}
-
-func stringIsPortDefinition() schema.SchemaValidateFunc {
-	return validation.StringMatch(
-		regexp.MustCompile("^(([0-9]+(,[0-9]+){0,9})|([0-9]+-[0-9]+)|(any))$"),
-		"port definition has to be: up to 10 comma sepparated numbers (22,23), range (20-23) or word 'any'")
-}
-
-func stringIsSpeedBand() schema.SchemaValidateFunc {
-	return validation.StringMatch(regexp.MustCompile("^[0-9]+(MB|GB)$"), "SpeedBand should consist of digit followed by MB or GB")
 }
 
 func stringsFound(source []string, target []string) bool {

--- a/equinix/resource_ecx_l2_connection.go
+++ b/equinix/resource_ecx_l2_connection.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ecx-go/v2"
 	"github.com/equinix/rest-go"
@@ -210,7 +211,7 @@ func createECXL2ConnectionResourceSchema() map[string]*schema.Schema {
 			MinItems: 1,
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
-				ValidateFunc: stringIsEmailAddress(),
+				ValidateFunc: equinix_validation.StringIsEmailAddress,
 			},
 			Description: ecxL2ConnectionDescriptions["Notifications"],
 		},
@@ -324,7 +325,7 @@ func createECXL2ConnectionResourceSchema() map[string]*schema.Schema {
 			Optional:     true,
 			Computed:     true,
 			ForceNew:     true,
-			ValidateFunc: stringIsMetroCode(),
+			ValidateFunc: equinix_validation.StringIsMetroCode,
 			Description:  ecxL2ConnectionDescriptions["SellerMetroCode"],
 		},
 		ecxL2ConnectionSchemaNames["AuthorizationKey"]: {
@@ -576,7 +577,7 @@ func createECXL2ConnectionSecondaryResourceSchema() map[string]*schema.Schema {
 			Optional:     true,
 			Computed:     true,
 			ForceNew:     true,
-			ValidateFunc: stringIsMetroCode(),
+			ValidateFunc: equinix_validation.StringIsMetroCode,
 			Description:  ecxL2ConnectionDescriptions["SellerMetroCode"],
 		},
 		ecxL2ConnectionSchemaNames["AuthorizationKey"]: {

--- a/equinix/resource_ecx_l2_serviceprofile.go
+++ b/equinix/resource_ecx_l2_serviceprofile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ecx-go/v2"
 	"github.com/equinix/rest-go"
@@ -205,7 +206,7 @@ func createECXL2ServiceProfileResourceSchema() map[string]*schema.Schema {
 			Description: ecxL2ServiceProfileDescriptions["OnBandwidthThresholdNotification"],
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
-				ValidateFunc: stringIsEmailAddress(),
+				ValidateFunc: equinix_validation.StringIsEmailAddress,
 			},
 		},
 		ecxL2ServiceProfileSchemaNames["OnProfileApprovalRejectNotification"]: {
@@ -215,7 +216,7 @@ func createECXL2ServiceProfileResourceSchema() map[string]*schema.Schema {
 			Description: ecxL2ServiceProfileDescriptions["OnProfileApprovalRejectNotification"],
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
-				ValidateFunc: stringIsEmailAddress(),
+				ValidateFunc: equinix_validation.StringIsEmailAddress,
 			},
 		},
 		ecxL2ServiceProfileSchemaNames["OnVcApprovalRejectionNotification"]: {
@@ -225,7 +226,7 @@ func createECXL2ServiceProfileResourceSchema() map[string]*schema.Schema {
 			Description: ecxL2ServiceProfileDescriptions["OnVcApprovalRejectionNotification"],
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
-				ValidateFunc: stringIsEmailAddress(),
+				ValidateFunc: equinix_validation.StringIsEmailAddress,
 			},
 		},
 		ecxL2ServiceProfileSchemaNames["OverSubscription"]: {
@@ -248,7 +249,7 @@ func createECXL2ServiceProfileResourceSchema() map[string]*schema.Schema {
 			Description: ecxL2ServiceProfileDescriptions["PrivateUserEmails"],
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
-				ValidateFunc: stringIsEmailAddress(),
+				ValidateFunc: equinix_validation.StringIsEmailAddress,
 			},
 		},
 		ecxL2ServiceProfileSchemaNames["RequiredRedundancy"]: {
@@ -312,7 +313,7 @@ func createECXL2ServiceProfileResourceSchema() map[string]*schema.Schema {
 					ecxL2ServiceProfilePortSchemaNames["MetroCode"]: {
 						Type:         schema.TypeString,
 						Required:     true,
-						ValidateFunc: stringIsMetroCode(),
+						ValidateFunc: equinix_validation.StringIsMetroCode,
 						Description:  ecxL2ServiceProfilePortDescriptions["MetroCode"],
 					},
 				},

--- a/equinix/resource_network_acl_template.go
+++ b/equinix/resource_network_acl_template.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
 	"github.com/equinix/rest-go"
@@ -114,7 +115,7 @@ func createNetworkACLTemplateSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Deprecated:   networkACLTemplateDeprecateDescriptions["MetroCode"],
-			ValidateFunc: stringIsMetroCode(),
+			ValidateFunc: equinix_validation.StringIsMetroCode,
 			Description:  networkACLTemplateDescriptions["MetroCode"],
 		},
 		networkACLTemplateSchemaNames["DeviceUUID"]: {
@@ -187,13 +188,13 @@ func createNetworkACLTemplateInboundRuleSchema() map[string]*schema.Schema {
 		networkACLTemplateInboundRuleSchemaNames["SrcPort"]: {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: stringIsPortDefinition(),
+			ValidateFunc: equinix_validation.StringIsPortDefinition,
 			Description:  networkACLTemplateInboundRuleDescriptions["SrcPort"],
 		},
 		networkACLTemplateInboundRuleSchemaNames["DstPort"]: {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: stringIsPortDefinition(),
+			ValidateFunc: equinix_validation.StringIsPortDefinition,
 			Description:  networkACLTemplateInboundRuleDescriptions["DstPort"],
 		},
 		networkACLTemplateInboundRuleSchemaNames["Description"]: {

--- a/equinix/resource_network_device.go
+++ b/equinix/resource_network_device.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
 	"github.com/equinix/rest-go"
@@ -252,7 +253,7 @@ func createNetworkDeviceSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: stringIsMetroCode(),
+			ValidateFunc: equinix_validation.StringIsMetroCode,
 			Description:  neDeviceDescriptions["MetroCode"],
 		},
 		neDeviceSchemaNames["IBX"]: {
@@ -374,7 +375,7 @@ func createNetworkDeviceSchema() map[string]*schema.Schema {
 			MinItems: 1,
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
-				ValidateFunc: stringIsEmailAddress(),
+				ValidateFunc: equinix_validation.StringIsEmailAddress,
 			},
 			Description: neDeviceDescriptions["Notifications"],
 		},
@@ -523,7 +524,7 @@ func createNetworkDeviceSchema() map[string]*schema.Schema {
 						Type:         schema.TypeString,
 						Required:     true,
 						ForceNew:     true,
-						ValidateFunc: stringIsMetroCode(),
+						ValidateFunc: equinix_validation.StringIsMetroCode,
 						Description:  neDeviceDescriptions["MetroCode"],
 					},
 					neDeviceSchemaNames["IBX"]: {
@@ -608,7 +609,7 @@ func createNetworkDeviceSchema() map[string]*schema.Schema {
 						MinItems: 1,
 						Elem: &schema.Schema{
 							Type:         schema.TypeString,
-							ValidateFunc: stringIsEmailAddress(),
+							ValidateFunc: equinix_validation.StringIsEmailAddress,
 						},
 						Description: neDeviceDescriptions["Notifications"],
 					},

--- a/equinix/resource_network_device_link.go
+++ b/equinix/resource_network_device_link.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/equinix/terraform-provider-equinix/internal/hashcode"
-
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/hashcode"
+	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
 	"github.com/hashicorp/go-cty/cty"
@@ -197,13 +197,13 @@ func createNetworkDeviceLinkConnectionResourceSchema() map[string]*schema.Schema
 		networkDeviceLinkConnectionSchemaNames["SourceMetroCode"]: {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: stringIsMetroCode(),
+			ValidateFunc: equinix_validation.StringIsMetroCode,
 			Description:  networkDeviceLinkConnectionDescriptions["SourceMetroCode"],
 		},
 		networkDeviceLinkConnectionSchemaNames["DestinationMetroCode"]: {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: stringIsMetroCode(),
+			ValidateFunc: equinix_validation.StringIsMetroCode,
 			Description:  networkDeviceLinkConnectionDescriptions["DestinationMetroCode"],
 		},
 		networkDeviceLinkConnectionSchemaNames["SourceZoneCode"]: {

--- a/equinix/resource_network_file.go
+++ b/equinix/resource_network_file.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equinix/ne-go"
 	"github.com/equinix/rest-go"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -75,7 +76,7 @@ func createNetworkFileSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: stringIsMetroCode(),
+			ValidateFunc: equinix_validation.StringIsMetroCode,
 			Description:  networkFileDescriptions["MetroCode"],
 		},
 		networkFileSchemaNames["DeviceTypeCode"]: {

--- a/internal/validation/strings.go
+++ b/internal/validation/strings.go
@@ -1,0 +1,16 @@
+package validation
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var (
+	StringIsMetroCode      = validation.StringMatch(regexp.MustCompile("^[A-Z]{2}$"), "MetroCode must consist of two capital letters")
+	StringIsEmailAddress   = validation.StringMatch(regexp.MustCompile("^[^ @]+@[^ @]+$"), "not valid email address")
+	StringIsPortDefinition = validation.StringMatch(
+		regexp.MustCompile("^(([0-9]+(,[0-9]+){0,9})|([0-9]+-[0-9]+)|(any))$"),
+		"port definition has to be: up to 10 comma sepparated numbers (22,23), range (20-23) or word 'any'")
+	StringIsSpeedBand = validation.StringMatch(regexp.MustCompile("^[0-9]+(MB|GB)$"), "SpeedBand should consist of digit followed by MB or GB")
+)


### PR DESCRIPTION
This moves some custom string validation functions out of `provider.go` and into the `validation` package so that resource & data source code is not tied so tightly to `provider.go`.