### PR TITLE
refactor: move mutexkv to its own package

### DIFF
--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -22,7 +22,6 @@ import (
 )
 
 var (
-	metalMutexKV         = NewMutexKV()
 	DeviceNetworkTypes   = []string{"layer3", "hybrid", "layer2-individual", "layer2-bonded"}
 	DeviceNetworkTypesHB = []string{"layer3", "hybrid", "hybrid-bonded", "layer2-individual", "layer2-bonded"}
 	NetworkTypeList      = strings.Join(DeviceNetworkTypes, ", ")

--- a/internal/mutexkv/mutexkv.go
+++ b/internal/mutexkv/mutexkv.go
@@ -1,8 +1,12 @@
-package equinix
+package mutexkv
 
 import (
 	"log"
 	"sync"
+)
+
+var (
+	Metal = NewMutexKV()
 )
 
 // MutexKV is a simple key/value store for arbitrary mutexes. It can be used to


### PR DESCRIPTION
Moving mutexkv out of provider.go makes it easier to restructure our code.