### PR TITLE
refactor: move error functions out of package.go

### DIFF
--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -3,7 +3,6 @@ package equinix
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"reflect"
 	"strings"
 	"time"
@@ -11,9 +10,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/metal_project_ssh_key"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/metal_ssh_key"
 
-	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
 	"github.com/equinix/ecx-go/v2"
-	"github.com/equinix/rest-go"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -254,24 +251,6 @@ func expandInterfaceMapToStringMap(mapIn map[string]interface{}) map[string]stri
 	return mapOut
 }
 
-func hasApplicationErrorCode(errors []rest.ApplicationError, code string) bool {
-	for _, err := range errors {
-		if err.Code == code {
-			return true
-		}
-	}
-	return false
-}
-
-func hasModelErrorCode(errors []v4.ModelError, code string) bool {
-	for _, err := range errors {
-		if err.ErrorCode == code {
-			return true
-		}
-	}
-	return false
-}
-
 func stringsFound(source []string, target []string) bool {
 	for i := range source {
 		if !isStringInSlice(source[i], target) {
@@ -396,15 +375,6 @@ func slicesMatchCaseInsensitive(s1, s2 []string) bool {
 		}
 	}
 	return true
-}
-
-func isRestNotFoundError(err error) bool {
-	if restErr, ok := err.(rest.Error); ok {
-		if restErr.HTTPCode == http.StatusNotFound {
-			return true
-		}
-	}
-	return false
 }
 
 func schemaSetToMap(set *schema.Set) map[int]interface{} {

--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -2,7 +2,6 @@ package equinix
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"reflect"
 	"regexp"
@@ -13,8 +12,6 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/hashcode"
 
 	"github.com/equinix/ecx-go/v2"
-	"github.com/equinix/rest-go"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
@@ -147,23 +144,6 @@ func TestProvider(t *testing.T) {
 	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-}
-
-func TestProvider_hasApplicationErrorCode(t *testing.T) {
-	// given
-	code := "ERR-505"
-	errors := []rest.ApplicationError{
-		{
-			Code: "ERR-505",
-		},
-		{
-			Code: acctest.RandString(10),
-		},
-	}
-	// when
-	result := hasApplicationErrorCode(errors, code)
-	// then
-	assert.True(t, result, "Error list contains error with given code")
 }
 
 func TestProvider_stringsFound(t *testing.T) {
@@ -349,27 +329,6 @@ func TestProvider_slicesMatch(t *testing.T) {
 	for i := range expected {
 		assert.Equal(t, expected[i], results[i])
 	}
-}
-
-func TestProvider_isRestNotFoundError(t *testing.T) {
-	// given
-	input := []error{
-		rest.Error{HTTPCode: http.StatusNotFound, Message: "Not Found"},
-		rest.Error{HTTPCode: http.StatusInternalServerError, Message: "Internal Server Error"},
-		fmt.Errorf("some bogus error"),
-	}
-	expected := []bool{
-		true,
-		false,
-		false,
-	}
-	// when
-	result := make([]bool, len(input))
-	for i := range input {
-		result[i] = isRestNotFoundError(input[i])
-	}
-	// then
-	assert.Equal(t, expected, result, "Result matches expected output")
 }
 
 func TestProvider_schemaSetToMap(t *testing.T) {

--- a/equinix/resource_ecx_l2_connection.go
+++ b/equinix/resource_ecx_l2_connection.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ecx-go/v2"
@@ -778,7 +779,7 @@ func resourceECXL2ConnectionDelete(ctx context.Context, d *schema.ResourceData, 
 		restErr, ok := err.(rest.Error)
 		if ok {
 			// IC-LAYER2-4021 = Connection already deleted
-			if hasApplicationErrorCode(restErr.ApplicationErrors, "IC-LAYER2-4021") {
+			if equinix_errors.HasApplicationErrorCode(restErr.ApplicationErrors, "IC-LAYER2-4021") {
 				return diags
 			}
 		}
@@ -792,7 +793,7 @@ func resourceECXL2ConnectionDelete(ctx context.Context, d *schema.ResourceData, 
 			restErr, ok := err.(rest.Error)
 			if ok {
 				// IC-LAYER2-4021 = Connection already deleted
-				if hasApplicationErrorCode(restErr.ApplicationErrors, "IC-LAYER2-4021") {
+				if equinix_errors.HasApplicationErrorCode(restErr.ApplicationErrors, "IC-LAYER2-4021") {
 					return diags
 				}
 			}

--- a/equinix/resource_ecx_l2_serviceprofile.go
+++ b/equinix/resource_ecx_l2_serviceprofile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ecx-go/v2"
@@ -392,7 +393,7 @@ func resourceECXL2ServiceProfileDelete(ctx context.Context, d *schema.ResourceDa
 		restErr, ok := err.(rest.Error)
 		if ok {
 			// IC-PROFILE-004 =  profile does not exist
-			if hasApplicationErrorCode(restErr.ApplicationErrors, "IC-PROFILE-004") {
+			if equinix_errors.HasApplicationErrorCode(restErr.ApplicationErrors, "IC-PROFILE-004") {
 				return diags
 			}
 		}

--- a/equinix/resource_fabric_cloud_router.go
+++ b/equinix/resource_fabric_cloud_router.go
@@ -224,7 +224,7 @@ func resourceCloudRouterDelete(ctx context.Context, d *schema.ResourceData, meta
 		errors, ok := err.(v4.GenericSwaggerError).Model().([]v4.ModelError)
 		if ok {
 			// EQ-3040055 = There is an existing update in REQUESTED state
-			if hasModelErrorCode(errors, "EQ-3040055") {
+			if equinix_errors.HasModelErrorCode(errors, "EQ-3040055") {
 				return diags
 			}
 		}

--- a/equinix/resource_fabric_connection.go
+++ b/equinix/resource_fabric_connection.go
@@ -387,7 +387,7 @@ func resourceFabricConnectionDelete(ctx context.Context, d *schema.ResourceData,
 		errors, ok := err.(v4.GenericSwaggerError).Model().([]v4.ModelError)
 		if ok {
 			// EQ-3142509 = Connection already deleted
-			if hasModelErrorCode(errors, "EQ-3142509") {
+			if equinix_errors.HasModelErrorCode(errors, "EQ-3142509") {
 				return diags
 			}
 		}

--- a/equinix/resource_fabric_routing_protocol.go
+++ b/equinix/resource_fabric_routing_protocol.go
@@ -257,7 +257,7 @@ func resourceFabricRoutingProtocolDelete(ctx context.Context, d *schema.Resource
 		errors, ok := err.(v4.GenericSwaggerError).Model().([]v4.ModelError)
 		if ok {
 			// EQ-3142509 = Connection already deleted
-			if hasModelErrorCode(errors, "EQ-3142509") {
+			if equinix_errors.HasModelErrorCode(errors, "EQ-3142509") {
 				return diags
 			}
 		}

--- a/equinix/resource_network_device_link.go
+++ b/equinix/resource_network_device_link.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	"github.com/equinix/terraform-provider-equinix/internal/hashcode"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
@@ -251,7 +252,7 @@ func resourceNetworkDeviceLinkRead(ctx context.Context, d *schema.ResourceData, 
 	var diags diag.Diagnostics
 	link, err := client.GetDeviceLinkGroup(d.Id())
 	if err != nil {
-		if isRestNotFoundError(err) {
+		if equinix_errors.IsRestNotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
@@ -312,7 +313,7 @@ func resourceNetworkDeviceLinkDelete(ctx context.Context, d *schema.ResourceData
 	m.(*config.Config).AddModuleToNEUserAgent(&client, d)
 	var diags diag.Diagnostics
 	if err := client.DeleteDeviceLinkGroup(d.Id()); err != nil {
-		if isRestNotFoundError(err) {
+		if equinix_errors.IsRestNotFoundError(err) {
 			return nil
 		}
 		return diag.FromErr(err)
@@ -470,7 +471,7 @@ func createDeviceLinkStatusDeleteWaitConfiguration(fetchFunc getDeviceLinkGroup,
 		Refresh: func() (interface{}, string, error) {
 			resp, err := fetchFunc(id)
 			if err != nil {
-				if isRestNotFoundError(err) {
+				if equinix_errors.IsRestNotFoundError(err) {
 					return resp, ne.DeviceLinkGroupStatusDeprovisioned, nil
 				}
 				return nil, "", err

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	fabric "github.com/equinix-labs/fabric-go/fabric/v4"
+	"github.com/equinix/rest-go"
 	"github.com/packethost/packngo"
 )
 
@@ -191,4 +192,31 @@ func IgnoreResponseErrors(ignore ...func(resp *http.Response, err error) bool) f
 		}
 		return err
 	}
+}
+
+func IsRestNotFoundError(err error) bool {
+	if restErr, ok := err.(rest.Error); ok {
+		if restErr.HTTPCode == http.StatusNotFound {
+			return true
+		}
+	}
+	return false
+}
+
+func HasApplicationErrorCode(errors []rest.ApplicationError, code string) bool {
+	for _, err := range errors {
+		if err.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func HasModelErrorCode(errors []fabric.ModelError, code string) bool {
+	for _, err := range errors {
+		if err.ErrorCode == code {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,49 @@
+package errors
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/equinix/rest-go"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvider_HasApplicationErrorCode(t *testing.T) {
+	// given
+	code := "ERR-505"
+	errors := []rest.ApplicationError{
+		{
+			Code: "ERR-505",
+		},
+		{
+			Code: acctest.RandString(10),
+		},
+	}
+	// when
+	result := HasApplicationErrorCode(errors, code)
+	// then
+	assert.True(t, result, "Error list contains error with given code")
+}
+
+func TestProvider_IsRestNotFoundError(t *testing.T) {
+	// given
+	input := []error{
+		rest.Error{HTTPCode: http.StatusNotFound, Message: "Not Found"},
+		rest.Error{HTTPCode: http.StatusInternalServerError, Message: "Internal Server Error"},
+		fmt.Errorf("some bogus error"),
+	}
+	expected := []bool{
+		true,
+		false,
+		false,
+	}
+	// when
+	result := make([]bool, len(input))
+	for i := range input {
+		result[i] = IsRestNotFoundError(input[i])
+	}
+	// then
+	assert.Equal(t, expected, result, "Result matches expected output")
+}


### PR DESCRIPTION
This moves some private error-related functions out of `provider.go` into a separate package so that resources and data sources aren't unnecessarily tied to the provider code file.