### PR TITLE
refactor: move converters out of provider.go

### DIFF
--- a/equinix/data_source_ecx_l2_sellerprofiles.go
+++ b/equinix/data_source_ecx_l2_sellerprofiles.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ecx-go/v2"
@@ -99,8 +100,8 @@ func dataSourceECXL2SellerProfilesRead(ctx context.Context, d *schema.ResourceDa
 	}
 	var filteredProfiles []ecx.L2ServiceProfile
 	nameRegex := d.Get(ecxL2SellerProfilesSchemaNames["NameRegex"]).(string)
-	metros := expandSetToStringList(d.Get(ecxL2SellerProfilesSchemaNames["Metros"]).(*schema.Set))
-	speedBands := expandSetToStringList(d.Get(ecxL2SellerProfilesSchemaNames["SpeedBands"]).(*schema.Set))
+	metros := converters.SetToStringList(d.Get(ecxL2SellerProfilesSchemaNames["Metros"]).(*schema.Set))
+	speedBands := converters.SetToStringList(d.Get(ecxL2SellerProfilesSchemaNames["SpeedBands"]).(*schema.Set))
 	orgName := d.Get(ecxL2SellerProfilesSchemaNames["OrganizationName"]).(string)
 	globalOrgName := d.Get(ecxL2SellerProfilesSchemaNames["GlobalOrganization"]).(string)
 	for _, profile := range profiles {

--- a/equinix/data_source_network_device_software.go
+++ b/equinix/data_source_network_device_software.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 
 	"github.com/equinix/ne-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -116,7 +117,7 @@ func dataSourceNetworkDeviceSoftwareRead(ctx context.Context, d *schema.Resource
 	conf := m.(*config.Config)
 	var diags diag.Diagnostics
 	typeCode := d.Get(networkDeviceSoftwareSchemaNames["DeviceTypeCode"]).(string)
-	pkgCodes := expandSetToStringList(d.Get(networkDeviceSoftwareSchemaNames["PackageCodes"]).(*schema.Set))
+	pkgCodes := converters.SetToStringList(d.Get(networkDeviceSoftwareSchemaNames["PackageCodes"]).(*schema.Set))
 	versions, err := conf.Ne.GetDeviceSoftwareVersions(typeCode)
 	if err != nil {
 		return diag.FromErr(err)

--- a/equinix/data_source_network_device_type.go
+++ b/equinix/data_source_network_device_type.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
@@ -90,7 +91,7 @@ func dataSourceNetworkDeviceTypeRead(ctx context.Context, d *schema.ResourceData
 	name := d.Get(networkDeviceTypeSchemaNames["Name"]).(string)
 	vendor := d.Get(networkDeviceTypeSchemaNames["Vendor"]).(string)
 	category := d.Get(networkDeviceTypeSchemaNames["Category"]).(string)
-	metroCodes := expandSetToStringList(d.Get(networkDeviceTypeSchemaNames["MetroCodes"]).(*schema.Set))
+	metroCodes := converters.SetToStringList(d.Get(networkDeviceTypeSchemaNames["MetroCodes"]).(*schema.Set))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/equinix/data_source_network_platform.go
+++ b/equinix/data_source_network_platform.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 
 	"github.com/equinix/ne-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -122,19 +123,19 @@ func dataSourceNetworkDevicePlatformRead(ctx context.Context, d *schema.Resource
 			continue
 		}
 		if v, ok := d.GetOk(networkDevicePlatformSchemaNames["PackageCodes"]); ok {
-			pkgCodes := expandSetToStringList(v.(*schema.Set))
+			pkgCodes := converters.SetToStringList(v.(*schema.Set))
 			if !stringsFound(pkgCodes, platform.PackageCodes) {
 				continue
 			}
 		}
 		if v, ok := d.GetOk(networkDevicePlatformSchemaNames["ManagementTypes"]); ok {
-			mgmtTypes := expandSetToStringList(v.(*schema.Set))
+			mgmtTypes := converters.SetToStringList(v.(*schema.Set))
 			if !stringsFound(mgmtTypes, platform.ManagementTypes) {
 				continue
 			}
 		}
 		if v, ok := d.GetOk(networkDevicePlatformSchemaNames["LicenseOptions"]); ok {
-			licOptions := expandSetToStringList(v.(*schema.Set))
+			licOptions := converters.SetToStringList(v.(*schema.Set))
 			if !stringsFound(licOptions, platform.LicenseOptions) {
 				continue
 			}

--- a/equinix/fabric_mapping_helper.go
+++ b/equinix/fabric_mapping_helper.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -165,7 +166,7 @@ func notificationToFabric(schemaNotifications []interface{}) []v4.SimplifiedNoti
 		ntype := n.(map[string]interface{})["type"].(string)
 		interval := n.(map[string]interface{})["send_interval"].(string)
 		emailsRaw := n.(map[string]interface{})["emails"].([]interface{})
-		emails := expandListToStringList(emailsRaw)
+		emails := converters.IfArrToStringArr(emailsRaw)
 		notifications = append(notifications, v4.SimplifiedNotification{
 			Type_:        ntype,
 			SendInterval: interval,

--- a/equinix/fabric_mapping_service_profile_helper.go
+++ b/equinix/fabric_mapping_service_profile_helper.go
@@ -2,6 +2,7 @@ package equinix
 
 import (
 	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -200,7 +201,7 @@ func accessPointTypeConfigsToFabric(schemaAccessPointTypeConfigs []interface{}) 
 		}
 
 		supportedBandwidthsRaw := accessPoint.(map[string]interface{})["supported_bandwidths"].([]interface{})
-		spSupportedBandwidths := expandListToInt32List(supportedBandwidthsRaw)
+		spSupportedBandwidths := converters.ListToInt32List(supportedBandwidthsRaw)
 
 		accessPointTypeConfigs = append(accessPointTypeConfigs, v4.ServiceProfileAccessPointType{
 			Type_:                        &spType,
@@ -270,7 +271,7 @@ func customFieldsToFabric(schemaCustomField []interface{}) []v4.CustomField {
 		cfRequired := customField.(map[string]interface{})["required"].(bool)
 		cfDataType := customField.(map[string]interface{})["data_type"].(string)
 		optionsRaw := customField.(map[string]interface{})["options"].([]interface{})
-		cfOptions := expandListToStringList(optionsRaw)
+		cfOptions := converters.IfArrToStringArr(optionsRaw)
 		cfCaptureInEmail := customField.(map[string]interface{})["capture_in_email"].(bool)
 		customFields = append(customFields, v4.CustomField{
 			Label:          cfLabel,
@@ -387,7 +388,7 @@ func metrosToFabric(schemaMetros []interface{}) []v4.ServiceMetro {
 		mCode := metro.(map[string]interface{})["code"].(string)
 		mName := metro.(map[string]interface{})["name"].(string)
 		ibxsRaw := metro.(map[string]interface{})["ibxs"].([]interface{})
-		mIbxs := expandListToStringList(ibxsRaw)
+		mIbxs := converters.IfArrToStringArr(ibxsRaw)
 		mInTrail := metro.(map[string]interface{})["in_trail"].(bool)
 		mDisplayName := metro.(map[string]interface{})["display_name"].(string)
 		mSellerRegions := metro.(map[string]interface{})["seller_regions"].(map[string]string)
@@ -444,7 +445,7 @@ func serviceProfilesSearchFilterRequestToFabric(schemaServiceProfileFilterReques
 		sProperty := s.(map[string]interface{})["property"].(string)
 		operator := s.(map[string]interface{})["operator"].(string)
 		valuesRaw := s.(map[string]interface{})["values"].([]interface{})
-		values := expandListToStringList(valuesRaw)
+		values := converters.IfArrToStringArr(valuesRaw)
 		mappedFilter = v4.ServiceProfileSimpleExpression{Property: sProperty, Operator: operator, Values: values}
 	}
 	return mappedFilter

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -222,35 +222,6 @@ func configureProvider(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	return &config, nil
 }
 
-func expandListToStringList(list []interface{}) []string {
-	result := make([]string, len(list))
-	for i, v := range list {
-		result[i] = fmt.Sprint(v)
-	}
-	return result
-}
-
-func expandListToInt32List(list []interface{}) []int32 {
-	result := make([]int32, len(list))
-	for i, v := range list {
-		result[i] = int32(v.(int))
-	}
-	return result
-}
-
-func expandSetToStringList(set *schema.Set) []string {
-	list := set.List()
-	return expandListToStringList(list)
-}
-
-func expandInterfaceMapToStringMap(mapIn map[string]interface{}) map[string]string {
-	mapOut := make(map[string]string)
-	for k, v := range mapIn {
-		mapOut[k] = fmt.Sprintf("%v", v)
-	}
-	return mapOut
-}
-
 func stringsFound(source []string, target []string) bool {
 	for i := range source {
 		if !isStringInSlice(source[i], target) {

--- a/equinix/resource_ecx_l2_connection.go
+++ b/equinix/resource_ecx_l2_connection.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
@@ -827,7 +828,7 @@ func createECXL2Connections(d *schema.ResourceData) (*ecx.L2Connection, *ecx.L2C
 		primary.SpeedUnit = ecx.String(v.(string))
 	}
 	if v, ok := d.GetOk(ecxL2ConnectionSchemaNames["Notifications"]); ok {
-		primary.Notifications = expandSetToStringList(v.(*schema.Set))
+		primary.Notifications = converters.SetToStringList(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk(ecxL2ConnectionSchemaNames["PurchaseOrderNumber"]); ok {
 		primary.PurchaseOrderNumber = ecx.String(v.(string))

--- a/equinix/resource_ecx_l2_connection_test.go
+++ b/equinix/resource_ecx_l2_connection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/equinix/ecx-go/v2"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
@@ -112,7 +113,7 @@ func TestFabricL2Connection_updateResourceData(t *testing.T) {
 	assert.Equal(t, ecx.StringValue(input.SpeedUnit), d.Get(ecxL2ConnectionSchemaNames["SpeedUnit"]), "SpeedUnit matches")
 	assert.Equal(t, ecx.StringValue(input.Status), d.Get(ecxL2ConnectionSchemaNames["Status"]), "Status matches")
 	assert.Equal(t, ecx.StringValue(input.ProviderStatus), d.Get(ecxL2ConnectionSchemaNames["ProviderStatus"]), "ProviderStatus matches")
-	assert.Equal(t, input.Notifications, expandSetToStringList(d.Get(ecxL2ConnectionSchemaNames["Notifications"]).(*schema.Set)), "Notifications matches")
+	assert.Equal(t, input.Notifications, converters.SetToStringList(d.Get(ecxL2ConnectionSchemaNames["Notifications"]).(*schema.Set)), "Notifications matches")
 	assert.Equal(t, ecx.StringValue(input.PurchaseOrderNumber), d.Get(ecxL2ConnectionSchemaNames["PurchaseOrderNumber"]), "PurchaseOrderNumber matches")
 	assert.Equal(t, ecx.StringValue(input.PortUUID), d.Get(ecxL2ConnectionSchemaNames["PortUUID"]), "PortUUID matches")
 	assert.Equal(t, ecx.StringValue(input.DeviceUUID), d.Get(ecxL2ConnectionSchemaNames["DeviceUUID"]), "DeviceUUID matches")

--- a/equinix/resource_ecx_l2_serviceprofile.go
+++ b/equinix/resource_ecx_l2_serviceprofile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
@@ -447,13 +448,13 @@ func createECXL2ServiceProfile(d *schema.ResourceData) *ecx.L2ServiceProfile {
 		profile.Name = ecx.String(v.(string))
 	}
 	if v, ok := d.GetOk(ecxL2ServiceProfileSchemaNames["OnBandwidthThresholdNotification"]); ok {
-		profile.OnBandwidthThresholdNotification = expandSetToStringList(v.(*schema.Set))
+		profile.OnBandwidthThresholdNotification = converters.SetToStringList(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk(ecxL2ServiceProfileSchemaNames["OnProfileApprovalRejectNotification"]); ok {
-		profile.OnProfileApprovalRejectNotification = expandSetToStringList(v.(*schema.Set))
+		profile.OnProfileApprovalRejectNotification = converters.SetToStringList(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk(ecxL2ServiceProfileSchemaNames["OnVcApprovalRejectionNotification"]); ok {
-		profile.OnVcApprovalRejectionNotification = expandSetToStringList(v.(*schema.Set))
+		profile.OnVcApprovalRejectionNotification = converters.SetToStringList(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk(ecxL2ServiceProfileSchemaNames["OverSubscription"]); ok {
 		profile.OverSubscription = ecx.String(v.(string))
@@ -462,7 +463,7 @@ func createECXL2ServiceProfile(d *schema.ResourceData) *ecx.L2ServiceProfile {
 		profile.Private = ecx.Bool(v.(bool))
 	}
 	if v, ok := d.GetOk(ecxL2ServiceProfileSchemaNames["PrivateUserEmails"]); ok {
-		profile.PrivateUserEmails = expandSetToStringList(v.(*schema.Set))
+		profile.PrivateUserEmails = converters.SetToStringList(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk(ecxL2ServiceProfileSchemaNames["RequiredRedundancy"]); ok {
 		profile.RequiredRedundancy = ecx.Bool(v.(bool))
@@ -552,7 +553,7 @@ func updateECXL2ServiceProfileResource(profile *ecx.L2ServiceProfile, d *schema.
 	// API accepts capitalizations of the private user emails and converts it to a lowercase string
 	// If API retuns same emails in lowercase we keep to suppress diff
 	if v, ok := d.GetOk(ecxL2ServiceProfileSchemaNames["PrivateUserEmails"]); ok {
-		prevPrivateUserEmails := expandSetToStringList(v.(*schema.Set))
+		prevPrivateUserEmails := converters.SetToStringList(v.(*schema.Set))
 		if slicesMatchCaseInsensitive(prevPrivateUserEmails, profile.PrivateUserEmails) {
 			profile.PrivateUserEmails = prevPrivateUserEmails
 		}

--- a/equinix/resource_ecx_l2_serviceprofile_test.go
+++ b/equinix/resource_ecx_l2_serviceprofile_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/equinix/ecx-go/v2"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -167,12 +168,12 @@ func TestFabricL2ServiceProfile_updateResourceData(t *testing.T) {
 	assert.Equal(t, ecx.BoolValue(input.EquinixManagedPortAndVlan), d.Get(ecxL2ServiceProfileSchemaNames["EquinixManagedPortAndVlan"]), "EquinixManagedPortAndVlan matches")
 	assert.Equal(t, ecx.StringValue(input.IntegrationID), d.Get(ecxL2ServiceProfileSchemaNames["IntegrationID"]), "IntegrationID matches")
 	assert.Equal(t, ecx.StringValue(input.Name), d.Get(ecxL2ServiceProfileSchemaNames["Name"]), "Name matches")
-	assert.Equal(t, input.OnBandwidthThresholdNotification, expandSetToStringList(d.Get(ecxL2ServiceProfileSchemaNames["OnBandwidthThresholdNotification"]).(*schema.Set)), "OnBandwidthThresholdNotification matches")
-	assert.Equal(t, input.OnProfileApprovalRejectNotification, expandSetToStringList(d.Get(ecxL2ServiceProfileSchemaNames["OnProfileApprovalRejectNotification"]).(*schema.Set)), "OnProfileApprovalRejectNotification matches")
-	assert.Equal(t, input.OnVcApprovalRejectionNotification, expandSetToStringList(d.Get(ecxL2ServiceProfileSchemaNames["OnVcApprovalRejectionNotification"]).(*schema.Set)), "OnVcApprovalRejectionNotification matches")
+	assert.Equal(t, input.OnBandwidthThresholdNotification, converters.SetToStringList(d.Get(ecxL2ServiceProfileSchemaNames["OnBandwidthThresholdNotification"]).(*schema.Set)), "OnBandwidthThresholdNotification matches")
+	assert.Equal(t, input.OnProfileApprovalRejectNotification, converters.SetToStringList(d.Get(ecxL2ServiceProfileSchemaNames["OnProfileApprovalRejectNotification"]).(*schema.Set)), "OnProfileApprovalRejectNotification matches")
+	assert.Equal(t, input.OnVcApprovalRejectionNotification, converters.SetToStringList(d.Get(ecxL2ServiceProfileSchemaNames["OnVcApprovalRejectionNotification"]).(*schema.Set)), "OnVcApprovalRejectionNotification matches")
 	assert.Equal(t, ecx.StringValue(input.OverSubscription), d.Get(ecxL2ServiceProfileSchemaNames["OverSubscription"]), "OverSubscription matches")
 	assert.Equal(t, ecx.BoolValue(input.Private), d.Get(ecxL2ServiceProfileSchemaNames["Private"]), "Private matches")
-	assert.Equal(t, input.PrivateUserEmails, expandSetToStringList(d.Get(ecxL2ServiceProfileSchemaNames["PrivateUserEmails"]).(*schema.Set)), "PrivateUserEmails matches")
+	assert.Equal(t, input.PrivateUserEmails, converters.SetToStringList(d.Get(ecxL2ServiceProfileSchemaNames["PrivateUserEmails"]).(*schema.Set)), "PrivateUserEmails matches")
 	assert.Equal(t, ecx.BoolValue(input.RequiredRedundancy), d.Get(ecxL2ServiceProfileSchemaNames["RequiredRedundancy"]), "RequiredRedundancy matches")
 	assert.Equal(t, ecx.BoolValue(input.SpeedFromAPI), d.Get(ecxL2ServiceProfileSchemaNames["SpeedFromAPI"]), "SpeedFromAPI matches")
 	assert.Equal(t, ecx.StringValue(input.TagType), d.Get(ecxL2ServiceProfileSchemaNames["TagType"]), "TagType matches")

--- a/equinix/resource_fabric_service_profile.go
+++ b/equinix/resource_fabric_service_profile.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 
@@ -77,7 +78,7 @@ func getServiceProfileRequestPayload(d *schema.ResourceData) v4.ServiceProfileRe
 	var tags []string
 	if d.Get("tags") != nil {
 		schemaTags := d.Get("tags").([]interface{})
-		tags = expandListToStringList(schemaTags)
+		tags = converters.IfArrToStringArr(schemaTags)
 	}
 
 	spVisibility := v4.ServiceProfileVisibilityEnum(d.Get("visibility").(string))
@@ -85,7 +86,7 @@ func getServiceProfileRequestPayload(d *schema.ResourceData) v4.ServiceProfileRe
 	var spAllowedEmails []string
 	if d.Get("allowed_emails") != nil {
 		schemaAllowedEmails := d.Get("allowed_emails").([]interface{})
-		spAllowedEmails = expandListToStringList(schemaAllowedEmails)
+		spAllowedEmails = converters.IfArrToStringArr(schemaAllowedEmails)
 	}
 
 	schemaAccessPointTypeConfigs := d.Get("access_point_type_configs").([]interface{})

--- a/equinix/resource_metal_vrf.go
+++ b/equinix/resource_metal_vrf.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 
@@ -70,7 +71,7 @@ func resourceMetalVRFCreate(ctx context.Context, d *schema.ResourceData, meta in
 		Description: d.Get("description").(string),
 		Metro:       d.Get("metro").(string),
 		LocalASN:    d.Get("local_asn").(int),
-		IPRanges:    expandSetToStringList(d.Get("ip_ranges").(*schema.Set)),
+		IPRanges:    converters.SetToStringList(d.Get("ip_ranges").(*schema.Set)),
 	}
 
 	projectId := d.Get("project_id").(string)
@@ -102,7 +103,7 @@ func resourceMetalVRFUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		updateRequest.LocalASN = iPtr(d.Get("local_asn").(int))
 	}
 	if d.HasChange("ip_ranges") {
-		ipRanges := expandSetToStringList(d.Get("ip_ranges").(*schema.Set))
+		ipRanges := converters.SetToStringList(d.Get("ip_ranges").(*schema.Set))
 		updateRequest.IPRanges = &ipRanges
 	}
 

--- a/equinix/resource_network_acl_template.go
+++ b/equinix/resource_network_acl_template.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
@@ -338,7 +339,7 @@ func expandACLTemplateInboundRules(rules []interface{}) []ne.ACLTemplateInboundR
 		rule := ne.ACLTemplateInboundRule{}
 		rule.SeqNo = ne.Int(i + 1)
 		if v, ok := ruleMap[networkACLTemplateInboundRuleSchemaNames["Subnets"]]; ok {
-			rule.Subnets = expandListToStringList(v.([]interface{}))
+			rule.Subnets = converters.IfArrToStringArr(v.([]interface{}))
 		}
 		if v, ok := ruleMap[networkACLTemplateInboundRuleSchemaNames["Subnet"]]; ok {
 			rule.Subnet = ne.String(v.(string))

--- a/equinix/resource_network_acl_template_test.go
+++ b/equinix/resource_network_acl_template_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/equinix/ne-go"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -119,7 +120,7 @@ func TestNetworkACLTemplate_expandInboundRules(t *testing.T) {
 	expected := []ne.ACLTemplateInboundRule{
 		{
 			SeqNo:       ne.Int(1),
-			Subnets:     expandListToStringList(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Subnets"]].([]interface{})),
+			Subnets:     converters.IfArrToStringArr(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Subnets"]].([]interface{})),
 			Subnet:      nilSubnet,
 			Protocol:    ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Protocol"]].(string)),
 			SrcPort:     ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["SrcPort"]].(string)),

--- a/equinix/resource_network_device.go
+++ b/equinix/resource_network_device.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
@@ -1072,7 +1073,7 @@ func createNetworkDevices(d *schema.ResourceData) (*ne.Device, *ne.Device) {
 		primary.AccountNumber = ne.String(v.(string))
 	}
 	if v, ok := d.GetOk(neDeviceSchemaNames["Notifications"]); ok {
-		primary.Notifications = expandSetToStringList(v.(*schema.Set))
+		primary.Notifications = converters.SetToStringList(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk(neDeviceSchemaNames["PurchaseOrderNumber"]); ok {
 		primary.PurchaseOrderNumber = ne.String(v.(string))
@@ -1094,7 +1095,7 @@ func createNetworkDevices(d *schema.ResourceData) (*ne.Device, *ne.Device) {
 	}
 	primary.IsSelfManaged = ne.Bool(d.Get(neDeviceSchemaNames["IsSelfManaged"]).(bool))
 	if v, ok := d.GetOk(neDeviceSchemaNames["VendorConfiguration"]); ok {
-		primary.VendorConfiguration = expandInterfaceMapToStringMap(v.(map[string]interface{}))
+		primary.VendorConfiguration = converters.InterfaceMapToStringMap(v.(map[string]interface{}))
 	}
 	if v, ok := d.GetOk(neDeviceSchemaNames["WanInterfaceId"]); ok {
 		primary.WanInterfaceId = ne.String(v.(string))
@@ -1318,7 +1319,7 @@ func expandNetworkDeviceSecondary(devices []interface{}) *ne.Device {
 		transformed.AccountNumber = ne.String(v.(string))
 	}
 	if v, ok := device[neDeviceSchemaNames["Notifications"]]; ok {
-		transformed.Notifications = expandSetToStringList(v.(*schema.Set))
+		transformed.Notifications = converters.SetToStringList(v.(*schema.Set))
 	}
 	if v, ok := device[neDeviceSchemaNames["AdditionalBandwidth"]]; ok && !isEmpty(v) {
 		transformed.AdditionalBandwidth = ne.Int(v.(int))
@@ -1327,7 +1328,7 @@ func expandNetworkDeviceSecondary(devices []interface{}) *ne.Device {
 		transformed.WanInterfaceId = ne.String(v.(string))
 	}
 	if v, ok := device[neDeviceSchemaNames["VendorConfiguration"]]; ok {
-		transformed.VendorConfiguration = expandInterfaceMapToStringMap(v.(map[string]interface{}))
+		transformed.VendorConfiguration = converters.InterfaceMapToStringMap(v.(map[string]interface{}))
 	}
 	if v, ok := device[neDeviceSchemaNames["UserPublicKey"]]; ok {
 		userKeys := expandNetworkDeviceUserKeys(v.(*schema.Set))
@@ -1498,9 +1499,7 @@ func fillNetworkDeviceUpdateRequest(updateReq ne.DeviceUpdateRequest, changes ma
 		case neDeviceSchemaNames["TermLength"]:
 			updateReq.WithTermLength(changeValue.(int))
 		case neDeviceSchemaNames["Notifications"]:
-			updateReq.WithNotifications(expandSetToStringList(changeValue.(*schema.Set)))
-		case neDeviceSchemaNames["CoreCount"]:
-			updateReq.WithCore(changeValue.(int))
+			updateReq.WithNotifications(converters.SetToStringList(changeValue.(*schema.Set)))
 		case neDeviceSchemaNames["AdditionalBandwidth"]:
 			updateReq.WithAdditionalBandwidth(changeValue.(int))
 		case neDeviceSchemaNames["ACLTemplateUUID"]:

--- a/equinix/resource_network_device_test.go
+++ b/equinix/resource_network_device_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/equinix/ne-go"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -143,7 +144,7 @@ func TestNetworkDevice_updateResourceData(t *testing.T) {
 	assert.Empty(t, d.Get(neDeviceSchemaNames["LicenseToken"]), "LicenseToken is empty")
 	assert.Equal(t, ne.StringValue(inputPrimary.ACLTemplateUUID), d.Get(neDeviceSchemaNames["ACLTemplateUUID"]), "ACLTemplateUUID matches")
 	assert.Equal(t, ne.StringValue(inputPrimary.AccountNumber), d.Get(neDeviceSchemaNames["AccountNumber"]), "AccountNumber matches")
-	assert.Equal(t, inputPrimary.Notifications, expandSetToStringList(d.Get(neDeviceSchemaNames["Notifications"]).(*schema.Set)), "Notifications matches")
+	assert.Equal(t, inputPrimary.Notifications, converters.SetToStringList(d.Get(neDeviceSchemaNames["Notifications"]).(*schema.Set)), "Notifications matches")
 	assert.Equal(t, ne.StringValue(inputPrimary.PurchaseOrderNumber), d.Get(neDeviceSchemaNames["PurchaseOrderNumber"]), "PurchaseOrderNumber matches")
 	assert.Equal(t, ne.IntValue(inputPrimary.TermLength), d.Get(neDeviceSchemaNames["TermLength"]), "TermLength matches")
 	assert.Equal(t, ne.IntValue(inputPrimary.AdditionalBandwidth), d.Get(neDeviceSchemaNames["AdditionalBandwidth"]), "AdditionalBandwidth matches")
@@ -152,7 +153,7 @@ func TestNetworkDevice_updateResourceData(t *testing.T) {
 	assert.Empty(t, d.Get(neDeviceSchemaNames["WanInterfaceId"]), "Wan Interface Id is empty")
 	assert.Equal(t, ne.IntValue(inputPrimary.CoreCount), d.Get(neDeviceSchemaNames["CoreCount"]), "CoreCount matches")
 	assert.Equal(t, ne.BoolValue(inputPrimary.IsSelfManaged), d.Get(neDeviceSchemaNames["IsSelfManaged"]), "IsSelfManaged matches")
-	assert.Equal(t, inputPrimary.VendorConfiguration, expandInterfaceMapToStringMap(d.Get(neDeviceSchemaNames["VendorConfiguration"]).(map[string]interface{})), "VendorConfiguration matches")
+	assert.Equal(t, inputPrimary.VendorConfiguration, converters.InterfaceMapToStringMap(d.Get(neDeviceSchemaNames["VendorConfiguration"]).(map[string]interface{})), "VendorConfiguration matches")
 	assert.Equal(t, inputPrimary.UserPublicKey, expandNetworkDeviceUserKeys(d.Get(neDeviceSchemaNames["UserPublicKey"]).(*schema.Set))[0], "UserPublicKey matches")
 	assert.Equal(t, ne.IntValue(inputPrimary.ASN), d.Get(neDeviceSchemaNames["ASN"]), "ASN matches")
 	assert.Equal(t, ne.StringValue(inputPrimary.ZoneCode), d.Get(neDeviceSchemaNames["ZoneCode"]), "ZoneCode matches")
@@ -296,7 +297,7 @@ func TestNetworkDevice_expandSecondary(t *testing.T) {
 		LicenseFile:         ne.String(input[0].(map[string]interface{})[neDeviceSchemaNames["LicenseFile"]].(string)),
 		ACLTemplateUUID:     ne.String(input[0].(map[string]interface{})[neDeviceSchemaNames["ACLTemplateUUID"]].(string)),
 		AccountNumber:       ne.String(input[0].(map[string]interface{})[neDeviceSchemaNames["AccountNumber"]].(string)),
-		Notifications:       expandSetToStringList(input[0].(map[string]interface{})[neDeviceSchemaNames["Notifications"]].(*schema.Set)),
+		Notifications:       converters.SetToStringList(input[0].(map[string]interface{})[neDeviceSchemaNames["Notifications"]].(*schema.Set)),
 		AdditionalBandwidth: ne.Int(input[0].(map[string]interface{})[neDeviceSchemaNames["AdditionalBandwidth"]].(int)),
 		VendorConfiguration: map[string]string{
 			"key": "value",

--- a/equinix/resource_network_ssh_user.go
+++ b/equinix/resource_network_ssh_user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 
 	"github.com/equinix/ne-go"
 	"github.com/hashicorp/go-cty/cty"
@@ -127,8 +128,8 @@ func resourceNetworkSSHUserUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 	if d.HasChange(networkSSHUserSchemaNames["DeviceUUIDs"]) {
 		a, b := d.GetChange(networkSSHUserSchemaNames["DeviceUUIDs"])
-		aList := expandSetToStringList(a.(*schema.Set))
-		bList := expandSetToStringList(b.(*schema.Set))
+		aList := converters.SetToStringList(a.(*schema.Set))
+		bList := converters.SetToStringList(b.(*schema.Set))
 		updateReq.WithDeviceChange(aList, bList)
 	}
 	if err := updateReq.Execute(); err != nil {
@@ -160,7 +161,7 @@ func createNetworkSSHUser(d *schema.ResourceData) ne.SSHUser {
 		user.Password = ne.String(v.(string))
 	}
 	if v, ok := d.GetOk(networkSSHUserSchemaNames["DeviceUUIDs"]); ok {
-		user.DeviceUUIDs = expandSetToStringList(v.(*schema.Set))
+		user.DeviceUUIDs = converters.SetToStringList(v.(*schema.Set))
 	}
 	return user
 }

--- a/equinix/resource_network_ssh_user_test.go
+++ b/equinix/resource_network_ssh_user_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/equinix/ne-go"
+	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -44,5 +45,5 @@ func TestNetworkSSHUser_updateResourceData(t *testing.T) {
 	assert.Nil(t, err, "Update of resource data does not return error")
 	assert.Equal(t, ne.StringValue(input.Username), d.Get(networkSSHUserSchemaNames["Username"]), "Username matches")
 	assert.Equal(t, ne.StringValue(input.Password), d.Get(networkSSHUserSchemaNames["Password"]), "Password matches")
-	assert.Equal(t, input.DeviceUUIDs, expandSetToStringList(d.Get(networkSSHUserSchemaNames["DeviceUUIDs"]).(*schema.Set)), "DeviceUUIDs matches")
+	assert.Equal(t, input.DeviceUUIDs, converters.SetToStringList(d.Get(networkSSHUserSchemaNames["DeviceUUIDs"]).(*schema.Set)), "DeviceUUIDs matches")
 }

--- a/internal/converters/converters.go
+++ b/internal/converters/converters.go
@@ -1,8 +1,11 @@
 package converters
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func StringArrToIfArr(sli []string) []interface{} {
@@ -63,4 +66,25 @@ func Difference(a, b []string) []string {
 		}
 	}
 	return diff
+}
+
+func ListToInt32List(list []interface{}) []int32 {
+	result := make([]int32, len(list))
+	for i, v := range list {
+		result[i] = int32(v.(int))
+	}
+	return result
+}
+
+func SetToStringList(set *schema.Set) []string {
+	list := set.List()
+	return IfArrToStringArr(list)
+}
+
+func InterfaceMapToStringMap(mapIn map[string]interface{}) map[string]string {
+	mapOut := make(map[string]string)
+	for k, v := range mapIn {
+		mapOut[k] = fmt.Sprintf("%v", v)
+	}
+	return mapOut
 }


### PR DESCRIPTION
This moves some type conversion utility functions out of `provider.go` into the existing `converters` package so that they can be safely used by multiple resources and data sources without forcing those resources and data sources to be in the same package as the provider definition.