### PR TITLE
chore: stabilize Metal organization test

### DIFF
--- a/equinix/resource_metal_organization_acc_test.go
+++ b/equinix/resource_metal_organization_acc_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
@@ -75,7 +76,8 @@ func TestAccMetalOrganization_create(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMetalOrganizationConfig_basicUpdate(rInt),
+				PreConfig: testAccMetalWaitForOrganization,
+				Config:    testAccMetalOrganizationConfig_basicUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMetalOrganizationExists("equinix_metal_organization.test", &org2),
 					resource.TestCheckResourceAttr(
@@ -102,6 +104,14 @@ func testAccMetalSameOrganization(t *testing.T, before, after *packngo.Organizat
 		}
 		return nil
 	}
+}
+
+func testAccMetalWaitForOrganization() {
+	// Some aspect of organization creation takes a while
+	// to propagate; updating an organization too soon after
+	// create causes test failures and probably doesn't
+	// reflect real-world usage.
+	time.Sleep(5 * time.Minute)
 }
 
 func TestAccMetalOrganization_importBasic(t *testing.T) {


### PR DESCRIPTION
The terraform acceptance test for `metal_organization` creates an organization and then very quickly updates it.  The update step started failing at some point mid-2023 and was briefly fixed, but it has been failing consistently for quite a while now.

There is some background processing that happens when an organization is created, and the API will throw an error if the organization is updated before that background processing is finished.  This adds a delay between the create and update calls for an organization so that the affected test can pass.

Fixes #463.