### PR TITLE
fix: send an empty array for IP ranges instead of null

### DIFF
--- a/internal/converters/converters.go
+++ b/internal/converters/converters.go
@@ -17,12 +17,9 @@ func StringArrToIfArr(sli []string) []interface{} {
 }
 
 func IfArrToStringArr(ifaceArr []interface{}) []string {
-	var arr []string
-	for _, v := range ifaceArr {
-		if v == nil {
-			continue
-		}
-		arr = append(arr, v.(string))
+	arr := make([]string, len(ifaceArr))
+	for i, v := range ifaceArr {
+		arr[i] = fmt.Sprint(v)
 	}
 	return arr
 }


### PR DESCRIPTION
Fix #515.

The `TestAccMetalVRF_withIPRanges` started failing recently with an error that `ip_ranges` cannot be null.  It appears this test failure was caused by #509, which consolidated the [`expandListToStringList`](https://github.com/equinix/terraform-provider-equinix/pull/509/files#diff-17a1d27f648a15532c90c0ed8e7b143adde23b59dec5bbe4222db41a0a94ea0aL225-L232) and `IfArrToStringArr` functions.

This updates the `IfArrToStringArr` converter to match the old `expandListToStringList` implementation, which fixes the failing test.