### PR TITLE
fix: fixing WaitForConnectionProviderStatus function for AWS connections

### DIFF
--- a/equinix/resource_fabric_connection.go
+++ b/equinix/resource_fabric_connection.go
@@ -321,9 +321,9 @@ func waitForConnectionProviderStatusChange(uuid string, meta interface{}, ctx co
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			string(v4.PENDING_APPROVAL_ProviderStatus),
+			string(v4.PROVISIONING_ProviderStatus),
 		},
 		Target: []string{
-			string(v4.PROVISIONING_ProviderStatus),
 			string(v4.PROVISIONED_ProviderStatus),
 		},
 		Refresh: func() (interface{}, string, error) {


### PR DESCRIPTION
Added string(v4.PROVISIONING_ProviderStatus) to pending block for AWS connections