### PR TITLE
refactor: move resource data change detectors to separate package

### DIFF
--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -3,15 +3,12 @@ package equinix
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/equinix/terraform-provider-equinix/internal/config"
-	"github.com/equinix/terraform-provider-equinix/internal/hashcode"
-
 	"github.com/equinix/ecx-go/v2"
+	"github.com/equinix/terraform-provider-equinix/internal/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
@@ -23,28 +20,6 @@ var (
 	testAccProvider          *schema.Provider
 	testExternalProviders    map[string]resource.ExternalProvider
 )
-
-type mockedResourceDataProvider struct {
-	actual map[string]interface{}
-	old    map[string]interface{}
-}
-
-func (r mockedResourceDataProvider) Get(key string) interface{} {
-	return r.actual[key]
-}
-
-func (r mockedResourceDataProvider) GetOk(key string) (interface{}, bool) {
-	v, ok := r.actual[key]
-	return v, ok
-}
-
-func (r mockedResourceDataProvider) HasChange(key string) bool {
-	return !reflect.DeepEqual(r.old[key], r.actual[key])
-}
-
-func (r mockedResourceDataProvider) GetChange(key string) (interface{}, interface{}) {
-	return r.old[key], r.actual[key]
-}
 
 type mockECXClient struct {
 	GetUserPortsFn func() ([]ecx.Port, error)
@@ -176,82 +151,6 @@ func TestProvider_stringsFound_negative(t *testing.T) {
 	assert.False(t, result, "Given strings were found")
 }
 
-func TestProvider_resourceDataChangedKeys(t *testing.T) {
-	// given
-	keys := []string{"key", "keyTwo", "keyThree"}
-	rd := mockedResourceDataProvider{
-		actual: map[string]interface{}{
-			"key":    "value",
-			"keyTwo": "newValueTwo",
-		},
-		old: map[string]interface{}{
-			"key":    "value",
-			"keyTwo": "valueTwo",
-		},
-	}
-	expected := map[string]interface{}{
-		"keyTwo": "newValueTwo",
-	}
-	// when
-	result := getResourceDataChangedKeys(keys, rd)
-	// then
-	assert.Equal(t, expected, result, "Function returns valid key changes")
-}
-
-func TestProvider_resourceDataListElementChanges(t *testing.T) {
-	// given
-	keys := []string{"key", "keyTwo", "keyThree"}
-	listKeyName := "myList"
-	rd := mockedResourceDataProvider{
-		old: map[string]interface{}{
-			listKeyName: []interface{}{
-				map[string]interface{}{
-					"key":      "value",
-					"keyTwo":   "valueTwo",
-					"keyThree": 50,
-				},
-			},
-		},
-		actual: map[string]interface{}{
-			listKeyName: []interface{}{
-				map[string]interface{}{
-					"key":      "value",
-					"keyTwo":   "newValueTwo",
-					"keyThree": 100,
-				},
-			},
-		},
-	}
-	expected := map[string]interface{}{
-		"keyTwo":   "newValueTwo",
-		"keyThree": 100,
-	}
-	// when
-	result := getResourceDataListElementChanges(keys, listKeyName, 0, rd)
-	// then
-	assert.Equal(t, expected, result, "Function returns valid key changes")
-}
-
-func TestProvider_mapChanges(t *testing.T) {
-	// given
-	keys := []string{"key", "keyTwo", "keyThree"}
-	old := map[string]interface{}{
-		"key":    "value",
-		"keyTwo": "valueTwo",
-	}
-	new := map[string]interface{}{
-		"key":    "newValue",
-		"keyTwo": "valueTwo",
-	}
-	expected := map[string]interface{}{
-		"key": "newValue",
-	}
-	// when
-	result := getMapChangedKeys(keys, old, new)
-	// then
-	assert.Equal(t, expected, result, "Function returns valid key changes")
-}
-
 func TestProvider_isEmpty(t *testing.T) {
 	// given
 	input := []interface{}{
@@ -329,31 +228,6 @@ func TestProvider_slicesMatch(t *testing.T) {
 	for i := range expected {
 		assert.Equal(t, expected[i], results[i])
 	}
-}
-
-func TestProvider_schemaSetToMap(t *testing.T) {
-	// given
-	type item struct {
-		id       string
-		valueOne int
-		valueTwo int
-	}
-	setFunc := func(v interface{}) int {
-		i := v.(item)
-		return hashcode.String(i.id)
-	}
-	items := []interface{}{
-		item{"id1", 100, 200},
-		item{"id2", 666, 999},
-		item{"id3", 0, 100},
-	}
-	set := schema.NewSet(setFunc, items)
-	// when
-	list := schemaSetToMap(set)
-	// then
-	assert.Equal(t, items[0], list[setFunc(items[0])])
-	assert.Equal(t, items[1], list[setFunc(items[1])])
-	assert.Equal(t, items[2], list[setFunc(items[2])])
 }
 
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾

--- a/equinix/resource_ecx_l2_connection.go
+++ b/equinix/resource_ecx_l2_connection.go
@@ -10,6 +10,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
+	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ecx-go/v2"
@@ -755,13 +756,13 @@ func resourceECXL2ConnectionUpdate(ctx context.Context, d *schema.ResourceData, 
 		ecxL2ConnectionSchemaNames["Speed"],
 		ecxL2ConnectionSchemaNames["SpeedUnit"],
 	}
-	primaryChanges := getResourceDataChangedKeys(supportedChanges, d)
+	primaryChanges := equinix_schema.GetResourceDataChangedKeys(supportedChanges, d)
 	primaryUpdateReq := client.NewL2ConnectionUpdateRequest(d.Id())
 	if err := fillFabricL2ConnectionUpdateRequest(primaryUpdateReq, primaryChanges).Execute(); err != nil {
 		return diag.FromErr(err)
 	}
 	if redID, ok := d.GetOk(ecxL2ConnectionSchemaNames["RedundantUUID"]); ok {
-		secondaryChanges := getResourceDataListElementChanges(supportedChanges, ecxL2ConnectionSchemaNames["SecondaryConnection"], 0, d)
+		secondaryChanges := equinix_schema.GetResourceDataListElementChanges(supportedChanges, ecxL2ConnectionSchemaNames["SecondaryConnection"], 0, d)
 		secondaryUpdateReq := client.NewL2ConnectionUpdateRequest(redID.(string))
 		if err := fillFabricL2ConnectionUpdateRequest(secondaryUpdateReq, secondaryChanges).Execute(); err != nil {
 			return diag.FromErr(err)

--- a/equinix/resource_metal_organization.go
+++ b/equinix/resource_metal_organization.go
@@ -174,7 +174,7 @@ func resourceMetalOrganizationUpdate(d *schema.ResourceData, meta interface{}) e
 	meta.(*config.Config).AddModuleToMetalUserAgent(d)
 	client := meta.(*config.Config).Metal
 
-	changes := getResourceDataChangedKeys([]string{"name", "description", "website", "twitter", "logo", "address"}, d)
+	changes := equinix_schema.GetResourceDataChangedKeys([]string{"name", "description", "website", "twitter", "logo", "address"}, d)
 	updateRequest := &packngo.OrganizationUpdateRequest{}
 	for change, changeValue := range changes {
 		switch change {

--- a/equinix/resource_network_device.go
+++ b/equinix/resource_network_device.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 	"github.com/equinix/terraform-provider-equinix/internal/converters"
+	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
@@ -965,11 +966,11 @@ func resourceNetworkDeviceUpdate(ctx context.Context, d *schema.ResourceData, m 
 		neDeviceSchemaNames["ACLTemplateUUID"], neDeviceSchemaNames["MgmtAclTemplateUuid"],
 	}
 	updateReq := client.NewDeviceUpdateRequest(d.Id())
-	primaryChanges := getResourceDataChangedKeys(supportedChanges, d)
+	primaryChanges := equinix_schema.GetResourceDataChangedKeys(supportedChanges, d)
 	var clusterChanges map[string]interface{}
 	clusterSupportedChanges := []string{neDeviceClusterSchemaNames["ClusterName"]}
 	if _, ok := d.GetOk(neDeviceSchemaNames["ClusterDetails"]); ok {
-		clusterChanges = getResourceDataListElementChanges(clusterSupportedChanges, neDeviceSchemaNames["ClusterDetails"], 0, d)
+		clusterChanges = equinix_schema.GetResourceDataListElementChanges(clusterSupportedChanges, neDeviceSchemaNames["ClusterDetails"], 0, d)
 		for key, value := range clusterChanges {
 			primaryChanges[key] = value
 		}
@@ -979,7 +980,7 @@ func resourceNetworkDeviceUpdate(ctx context.Context, d *schema.ResourceData, m 
 	}
 	var secondaryChanges map[string]interface{}
 	if v, ok := d.GetOk(neDeviceSchemaNames["RedundantUUID"]); ok {
-		secondaryChanges = getResourceDataListElementChanges(supportedChanges, neDeviceSchemaNames["Secondary"], 0, d)
+		secondaryChanges = equinix_schema.GetResourceDataListElementChanges(supportedChanges, neDeviceSchemaNames["Secondary"], 0, d)
 		secondaryUpdateReq := client.NewDeviceUpdateRequest(v.(string))
 		if err := fillNetworkDeviceUpdateRequest(secondaryUpdateReq, secondaryChanges).Execute(); err != nil {
 			return diag.FromErr(err)

--- a/equinix/resource_network_device_link.go
+++ b/equinix/resource_network_device_link.go
@@ -8,6 +8,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	"github.com/equinix/terraform-provider-equinix/internal/hashcode"
+	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
@@ -274,7 +275,7 @@ func resourceNetworkDeviceLinkUpdate(ctx context.Context, d *schema.ResourceData
 	client := m.(*config.Config).Ne
 	m.(*config.Config).AddModuleToNEUserAgent(&client, d)
 	var diags diag.Diagnostics
-	changes := getResourceDataChangedKeys([]string{
+	changes := equinix_schema.GetResourceDataChangedKeys([]string{
 		networkDeviceLinkSchemaNames["Name"], networkDeviceLinkSchemaNames["Subnet"],
 		networkDeviceLinkSchemaNames["Devices"], networkDeviceLinkSchemaNames["Links"],
 	}, d)
@@ -517,4 +518,15 @@ func networkDeviceLinkConnectionKey(v interface{}) string {
 
 func networkDeviceLinkConnectionHash(v interface{}) int {
 	return hashcode.String(networkDeviceLinkConnectionKey(v))
+}
+
+func schemaSetToMap(set *schema.Set) map[int]interface{} {
+	transformed := make(map[int]interface{})
+	if set != nil {
+		list := set.List()
+		for i := range list {
+			transformed[set.F(list[i])] = list[i]
+		}
+	}
+	return transformed
 }

--- a/internal/schema/resourcedata.go
+++ b/internal/schema/resourcedata.go
@@ -1,0 +1,46 @@
+package schema
+
+import "reflect"
+
+// resourceDataProvider provies interface to schema.ResourceData
+// for convenient mocking purposes
+type resourceDataProvider interface {
+	Get(key string) interface{}
+	GetOk(key string) (interface{}, bool)
+	HasChange(key string) bool
+	GetChange(key string) (interface{}, interface{})
+}
+
+func getMapChangedKeys(keys []string, old, new map[string]interface{}) map[string]interface{} {
+	changed := make(map[string]interface{})
+	for _, key := range keys {
+		if !reflect.DeepEqual(old[key], new[key]) {
+			changed[key] = new[key]
+		}
+	}
+	return changed
+}
+
+func GetResourceDataChangedKeys(keys []string, d resourceDataProvider) map[string]interface{} {
+	changed := make(map[string]interface{})
+	for _, key := range keys {
+		if v := d.Get(key); v != nil && d.HasChange(key) {
+			changed[key] = v
+		}
+	}
+	return changed
+}
+
+func GetResourceDataListElementChanges(keys []string, listKeyName string, listIndex int, d resourceDataProvider) map[string]interface{} {
+	changed := make(map[string]interface{})
+	if !d.HasChange(listKeyName) {
+		return changed
+	}
+	old, new := d.GetChange(listKeyName)
+	oldList := old.([]interface{})
+	newList := new.([]interface{})
+	if len(oldList) < listIndex || len(newList) < listIndex {
+		return changed
+	}
+	return getMapChangedKeys(keys, oldList[listIndex].(map[string]interface{}), newList[listIndex].(map[string]interface{}))
+}

--- a/internal/schema/resourcedata_test.go
+++ b/internal/schema/resourcedata_test.go
@@ -1,0 +1,106 @@
+package schema
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockedResourceDataProvider struct {
+	actual map[string]interface{}
+	old    map[string]interface{}
+}
+
+func (r mockedResourceDataProvider) Get(key string) interface{} {
+	return r.actual[key]
+}
+
+func (r mockedResourceDataProvider) GetOk(key string) (interface{}, bool) {
+	v, ok := r.actual[key]
+	return v, ok
+}
+
+func (r mockedResourceDataProvider) HasChange(key string) bool {
+	return !reflect.DeepEqual(r.old[key], r.actual[key])
+}
+
+func (r mockedResourceDataProvider) GetChange(key string) (interface{}, interface{}) {
+	return r.old[key], r.actual[key]
+}
+
+func TestProvider_resourceDataChangedKeys(t *testing.T) {
+	// given
+	keys := []string{"key", "keyTwo", "keyThree"}
+	rd := mockedResourceDataProvider{
+		actual: map[string]interface{}{
+			"key":    "value",
+			"keyTwo": "newValueTwo",
+		},
+		old: map[string]interface{}{
+			"key":    "value",
+			"keyTwo": "valueTwo",
+		},
+	}
+	expected := map[string]interface{}{
+		"keyTwo": "newValueTwo",
+	}
+	// when
+	result := GetResourceDataChangedKeys(keys, rd)
+	// then
+	assert.Equal(t, expected, result, "Function returns valid key changes")
+}
+
+func TestProvider_resourceDataListElementChanges(t *testing.T) {
+	// given
+	keys := []string{"key", "keyTwo", "keyThree"}
+	listKeyName := "myList"
+	rd := mockedResourceDataProvider{
+		old: map[string]interface{}{
+			listKeyName: []interface{}{
+				map[string]interface{}{
+					"key":      "value",
+					"keyTwo":   "valueTwo",
+					"keyThree": 50,
+				},
+			},
+		},
+		actual: map[string]interface{}{
+			listKeyName: []interface{}{
+				map[string]interface{}{
+					"key":      "value",
+					"keyTwo":   "newValueTwo",
+					"keyThree": 100,
+				},
+			},
+		},
+	}
+	expected := map[string]interface{}{
+		"keyTwo":   "newValueTwo",
+		"keyThree": 100,
+	}
+	// when
+	result := GetResourceDataListElementChanges(keys, listKeyName, 0, rd)
+	// then
+	assert.Equal(t, expected, result, "Function returns valid key changes")
+}
+
+func TestProvider_mapChanges(t *testing.T) {
+	// given
+	keys := []string{"key", "keyTwo", "keyThree"}
+	old := map[string]interface{}{
+		"key":    "value",
+		"keyTwo": "valueTwo",
+	}
+	new := map[string]interface{}{
+		"key":    "newValue",
+		"keyTwo": "valueTwo",
+	}
+	expected := map[string]interface{}{
+		"key": "newValue",
+	}
+	// when
+	result := getMapChangedKeys(keys, old, new)
+	// then
+	assert.Equal(t, expected, result, "Function returns valid key changes")
+}

--- a/internal/schema/set_map.go
+++ b/internal/schema/set_map.go
@@ -1,4 +1,4 @@
-package utils
+package schema
 
 import (
 	"sort"


### PR DESCRIPTION
This moves some functions and related tests for detecting changes to resource data out of `provider.go` into its own package so that it's easier to isolate the SDK provider into its own package.  This was broken out of #518 