### PR TITLE
refactor: migrate to plugin sdkv2 helper/id and helper/retry packages

### DIFF
--- a/equinix/resource_fabric_cloud_router.go
+++ b/equinix/resource_fabric_cloud_router.go
@@ -14,7 +14,7 @@ import (
 
 	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -160,7 +160,7 @@ func resourceCloudRouterUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 func waitForCloudRouterUpdateCompletion(uuid string, meta interface{}, ctx context.Context) (v4.CloudRouter, error) {
 	log.Printf("Waiting for Cloud Router update to complete, uuid %s", uuid)
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Target: []string{string(v4.PROVISIONED_CloudRouterAccessPointState)},
 		Refresh: func() (interface{}, string, error) {
 			client := meta.(*config.Config).FabricClient
@@ -186,7 +186,7 @@ func waitForCloudRouterUpdateCompletion(uuid string, meta interface{}, ctx conte
 
 func waitUntilCloudRouterIsProvisioned(uuid string, meta interface{}, ctx context.Context) (v4.CloudRouter, error) {
 	log.Printf("Waiting for Cloud Router to be provisioned, uuid %s", uuid)
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			string(v4.PROVISIONING_CloudRouterAccessPointState),
 		},
@@ -240,7 +240,7 @@ func resourceCloudRouterDelete(ctx context.Context, d *schema.ResourceData, meta
 
 func waitUntilCloudRouterDeprovisioned(uuid string, meta interface{}, ctx context.Context) error {
 	log.Printf("Waiting for Fabric Cloud Router to be deprovisioned, uuid %s", uuid)
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			string(v4.DEPROVISIONING_CloudRouterAccessPointState),
 		},

--- a/equinix/resource_fabric_routing_protocol.go
+++ b/equinix/resource_fabric_routing_protocol.go
@@ -12,7 +12,7 @@ import (
 	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
 	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -314,7 +314,7 @@ func setFabricRoutingProtocolMap(d *schema.ResourceData, rp v4.RoutingProtocolDa
 
 func waitUntilRoutingProtocolIsProvisioned(uuid string, connUuid string, meta interface{}, ctx context.Context) (v4.RoutingProtocolData, error) {
 	log.Printf("Waiting for routing protocol to be provisioned, uuid %s", uuid)
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			string(v4.PROVISIONING_ConnectionState),
 			string(v4.REPROVISIONING_ConnectionState),
@@ -355,7 +355,7 @@ func waitUntilRoutingProtocolIsDeprovisioned(uuid string, connUuid string, meta 
 	log.Printf("Waiting for routing protocol to be deprovisioned, uuid %s", uuid)
 
 	/* check if resource is not found */
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Target: []string{
 			strconv.Itoa(404),
 		},
@@ -378,7 +378,7 @@ func waitUntilRoutingProtocolIsDeprovisioned(uuid string, connUuid string, meta 
 
 func waitForRoutingProtocolUpdateCompletion(rpChangeUuid string, uuid string, connUuid string, meta interface{}, ctx context.Context) (v4.RoutingProtocolChangeData, error) {
 	log.Printf("Waiting for routing protocol update to complete, uuid %s", uuid)
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Target: []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
 			client := meta.(*config.Config).FabricClient

--- a/internal/datalist/schema.go
+++ b/internal/datalist/schema.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -116,7 +116,7 @@ func dataListResourceRead(config *ResourceConfig) schema.ReadContextFunc {
 			flattenedRecords = applySorts(config.RecordSchema, flattenedRecords, sorts)
 		}
 
-		d.SetId(resource.UniqueId())
+		d.SetId(id.UniqueId())
 
 		if err := d.Set(config.ResultAttributeName, flattenedRecords); err != nil {
 			return diag.Errorf("unable to set `%s` attribute: %s", config.ResultAttributeName, err)


### PR DESCRIPTION
Previous step to migrate testing functionality from github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource to github.com/hashicorp/terraform-plugin-testing/v2/helper/resource required to add e2e tests to migrate from SDKv2 to Framework https://github.com/equinix/terraform-provider-equinix/pull/406#issuecomment-1897294576

Almost all resource.StateChangeConf references had already been previously migrated to retry.StateChangeConf