### PR TITLE
chore: fix test that is failing due to unrebased PR merges

### DIFF
--- a/equinix/data_source_fabric_port_acc_test.go
+++ b/equinix/data_source_fabric_port_acc_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDataSourceFabricPort_PNFV(t *testing.T) {


### PR DESCRIPTION
#526 adopted the terraform-plugin-testing module, but #520 introduced a new test that had a reference to the old terraform-plugin-sdk version of that module.  Since we don't have a requirement in place for PRs to be up-to-date before merging, #526 got merged without being updated to also fix the new test from #520, and as a result the `Go test` workflow started failing.  This updates the new test to match the others.