### PR TITLE
refactor: move network type declarations out of provider.go

### DIFF
--- a/equinix/data_source_metal_device.go
+++ b/equinix/data_source_metal_device.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/network"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -107,7 +108,7 @@ func dataSourceMetalDevice() *schema.Resource {
 			},
 			"network_type": {
 				Type:        schema.TypeString,
-				Description: "L2 network type of the device, one of" + NetworkTypeList,
+				Description: "L2 network type of the device, one of" + network.NetworkTypeList,
 				Computed:    true,
 			},
 			"hardware_reservation_id": {

--- a/equinix/data_source_metal_port.go
+++ b/equinix/data_source_metal_port.go
@@ -1,6 +1,7 @@
 package equinix
 
 import (
+	"github.com/equinix/terraform-provider-equinix/internal/network"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -31,7 +32,7 @@ func dataSourceMetalPort() *schema.Resource {
 			"network_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "One of " + NetworkTypeListHB,
+				Description: "One of " + network.NetworkTypeListHB,
 			},
 			"type": {
 				Type:        schema.TypeString,

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -16,13 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var (
-	DeviceNetworkTypes   = []string{"layer3", "hybrid", "layer2-individual", "layer2-bonded"}
-	DeviceNetworkTypesHB = []string{"layer3", "hybrid", "hybrid-bonded", "layer2-individual", "layer2-bonded"}
-	NetworkTypeList      = strings.Join(DeviceNetworkTypes, ", ")
-	NetworkTypeListHB    = strings.Join(DeviceNetworkTypesHB, ", ")
-)
-
 // Provider returns Equinix terraform *schema.Provider
 func Provider() *schema.Provider {
 	provider := &schema.Provider{

--- a/equinix/resource_metal_device.go
+++ b/equinix/resource_metal_device.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/equinix/terraform-provider-equinix/internal/converters"
+	"github.com/equinix/terraform-provider-equinix/internal/network"
 
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 
@@ -206,7 +207,7 @@ func resourceMetalDevice() *schema.Resource {
 			},
 			"network_type": {
 				Type:        schema.TypeString,
-				Description: "Network type of a device, used in [Layer 2 networking](https://metal.equinix.com/developers/docs/networking/layer2/). Will be one of " + NetworkTypeListHB,
+				Description: "Network type of a device, used in [Layer 2 networking](https://metal.equinix.com/developers/docs/networking/layer2/). Will be one of " + network.NetworkTypeListHB,
 				Computed:    true,
 				Deprecated:  "You should handle Network Type with one of 'equinix_metal_port' or 'equinix_metal_device_network_type' resources. See section 'Guides' for more info",
 			},

--- a/equinix/resource_metal_device_network_type.go
+++ b/equinix/resource_metal_device_network_type.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
+	"github.com/equinix/terraform-provider-equinix/internal/network"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
@@ -31,9 +32,9 @@ func resourceMetalDeviceNetworkType() *schema.Resource {
 			},
 			"type": {
 				Type:         schema.TypeString,
-				Description:  "Network type to set. Must be one of " + NetworkTypeListHB,
+				Description:  "Network type to set. Must be one of " + network.NetworkTypeListHB,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice(DeviceNetworkTypesHB, false),
+				ValidateFunc: validation.StringInSlice(network.DeviceNetworkTypesHB, false),
 			},
 		},
 	}

--- a/internal/network/types.go
+++ b/internal/network/types.go
@@ -1,0 +1,10 @@
+package network
+
+import "strings"
+
+var (
+	DeviceNetworkTypes   = []string{"layer3", "hybrid", "layer2-individual", "layer2-bonded"}
+	DeviceNetworkTypesHB = []string{"layer3", "hybrid", "hybrid-bonded", "layer2-individual", "layer2-bonded"}
+	NetworkTypeList      = strings.Join(DeviceNetworkTypes, ", ")
+	NetworkTypeListHB    = strings.Join(DeviceNetworkTypesHB, ", ")
+)


### PR DESCRIPTION
This moves some variables for Equinix Metal network types into its own package.  Removing this from provider.go will make it easer to move the existing SDK provider definition into a separate package from the provider resources & data sources.  This is broken out of