### PR TITLE
refactor: move isEmpty out of provider.go

### DIFF
--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -9,7 +9,6 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/metal_project_ssh_key"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/metal_ssh_key"
 
-	"github.com/equinix/ecx-go/v2"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -230,23 +229,6 @@ func isStringInSlice(needle string, hay []string) bool {
 		}
 	}
 	return false
-}
-
-func isEmpty(v interface{}) bool {
-	switch v := v.(type) {
-	case int:
-		return v == 0
-	case *int:
-		return ecx.IntValue(v) == 0
-	case string:
-		return v == ""
-	case *string:
-		return ecx.StringValue(v) == ""
-	case nil:
-		return true
-	default:
-		return false
-	}
 }
 
 func slicesMatch(s1, s2 []string) bool {

--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -151,49 +151,6 @@ func TestProvider_stringsFound_negative(t *testing.T) {
 	assert.False(t, result, "Given strings were found")
 }
 
-func TestProvider_isEmpty(t *testing.T) {
-	// given
-	input := []interface{}{
-		"test",
-		"",
-		nil,
-		123,
-		0,
-		43.43,
-	}
-	expected := []bool{
-		false,
-		true,
-		true,
-		false,
-		true,
-		false,
-		true,
-	}
-	// when then
-	for i := range input {
-		assert.Equal(t, expected[i], isEmpty(input[i]), "Input %v produces expected result %v", input[i], expected[i])
-	}
-}
-
-func TestProvider_setSchemaValueIfNotEmpty(t *testing.T) {
-	// given
-	key := "test"
-	s := map[string]*schema.Schema{
-		key: {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-	}
-	var b *int = nil
-	d := schema.TestResourceDataRaw(t, s, make(map[string]interface{}))
-	// when
-	setSchemaValueIfNotEmpty(key, b, d)
-	// then
-	_, ok := d.GetOk(key)
-	assert.False(t, ok, "Key was not set")
-}
-
 func TestProvider_slicesMatch(t *testing.T) {
 	// given
 	input := [][][]string{
@@ -300,11 +257,4 @@ func copyMap(source map[string]interface{}) map[string]interface{} {
 		target[k] = v
 	}
 	return target
-}
-
-func setSchemaValueIfNotEmpty(key string, value interface{}, d *schema.ResourceData) error {
-	if !isEmpty(value) {
-		return d.Set(key, value)
-	}
-	return nil
 }

--- a/equinix/resource_ecx_l2_connection.go
+++ b/equinix/resource_ecx_l2_connection.go
@@ -1032,40 +1032,40 @@ func expandECXL2ConnectionSecondary(conns []interface{}) *ecx.L2Connection {
 	if v, ok := conn[ecxL2ConnectionSchemaNames["Name"]]; ok {
 		transformed.Name = ecx.String(v.(string))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["ProfileUUID"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["ProfileUUID"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.ProfileUUID = ecx.String(v.(string))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["Speed"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["Speed"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.Speed = ecx.Int(v.(int))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["SpeedUnit"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["SpeedUnit"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.SpeedUnit = ecx.String(v.(string))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["PortUUID"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["PortUUID"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.PortUUID = ecx.String(v.(string))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["DeviceUUID"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["DeviceUUID"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.DeviceUUID = ecx.String(v.(string))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["DeviceInterfaceID"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["DeviceInterfaceID"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.DeviceInterfaceID = ecx.Int(v.(int))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["VlanSTag"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["VlanSTag"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.VlanSTag = ecx.Int(v.(int))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["VlanCTag"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["VlanCTag"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.VlanCTag = ecx.Int(v.(int))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["SellerRegion"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["SellerRegion"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.SellerRegion = ecx.String(v.(string))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["SellerMetroCode"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["SellerMetroCode"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.SellerMetroCode = ecx.String(v.(string))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["AuthorizationKey"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["AuthorizationKey"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.AuthorizationKey = ecx.String(v.(string))
 	}
-	if v, ok := conn[ecxL2ConnectionSchemaNames["ServiceToken"]]; ok && !isEmpty(v) {
+	if v, ok := conn[ecxL2ConnectionSchemaNames["ServiceToken"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.ServiceToken = ecx.String(v.(string))
 	}
 	return &transformed

--- a/equinix/resource_network_device.go
+++ b/equinix/resource_network_device.go
@@ -1294,46 +1294,46 @@ func expandNetworkDeviceSecondary(devices []interface{}) *ne.Device {
 	}
 	device := devices[0].(map[string]interface{})
 	transformed := &ne.Device{}
-	if v, ok := device[neDeviceSchemaNames["UUID"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["UUID"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.UUID = ne.String(v.(string))
 	}
-	if v, ok := device[neDeviceSchemaNames["Name"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["Name"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.Name = ne.String(v.(string))
 	}
-	if v, ok := device[neDeviceSchemaNames["MetroCode"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["MetroCode"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.MetroCode = ne.String(v.(string))
 	}
-	if v, ok := device[neDeviceSchemaNames["HostName"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["HostName"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.HostName = ne.String(v.(string))
 	}
-	if v, ok := device[neDeviceSchemaNames["LicenseToken"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["LicenseToken"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.LicenseToken = ne.String(v.(string))
 	}
-	if v, ok := device[neDeviceSchemaNames["LicenseFile"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["LicenseFile"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.LicenseFile = ne.String(v.(string))
 	}
-	if v, ok := device[neDeviceSchemaNames["LicenseFileID"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["LicenseFileID"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.LicenseFileID = ne.String(v.(string))
 	}
-	if v, ok := device[neDeviceSchemaNames["CloudInitFileID"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["CloudInitFileID"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.CloudInitFileID = ne.String(v.(string))
 	}
-	if v, ok := device[neDeviceSchemaNames["ACLTemplateUUID"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["ACLTemplateUUID"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.ACLTemplateUUID = ne.String(v.(string))
 	}
-	if v, ok := device[neDeviceSchemaNames["MgmtAclTemplateUuid"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["MgmtAclTemplateUuid"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.MgmtAclTemplateUuid = ne.String(v.(string))
 	}
-	if v, ok := device[neDeviceSchemaNames["AccountNumber"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["AccountNumber"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.AccountNumber = ne.String(v.(string))
 	}
 	if v, ok := device[neDeviceSchemaNames["Notifications"]]; ok {
 		transformed.Notifications = converters.SetToStringList(v.(*schema.Set))
 	}
-	if v, ok := device[neDeviceSchemaNames["AdditionalBandwidth"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["AdditionalBandwidth"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.AdditionalBandwidth = ne.Int(v.(int))
 	}
-	if v, ok := device[neDeviceSchemaNames["WanInterfaceId"]]; ok && !isEmpty(v) {
+	if v, ok := device[neDeviceSchemaNames["WanInterfaceId"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.WanInterfaceId = ne.String(v.(string))
 	}
 	if v, ok := device[neDeviceSchemaNames["VendorConfiguration"]]; ok {
@@ -1441,7 +1441,7 @@ func expandNetworkDeviceClusterDetails(clusterDetails []interface{}) *ne.Cluster
 	}
 	clusterDetail := clusterDetails[0].(map[string]interface{})
 	transformed := &ne.ClusterDetails{}
-	if v, ok := clusterDetail[neDeviceClusterSchemaNames["ClusterName"]]; ok && !isEmpty(v) {
+	if v, ok := clusterDetail[neDeviceClusterSchemaNames["ClusterName"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.ClusterName = ne.String(v.(string))
 	}
 	if v, ok := clusterDetail[neDeviceClusterSchemaNames["Node0"]]; ok {
@@ -1463,10 +1463,10 @@ func expandNetworkDeviceClusterNodeDetail(clusterNodeDetails []interface{}) *ne.
 	if v, ok := clusterNodeDetail[neDeviceClusterNodeSchemaNames["VendorConfiguration"]]; ok {
 		transformed.VendorConfiguration = expandVendorConfiguration(v.([]interface{}))
 	}
-	if v, ok := clusterNodeDetail[neDeviceClusterNodeSchemaNames["LicenseFileId"]]; ok && !isEmpty(v) {
+	if v, ok := clusterNodeDetail[neDeviceClusterNodeSchemaNames["LicenseFileId"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.LicenseFileId = ne.String(v.(string))
 	}
-	if v, ok := clusterNodeDetail[neDeviceClusterNodeSchemaNames["LicenseToken"]]; ok && !isEmpty(v) {
+	if v, ok := clusterNodeDetail[neDeviceClusterNodeSchemaNames["LicenseToken"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed.LicenseToken = ne.String(v.(string))
 	}
 	return transformed
@@ -1479,22 +1479,22 @@ func expandVendorConfiguration(vendorConfigs []interface{}) map[string]string {
 	}
 	vendorConfig := vendorConfigs[0].(map[string]interface{})
 	transformed := make(map[string]string)
-	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["Hostname"]]; ok && !isEmpty(v) {
+	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["Hostname"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed["hostname"] = v.(string)
 	}
-	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["AdminPassword"]]; ok && !isEmpty(v) {
+	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["AdminPassword"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed["adminPassword"] = v.(string)
 	}
-	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["Controller1"]]; ok && !isEmpty(v) {
+	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["Controller1"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed["controller1"] = v.(string)
 	}
-	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["ActivationKey"]]; ok && !isEmpty(v) {
+	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["ActivationKey"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed["activationKey"] = v.(string)
 	}
-	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["ControllerFqdn"]]; ok && !isEmpty(v) {
+	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["ControllerFqdn"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed["controllerFqdn"] = v.(string)
 	}
-	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["RootPassword"]]; ok && !isEmpty(v) {
+	if v, ok := vendorConfig[neDeviceVendorConfigSchemaNames["RootPassword"]]; ok && !equinix_validation.IsEmpty(v) {
 		transformed["rootPassword"] = v.(string)
 	}
 	return transformed

--- a/equinix/resource_network_device_acc_test.go
+++ b/equinix/resource_network_device_acc_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -1242,7 +1243,7 @@ func testAccNetworkDevice(ctx map[string]interface{}) string {
 data "equinix_network_account" "test" {
   metro_code = "%{device-metro_code}"
   status     = "Active"`, ctx)
-	if v, ok := ctx["device-account_name"]; ok && !isEmpty(v) {
+	if v, ok := ctx["device-account_name"]; ok && !validation.IsEmpty(v) {
 		config += nprintf(`
   name = "%{device-account_name}"`, ctx)
 	}
@@ -1253,7 +1254,7 @@ data "equinix_network_account" "test" {
 data "equinix_network_account" "test-secondary" {
   metro_code = "%{device-secondary_metro_code}"
   status     = "Active"`, ctx)
-		if v, ok := ctx["device-secondary_account_name"]; ok && !isEmpty(v) {
+		if v, ok := ctx["device-secondary_account_name"]; ok && !validation.IsEmpty(v) {
 			config += nprintf(`
   name = "%{device-secondary_account_name}"`, ctx)
 		}

--- a/internal/validation/empty.go
+++ b/internal/validation/empty.go
@@ -1,0 +1,20 @@
+package validation
+
+import "github.com/equinix/ecx-go/v2"
+
+func IsEmpty(v interface{}) bool {
+	switch v := v.(type) {
+	case int:
+		return v == 0
+	case *int:
+		return ecx.IntValue(v) == 0
+	case string:
+		return v == ""
+	case *string:
+		return ecx.StringValue(v) == ""
+	case nil:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/validation/empty_test.go
+++ b/internal/validation/empty_test.go
@@ -1,0 +1,32 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidation_IsEmpty(t *testing.T) {
+	// given
+	input := []interface{}{
+		"test",
+		"",
+		nil,
+		123,
+		0,
+		43.43,
+	}
+	expected := []bool{
+		false,
+		true,
+		true,
+		false,
+		true,
+		false,
+		true,
+	}
+	// when then
+	for i := range input {
+		assert.Equal(t, expected[i], IsEmpty(input[i]), "Input %v produces expected result %v", input[i], expected[i])
+	}
+}


### PR DESCRIPTION
The isEmpty function isn't a provider feature and is used by multiple resources, so it should go in its own package.

This also removes the `setSchemaValueIfNotEmpty` function because it included a reference to `isEmpty` and the only reference to the function was in a unit test covering the function.