### PR TITLE
fix: add the missing core count device update back

### DIFF
--- a/equinix/resource_network_device.go
+++ b/equinix/resource_network_device.go
@@ -1509,6 +1509,8 @@ func fillNetworkDeviceUpdateRequest(updateReq ne.DeviceUpdateRequest, changes ma
 			updateReq.WithTermLength(changeValue.(int))
 		case neDeviceSchemaNames["Notifications"]:
 			updateReq.WithNotifications(converters.SetToStringList(changeValue.(*schema.Set)))
+		case neDeviceSchemaNames["CoreCount"]:
+			updateReq.WithCore(changeValue.(int))
 		case neDeviceSchemaNames["AdditionalBandwidth"]:
 			updateReq.WithAdditionalBandwidth(changeValue.(int))
 		case neDeviceSchemaNames["ACLTemplateUUID"]:


### PR DESCRIPTION
Add the missing core count device update back
The core count field was introduced in the following PR: https://github.com/equinix/terraform-provider-equinix/pull/492
Then it was deleted from this PR: https://github.com/equinix/terraform-provider-equinix/pull/509