### PR TITLE
fix: correctly set organization_id in metal_project data source

### DIFF
--- a/internal/resources/metal/project/datasource.go
+++ b/internal/resources/metal/project/datasource.go
@@ -143,7 +143,7 @@ func dataSourceMetalProjectRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("payment_method_id", path.Base(project.PaymentMethod.GetHref()))
 	d.Set("name", project.GetName())
 	d.Set("project_id", project.GetId())
-	d.Set("organization_id", path.Base(project.Organization.GetId())) // Should be gethref?
+	d.Set("organization_id", path.Base(project.Organization.AdditionalProperties["href"].(string))) // spec: organization has no href
 	d.Set("created", project.GetCreatedAt().Format(time.RFC3339))
 	d.Set("updated", project.GetUpdatedAt().Format(time.RFC3339))
 	d.Set("backend_transfer", project.AdditionalProperties["backend_transfer_enabled"].(bool)) // No backend_transfer_enabled property in API spec

--- a/internal/resources/metal/project/datasource_test.go
+++ b/internal/resources/metal/project/datasource_test.go
@@ -32,6 +32,9 @@ func TestAccDataSourceMetalProject_byId(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						"equinix_metal_project.foobar", "id",
 						"data.equinix_metal_project.test", "id"),
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_project.foobar", "organization_id",
+						"data.equinix_metal_project.test", "organization_id"),
 				),
 			},
 		},

--- a/internal/resources/metal/project/resource.go
+++ b/internal/resources/metal/project/resource.go
@@ -199,8 +199,6 @@ func resourceMetalProjectRead(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("payment_method_id", path.Base(proj.PaymentMethod.GetHref()))
 	}
 	d.Set("name", proj.Name)
-	fmt.Println(proj.Organization.AdditionalProperties)
-	fmt.Println(proj.Organization.AdditionalProperties["href"])
 	d.Set("organization_id", path.Base(proj.Organization.AdditionalProperties["href"].(string))) // spec: organization has no href
 	d.Set("created", proj.GetCreatedAt().Format(time.RFC3339))
 	d.Set("updated", proj.GetUpdatedAt().Format(time.RFC3339))


### PR DESCRIPTION
The metal_project data source was attempting to read the organization ID for the specified project by looking directly at the `organization.id` field.  That field is only present on a project when the API request has `organization` in the `include` parameter.  Rather than include organization details and make the data source slower, this replicates the logic from the metal_project resource, which uses the organization's `href` field to get the organization ID.

While I was in this area of the code I also removed some debugging print statements that were merged unintentionally.