### PR TITLE
test: Update Fabric GHA workflow

### DIFF
--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -125,11 +125,18 @@ jobs:
           go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run="nothing"
 
       - name: Upload coverage to Codecov
+        concurrency: codecov-upload
         if: ${{ always() }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage_pnfv.txt
+
+      - name: Upload base coverage report for PNFV
+        uses: actions/upload-artifact@v2
+        with:
+          name: Fabric PNFV Coverage Report
+          path: ./coverage_pnfv.txt
 
   test-PFCR:
     name: Matrix Test
@@ -188,8 +195,15 @@ jobs:
           go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run="nothing"
 
       - name: Upload coverage to Codecov
+        concurrency: codecov-upload
         if: ${{ always() }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage_pfcr.txt
+
+      - name: Upload base coverage report for PFCR
+        uses: actions/upload-artifact@v2
+        with:
+          name: Fabric PFCR Coverage Report
+          path: ./coverage_pfcr.txt

--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Create Go Coverage HTML File
         run: |
-          go tool cover -html=./coverage_pfnv.txt -o ./coverage_pnfv.html
+          go tool cover -html=./coverage_pnfv.txt -o ./coverage_pnfv.html
 
       - name: Upload HTML Coverage Report for PNFV
         uses: actions/upload-artifact@v2

--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -125,7 +125,6 @@ jobs:
           go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run="nothing"
 
       - name: Upload coverage to Codecov
-        concurrency: codecov-upload
         if: ${{ always() }}
         uses: codecov/codecov-action@v3
         with:
@@ -195,7 +194,6 @@ jobs:
           go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run="nothing"
 
       - name: Upload coverage to Codecov
-        concurrency: codecov-upload
         if: ${{ always() }}
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -37,7 +37,7 @@ jobs:
       'external' || 'internal' }}
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.event_name == 'pull_request_target' && format('acctest-authorize-pr-{0}', github.event.pull_request.number) || 'acctest-authorize' }}
+      group: ${{ github.event_name == 'pull_request_target' && format('acctest-authorize-pr-{0}', github.event.pull_request.number) }}
       cancel-in-progress: true
     steps:
       - run: true
@@ -71,7 +71,6 @@ jobs:
   test-PFNV:
     name: Matrix Test
     needs: build
-    concurrency: fabricacctestpfnv
     runs-on: ubuntu-latest
     env:
       EQUINIX_API_ENDPOINT: "https://uatapi.equinix.com"
@@ -131,20 +130,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage_pnfv.txt
 
-      - name: Create Go Coverage HTML File
-        run: |
-          go tool cover -html=./coverage_pnfv.txt -o ./coverage_pnfv.html
-
-      - name: Upload HTML Coverage Report for PNFV
-        uses: actions/upload-artifact@v4
-        with:
-          name: Fabric PNFV Coverage Report
-          path: ./coverage_pnfv.html
-
   test-PFCR:
     name: Matrix Test
     needs: build
-    concurrency: fabricacctestpfcr
     runs-on: ubuntu-latest
     env:
       EQUINIX_API_ENDPOINT: "https://uatapi.equinix.com"
@@ -203,13 +191,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage_pfcr.txt
-
-      - name: Create Go Coverage HTML File
-        run: |
-          go tool cover -html=./coverage_pfcr.txt -o ./coverage_pfcr.html
-
-      - name: Upload HTML Coverage Report for PFCR
-        uses: actions/upload-artifact@v4
-        with:
-          name: Fabric PFCR Coverage Report
-          path: ./coverage_pfcr.html

--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -131,11 +131,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage_pnfv.txt
 
-      - name: Upload base coverage report for PNFV
+      - name: Create Go Coverage HTML File
+        run: |
+          go tool cover -html=./coverage_pfnv.txt -o ./coverage_pnfv.html
+
+      - name: Upload HTML Coverage Report for PNFV
         uses: actions/upload-artifact@v2
         with:
           name: Fabric PNFV Coverage Report
-          path: ./coverage_pnfv.txt
+          path: ./coverage_pnfv.html
 
   test-PFCR:
     name: Matrix Test
@@ -200,8 +204,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage_pfcr.txt
 
-      - name: Upload base coverage report for PFCR
+      - name: Create Go Coverage HTML File
+        run: |
+          go tool cover -html=./coverage_pfcr.txt -o ./coverage_pfcr.html
+
+      - name: Upload HTML Coverage Report for PFCR
         uses: actions/upload-artifact@v2
         with:
           name: Fabric PFCR Coverage Report
-          path: ./coverage_pfcr.txt
+          path: ./coverage_pfcr.html

--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -122,7 +122,7 @@ jobs:
           SWEEP_DIR: "./equinix"
         run: |
           # Added sweep-run to filter Fabric PNFV test
-          go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run=$(grep -o 'AddTestSweepers("[^"]*PNFV"' equinix/resource_fabric_* | cut -d '"' -f2 | paste -s -d, -)
+          go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run="nothing"
 
       - name: Upload coverage to Codecov
         if: ${{ always() }}
@@ -185,7 +185,7 @@ jobs:
           SWEEP_DIR: "./equinix"
         run: |
           # Added sweep-run to filter Fabric PFCR test
-          go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run=$(grep -o 'AddTestSweepers("[^"]*PFCR"' equinix/resource_fabric_* | cut -d '"' -f2 | paste -s -d, -)
+          go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run="nothing"
 
       - name: Upload coverage to Codecov
         if: ${{ always() }}

--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -37,7 +37,7 @@ jobs:
       'external' || 'internal' }}
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.event_name == 'pull_request_target' && format('acctest-authorize-pr-{0}', github.event.pull_request.number) }}
+      group: ${{ github.event_name == 'pull_request_target' && format('fabric-acctest-authorize-pr-{0}', github.event.pull_request.number) || 'fabric-acctest-authorize' }}
       cancel-in-progress: true
     steps:
       - run: true

--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -136,7 +136,7 @@ jobs:
           go tool cover -html=./coverage_pnfv.txt -o ./coverage_pnfv.html
 
       - name: Upload HTML Coverage Report for PNFV
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Fabric PNFV Coverage Report
           path: ./coverage_pnfv.html
@@ -209,7 +209,7 @@ jobs:
           go tool cover -html=./coverage_pfcr.txt -o ./coverage_pfcr.html
 
       - name: Upload HTML Coverage Report for PFCR
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Fabric PFCR Coverage Report
           path: ./coverage_pfcr.html

--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -122,7 +122,7 @@ jobs:
           SWEEP_DIR: "./equinix"
         run: |
           # Added sweep-run to filter Fabric PNFV test
-          go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run="nothing"
+          go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run=$(grep -o 'AddTestSweepers("[^"]*PNFV"' equinix/resource_fabric_* | cut -d '"' -f2 | paste -s -d, -)
 
       - name: Upload coverage to Codecov
         if: ${{ always() }}
@@ -195,7 +195,7 @@ jobs:
           SWEEP_DIR: "./equinix"
         run: |
           # Added sweep-run to filter Fabric PFCR test
-          go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run="nothing"
+          go test ${SWEEP_DIR} -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run=$(grep -o 'AddTestSweepers("[^"]*PFCR"' equinix/resource_fabric_* | cut -d '"' -f2 | paste -s -d, -)
 
       - name: Upload coverage to Codecov
         if: ${{ always() }}

--- a/equinix/resource_fabric_cloud_router_acc_test.go
+++ b/equinix/resource_fabric_cloud_router_acc_test.go
@@ -14,6 +14,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+func init() {
+	resource.AddTestSweepers("equinix_fabric_cloud_router_PFCR", &resource.Sweeper{
+		Name: "equinix_fabric_cloud_router",
+		F:    testSweepCloudRouters,
+	})
+}
+
+func testSweepCloudRouters(region string) error {
+	return nil
+}
+
 func TestAccCloudRouterCreate(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.TestAccPreCheck(t) },

--- a/equinix/resource_fabric_connection_acc_test.go
+++ b/equinix/resource_fabric_connection_acc_test.go
@@ -12,6 +12,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+func init() {
+	resource.AddTestSweepers("equinix_fabric_connection_PNFV", &resource.Sweeper{
+		Name: "equinix_fabric_connection",
+		F:    testSweepConnections,
+	})
+}
+
+func testSweepConnections(region string) error {
+	return nil
+}
+
 func TestAccFabricCreateConnection(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
* Upload coverage artifacts in html format to see Go coverage details for each run
* Add empty test sweepers for Fabric to avoid failing jobs on sweepers that aren't related to Fabric tests