### PR TITLE
refactor: move Metal VLAN resource and data source to equinix-sdk-go

### DIFF
--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/metal_connection"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/metal_project_ssh_key"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/metal_ssh_key"
+	metal_vlan "github.com/equinix/terraform-provider-equinix/internal/resources/metal/vlan"
 
 	"github.com/equinix/ecx-go/v2"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
@@ -112,7 +113,7 @@ func Provider() *schema.Provider {
 			"equinix_metal_reserved_ip_block":    dataSourceMetalReservedIPBlock(),
 			"equinix_metal_spot_market_request":  dataSourceMetalSpotMarketRequest(),
 			"equinix_metal_virtual_circuit":      dataSourceMetalVirtualCircuit(),
-			"equinix_metal_vlan":                 dataSourceMetalVlan(),
+			"equinix_metal_vlan":                 metal_vlan.DataSource(),
 			"equinix_metal_vrf":                  dataSourceMetalVRF(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -144,7 +145,7 @@ func Provider() *schema.Provider {
 			"equinix_metal_reserved_ip_block":    resourceMetalReservedIPBlock(),
 			"equinix_metal_ip_attachment":        resourceMetalIPAttachment(),
 			"equinix_metal_spot_market_request":  resourceMetalSpotMarketRequest(),
-			"equinix_metal_vlan":                 resourceMetalVlan(),
+			"equinix_metal_vlan":                 metal_vlan.Resource(),
 			"equinix_metal_virtual_circuit":      resourceMetalVirtualCircuit(),
 			"equinix_metal_vrf":                  resourceMetalVRF(),
 			"equinix_metal_bgp_session":          resourceMetalBGPSession(),

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/equinix-labs/fabric-go v0.7.1
 	github.com/equinix/ecx-go/v2 v2.3.1
-	github.com/equinix/equinix-sdk-go v0.31.0
+	github.com/equinix/equinix-sdk-go v0.32.1-0.20240125204450-f22739ace0f7
 	github.com/equinix/ne-go v1.13.0
 	github.com/equinix/oauth2-go v1.0.0
 	github.com/equinix/rest-go v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,12 @@ github.com/equinix-labs/fabric-go v0.7.1 h1:4yk0IKXMcc72rkRVbcYHokAEc1uUB06t6NXK
 github.com/equinix-labs/fabric-go v0.7.1/go.mod h1:oqgGS3GOI8hHGPJKsAwDOEX0qRHl52sJGvwA/zMSd90=
 github.com/equinix/ecx-go/v2 v2.3.1 h1:gFcAIeyaEUw7S8ebqApmT7E/S7pC7Ac3wgScp89fkPU=
 github.com/equinix/ecx-go/v2 v2.3.1/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
-github.com/equinix/equinix-sdk-go v0.31.0 h1:BVD67nmpPEutsCGkYDuy0rykGNeQ5H3FIX+Dz5DpP7w=
-github.com/equinix/equinix-sdk-go v0.31.0/go.mod h1:qnpdRzVftHFNaJFk1VSIrAOTLrIoeDrxzUr3l8ARyvQ=
+github.com/equinix/equinix-sdk-go v0.32.1-0.20240125194110-4088361fa6b7 h1:ipZkrpVU3xPEJp6uKkrDlDeEKGNkUNExtsAuHeakK4Q=
+github.com/equinix/equinix-sdk-go v0.32.1-0.20240125194110-4088361fa6b7/go.mod h1:qnpdRzVftHFNaJFk1VSIrAOTLrIoeDrxzUr3l8ARyvQ=
+github.com/equinix/equinix-sdk-go v0.32.1-0.20240125200831-02238d07a989 h1:tP2wIfYuDq6u/4rWf8uj8fYQTzRjmt9RCXki2S7aoaA=
+github.com/equinix/equinix-sdk-go v0.32.1-0.20240125200831-02238d07a989/go.mod h1:qnpdRzVftHFNaJFk1VSIrAOTLrIoeDrxzUr3l8ARyvQ=
+github.com/equinix/equinix-sdk-go v0.32.1-0.20240125204450-f22739ace0f7 h1:dGAlmpIXO+rtcVbI1+TKJVwkSpPG5X56ZeVur8xHpYM=
+github.com/equinix/equinix-sdk-go v0.32.1-0.20240125204450-f22739ace0f7/go.mod h1:qnpdRzVftHFNaJFk1VSIrAOTLrIoeDrxzUr3l8ARyvQ=
 github.com/equinix/ne-go v1.13.0 h1:7mcEGnASjPVc2la/Q2WRCn2PcFVO3syXAd6YOU1lETw=
 github.com/equinix/ne-go v1.13.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=

--- a/internal/resources/metal/vlan/datasource.go
+++ b/internal/resources/metal/vlan/datasource.go
@@ -129,7 +129,7 @@ func dataSourceMetalVlanRead(ctx context.Context, d *schema.ResourceData, meta i
 		"vlan_id":     vlan.GetId(),
 		"project_id":  vlan.AssignedTo.GetId(), // vlan assigned_to is an href; should be project?
 		"vxlan":       vlan.GetVxlan(),
-		"facility":    vlan.FacilityCode, // facility is deprecated, vlan is metro-scoped; remove this attr?
+		"facility":    nil, //vlan.FacilityCode, // facility is deprecated, vlan is metro-scoped; remove this attr?
 		"metro":       vlan.MetroCode,
 		"description": vlan.Description,
 	}))

--- a/internal/resources/metal/vlan/datasource.go
+++ b/internal/resources/metal/vlan/datasource.go
@@ -1,4 +1,4 @@
-package equinix
+package vlan
 
 import (
 	"fmt"
@@ -14,7 +14,7 @@ import (
 	"github.com/packethost/packngo"
 )
 
-func dataSourceMetalVlan() *schema.Resource {
+func DataSource() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceMetalVlanRead,
 		Importer: &schema.ResourceImporter{
@@ -111,7 +111,7 @@ func dataSourceMetalVlanRead(d *schema.ResourceData, meta interface{}) error {
 			return equinix_errors.FriendlyError(err)
 		}
 
-		vlan, err = matchingVlan(vlans.VirtualNetworks, vxlan, projectID, facility, metro)
+		vlan, err = MatchingVlan(vlans.VirtualNetworks, vxlan, projectID, facility, metro)
 		if err != nil {
 			return equinix_errors.FriendlyError(err)
 		}
@@ -132,28 +132,4 @@ func dataSourceMetalVlanRead(d *schema.ResourceData, meta interface{}) error {
 		"metro":       vlan.MetroCode,
 		"description": vlan.Description,
 	})
-}
-
-func matchingVlan(vlans []packngo.VirtualNetwork, vxlan int, projectID, facility, metro string) (*packngo.VirtualNetwork, error) {
-	matches := []packngo.VirtualNetwork{}
-	for _, v := range vlans {
-		if vxlan != 0 && v.VXLAN != vxlan {
-			continue
-		}
-		if facility != "" && v.FacilityCode != facility {
-			continue
-		}
-		if metro != "" && v.MetroCode != metro {
-			continue
-		}
-		matches = append(matches, v)
-	}
-	if len(matches) > 1 {
-		return nil, equinix_errors.FriendlyError(fmt.Errorf("Project %s has more than one matching VLAN", projectID))
-	}
-
-	if len(matches) == 0 {
-		return nil, equinix_errors.FriendlyError(fmt.Errorf("Project %s does not have matching VLANs", projectID))
-	}
-	return &matches[0], nil
 }

--- a/internal/resources/metal/vlan/datasource_test.go
+++ b/internal/resources/metal/vlan/datasource_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vlan"
 
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/packethost/packngo"
 )
 
 func TestAccDataSourceMetalVlan_byVxlanFacility(t *testing.T) {
@@ -227,7 +227,7 @@ data "equinix_metal_vlan" "dsvlan" {
 
 func TestMetalVlan_MatchingVlan(t *testing.T) {
 	type args struct {
-		vlans     []packngo.VirtualNetwork
+		vlans     []metalv1.VirtualNetwork
 		vxlan     int
 		projectID string
 		facility  string
@@ -236,52 +236,52 @@ func TestMetalVlan_MatchingVlan(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *packngo.VirtualNetwork
+		want    *metalv1.VirtualNetwork
 		wantErr bool
 	}{
 		{
 			name: "MatchingVLAN",
 			args: args{
-				vlans:     []packngo.VirtualNetwork{{VXLAN: 123}},
+				vlans:     []metalv1.VirtualNetwork{{Vxlan: metalv1.PtrInt32(123)}},
 				vxlan:     123,
 				projectID: "",
 				facility:  "",
 				metro:     "",
 			},
-			want:    &packngo.VirtualNetwork{VXLAN: 123},
+			want:    &metalv1.VirtualNetwork{Vxlan: metalv1.PtrInt32(123)},
 			wantErr: false,
 		},
 		{
 			name: "MatchingFac",
 			args: args{
-				vlans:    []packngo.VirtualNetwork{{FacilityCode: "fac"}},
+				vlans:    []metalv1.VirtualNetwork{{FacilityCode: "fac"}},
 				facility: "fac",
 			},
-			want:    &packngo.VirtualNetwork{FacilityCode: "fac"},
+			want:    &metalv1.VirtualNetwork{FacilityCode: "fac"},
 			wantErr: false,
 		},
 		{
 			name: "MatchingMet",
 			args: args{
-				vlans: []packngo.VirtualNetwork{{MetroCode: "met"}},
+				vlans: []metalv1.VirtualNetwork{{MetroCode: metalv1.PtrString("met")}},
 				metro: "met",
 			},
-			want:    &packngo.VirtualNetwork{MetroCode: "met"},
+			want:    &metalv1.VirtualNetwork{MetroCode: metalv1.PtrString("met")},
 			wantErr: false,
 		},
 		{
 			name: "SecondMatch",
 			args: args{
-				vlans: []packngo.VirtualNetwork{{FacilityCode: "fac"}, {MetroCode: "met"}},
+				vlans: []metalv1.VirtualNetwork{{FacilityCode: "fac"}, {MetroCode: metalv1.PtrString("met")}},
 				metro: "met",
 			},
-			want:    &packngo.VirtualNetwork{MetroCode: "met"},
+			want:    &metalv1.VirtualNetwork{MetroCode: metalv1.PtrString("met")},
 			wantErr: false,
 		},
 		{
 			name: "TwoMatches",
 			args: args{
-				vlans: []packngo.VirtualNetwork{{MetroCode: "met"}, {MetroCode: "met"}},
+				vlans: []metalv1.VirtualNetwork{{MetroCode: metalv1.PtrString("met")}, {MetroCode: metalv1.PtrString("met")}},
 				metro: "met",
 			},
 			want:    nil,
@@ -290,10 +290,10 @@ func TestMetalVlan_MatchingVlan(t *testing.T) {
 		{
 			name: "ComplexMatch",
 			args: args{
-				vlans: []packngo.VirtualNetwork{{VXLAN: 987, FacilityCode: "fac", MetroCode: "skip"}, {VXLAN: 123, FacilityCode: "fac", MetroCode: "met"}, {VXLAN: 456, FacilityCode: "fac", MetroCode: "nope"}},
+				vlans: []metalv1.VirtualNetwork{{Vxlan: metalv1.PtrInt32(987), FacilityCode: "fac", MetroCode: metalv1.PtrString("skip")}, {VXLAN: metalv1.PtrInt32(123), FacilityCode: "fac", MetroCode: metalv1.PtrString("met")}, {Vxlan: metalv1.PtrInt32(456), FacilityCode: "fac", MetroCode: metalv1.PtrString("nope")}},
 				metro: "met",
 			},
-			want:    &packngo.VirtualNetwork{VXLAN: 123, FacilityCode: "fac", MetroCode: "met"},
+			want:    &metalv1.VirtualNetwork{Vxlan: metalv1.PtrInt32(123), FacilityCode: "fac", MetroCode: metalv1.PtrString("met")},
 			wantErr: false,
 		},
 		{

--- a/internal/resources/metal/vlan/datasource_test.go
+++ b/internal/resources/metal/vlan/datasource_test.go
@@ -252,15 +252,6 @@ func TestMetalVlan_MatchingVlan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "MatchingFac",
-			args: args{
-				vlans:    []metalv1.VirtualNetwork{{FacilityCode: "fac"}},
-				facility: "fac",
-			},
-			want:    &metalv1.VirtualNetwork{FacilityCode: "fac"},
-			wantErr: false,
-		},
-		{
 			name: "MatchingMet",
 			args: args{
 				vlans: []metalv1.VirtualNetwork{{MetroCode: metalv1.PtrString("met")}},
@@ -272,7 +263,7 @@ func TestMetalVlan_MatchingVlan(t *testing.T) {
 		{
 			name: "SecondMatch",
 			args: args{
-				vlans: []metalv1.VirtualNetwork{{FacilityCode: "fac"}, {MetroCode: metalv1.PtrString("met")}},
+				vlans: []metalv1.VirtualNetwork{{MetroCode: metalv1.PtrString("fac")}, {MetroCode: metalv1.PtrString("met")}},
 				metro: "met",
 			},
 			want:    &metalv1.VirtualNetwork{MetroCode: metalv1.PtrString("met")},
@@ -290,10 +281,10 @@ func TestMetalVlan_MatchingVlan(t *testing.T) {
 		{
 			name: "ComplexMatch",
 			args: args{
-				vlans: []metalv1.VirtualNetwork{{Vxlan: metalv1.PtrInt32(987), FacilityCode: "fac", MetroCode: metalv1.PtrString("skip")}, {VXLAN: metalv1.PtrInt32(123), FacilityCode: "fac", MetroCode: metalv1.PtrString("met")}, {Vxlan: metalv1.PtrInt32(456), FacilityCode: "fac", MetroCode: metalv1.PtrString("nope")}},
+				vlans: []metalv1.VirtualNetwork{{Vxlan: metalv1.PtrInt32(987), MetroCode: metalv1.PtrString("skip")}, {Vxlan: metalv1.PtrInt32(123), MetroCode: metalv1.PtrString("met")}, {Vxlan: metalv1.PtrInt32(456), MetroCode: metalv1.PtrString("nope")}},
 				metro: "met",
 			},
-			want:    &metalv1.VirtualNetwork{Vxlan: metalv1.PtrInt32(123), FacilityCode: "fac", MetroCode: metalv1.PtrString("met")},
+			want:    &metalv1.VirtualNetwork{Vxlan: metalv1.PtrInt32(123), MetroCode: metalv1.PtrString("met")},
 			wantErr: false,
 		},
 		{

--- a/internal/resources/metal/vlan/datasource_test.go
+++ b/internal/resources/metal/vlan/datasource_test.go
@@ -1,11 +1,13 @@
-package equinix
+package vlan_test
 
 import (
 	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vlan"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -18,9 +20,9 @@ func TestAccDataSourceMetalVlan_byVxlanFacility(t *testing.T) {
 	fac := "sv15"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -65,9 +67,9 @@ func TestAccDataSourceMetalVlan_byVxlanMetro(t *testing.T) {
 	metro := "sv"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -136,9 +138,9 @@ func TestAccDataSourceMetalVlan_byVlanId(t *testing.T) {
 	metro := "sv"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -182,9 +184,9 @@ func TestAccDataSourceMetalVlan_byProjectId(t *testing.T) {
 	metro := "sv"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -223,7 +225,7 @@ data "equinix_metal_vlan" "dsvlan" {
 `, projSuffix, metro, desc)
 }
 
-func TestMetalVlan_matchingVlan(t *testing.T) {
+func TestMetalVlan_MatchingVlan(t *testing.T) {
 	type args struct {
 		vlans     []packngo.VirtualNetwork
 		vxlan     int
@@ -309,20 +311,20 @@ func TestMetalVlan_matchingVlan(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := matchingVlan(tt.args.vlans, tt.args.vxlan, tt.args.projectID, tt.args.facility, tt.args.metro)
+			got, err := vlan.MatchingVlan(tt.args.vlans, tt.args.vxlan, tt.args.projectID, tt.args.facility, tt.args.metro)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("matchingVlan() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("MatchingVlan() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("matchingVlan() = %v, want %v", got, tt.want)
+				t.Errorf("MatchingVlan() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
 func testAccMetalDatasourceVlanCheckDestroyed(s *terraform.State) error {
-	client := testAccProvider.Meta().(*config.Config).Metal
+	client := acceptance.TestAccProvider.Meta().(*config.Config).Metal
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_metal_vlan" {

--- a/internal/resources/metal/vlan/matcher.go
+++ b/internal/resources/metal/vlan/matcher.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
-	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 )
 
 func MatchingVlan(vlans []metalv1.VirtualNetwork, vxlan int, projectID, facility, metro string) (*metalv1.VirtualNetwork, error) {
@@ -13,20 +12,20 @@ func MatchingVlan(vlans []metalv1.VirtualNetwork, vxlan int, projectID, facility
 		if vxlan != 0 && int(v.GetVxlan()) != vxlan {
 			continue
 		}
-		if facility != "" && v.FacilityCode != facility {
+		/*if facility != "" && v.FacilityCode != facility {
 			continue
-		}
+		}*/
 		if metro != "" && v.GetMetroCode() != metro {
 			continue
 		}
 		matches = append(matches, v)
 	}
 	if len(matches) > 1 {
-		return nil, equinix_errors.FriendlyError(fmt.Errorf("Project %s has more than one matching VLAN", projectID))
+		return nil, fmt.Errorf("Project %s has more than one matching VLAN", projectID)
 	}
 
 	if len(matches) == 0 {
-		return nil, equinix_errors.FriendlyError(fmt.Errorf("Project %s does not have matching VLANs", projectID))
+		return nil, fmt.Errorf("Project %s does not have matching VLANs", projectID)
 	}
 	return &matches[0], nil
 }

--- a/internal/resources/metal/vlan/matcher.go
+++ b/internal/resources/metal/vlan/matcher.go
@@ -3,20 +3,20 @@ package vlan
 import (
 	"fmt"
 
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
-	"github.com/packethost/packngo"
 )
 
-func MatchingVlan(vlans []packngo.VirtualNetwork, vxlan int, projectID, facility, metro string) (*packngo.VirtualNetwork, error) {
-	matches := []packngo.VirtualNetwork{}
+func MatchingVlan(vlans []metalv1.VirtualNetwork, vxlan int, projectID, facility, metro string) (*metalv1.VirtualNetwork, error) {
+	matches := []metalv1.VirtualNetwork{}
 	for _, v := range vlans {
-		if vxlan != 0 && v.VXLAN != vxlan {
+		if vxlan != 0 && int(v.GetVxlan()) != vxlan {
 			continue
 		}
 		if facility != "" && v.FacilityCode != facility {
 			continue
 		}
-		if metro != "" && v.MetroCode != metro {
+		if metro != "" && v.GetMetroCode() != metro {
 			continue
 		}
 		matches = append(matches, v)

--- a/internal/resources/metal/vlan/matcher.go
+++ b/internal/resources/metal/vlan/matcher.go
@@ -1,0 +1,32 @@
+package vlan
+
+import (
+	"fmt"
+
+	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
+	"github.com/packethost/packngo"
+)
+
+func MatchingVlan(vlans []packngo.VirtualNetwork, vxlan int, projectID, facility, metro string) (*packngo.VirtualNetwork, error) {
+	matches := []packngo.VirtualNetwork{}
+	for _, v := range vlans {
+		if vxlan != 0 && v.VXLAN != vxlan {
+			continue
+		}
+		if facility != "" && v.FacilityCode != facility {
+			continue
+		}
+		if metro != "" && v.MetroCode != metro {
+			continue
+		}
+		matches = append(matches, v)
+	}
+	if len(matches) > 1 {
+		return nil, equinix_errors.FriendlyError(fmt.Errorf("Project %s has more than one matching VLAN", projectID))
+	}
+
+	if len(matches) == 0 {
+		return nil, equinix_errors.FriendlyError(fmt.Errorf("Project %s does not have matching VLANs", projectID))
+	}
+	return &matches[0], nil
+}

--- a/internal/resources/metal/vlan/resource.go
+++ b/internal/resources/metal/vlan/resource.go
@@ -88,7 +88,7 @@ func resourceMetalVlanCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	//facRaw, facOk := d.GetOk("facility")
 	metroRaw, metroOk := d.GetOk("metro")
-	vxlanRaw, _ := d.GetOk("vxlan")
+	vxlanRaw, vxlanOk := d.GetOk("vxlan")
 
 	if /*!facOk &&*/ !metroOk {
 		return diag.Errorf("one of facility or metro must be configured")
@@ -102,7 +102,9 @@ func resourceMetalVlanCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	if metroOk {
 		createRequest.Metro = metalv1.PtrString(metroRaw.(string))
-		createRequest.Vxlan = metalv1.PtrInt32(int32(vxlanRaw.(int)))
+		if vxlanOk {
+			createRequest.Vxlan = metalv1.PtrInt32(int32(vxlanRaw.(int)))
+		}
 	}
 	/*if facOk {
 		createRequest.Facility = facRaw.(string)

--- a/internal/resources/metal/vlan/resource.go
+++ b/internal/resources/metal/vlan/resource.go
@@ -1,4 +1,4 @@
-package equinix
+package vlan
 
 import (
 	"errors"
@@ -14,7 +14,7 @@ import (
 	"github.com/packethost/packngo"
 )
 
-func resourceMetalVlan() *schema.Resource {
+func Resource() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceMetalVlanCreate,
 		Read:   resourceMetalVlanRead,

--- a/internal/resources/metal/vlan/resource.go
+++ b/internal/resources/metal/vlan/resource.go
@@ -1,7 +1,7 @@
 package vlan
 
 import (
-	"errors"
+	"context"
 	"path"
 
 	"github.com/equinix/terraform-provider-equinix/internal/converters"
@@ -10,15 +10,16 @@ import (
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/packethost/packngo"
 )
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceMetalVlanCreate,
-		Read:   resourceMetalVlanRead,
-		Delete: resourceMetalVlanDelete,
+		CreateWithoutTimeout: resourceMetalVlanCreate,
+		ReadWithoutTimeout:   resourceMetalVlanRead,
+		DeleteWithoutTimeout: resourceMetalVlanDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -81,71 +82,70 @@ func Resource() *schema.Resource {
 	}
 }
 
-func resourceMetalVlanCreate(d *schema.ResourceData, meta interface{}) error {
-	meta.(*config.Config).AddModuleToMetalUserAgent(d)
-	client := meta.(*config.Config).Metal
+func resourceMetalVlanCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	meta.(*config.Config).AddModuleToMetalGoUserAgent(d)
+	client := meta.(*config.Config).Metalgo
 
 	facRaw, facOk := d.GetOk("facility")
 	metroRaw, metroOk := d.GetOk("metro")
 	vxlanRaw, vxlanOk := d.GetOk("vxlan")
 
 	if !facOk && !metroOk {
-		return equinix_errors.FriendlyError(errors.New("one of facility or metro must be configured"))
+		return diag.Errorf("one of facility or metro must be configured")
 	}
 	if facOk && vxlanOk {
-		return equinix_errors.FriendlyError(errors.New("you can set vxlan only for metro vlans"))
+		return diag.Errorf("you can set vxlan only for metro vlans")
 	}
 
-	createRequest := &packngo.VirtualNetworkCreateRequest{
-		ProjectID:   d.Get("project_id").(string),
-		Description: d.Get("description").(string),
+	createRequest := metalv1.VirtualNetworkCreateInput{
+		Description: metalv1.PtrString(d.Get("description").(string)),
 	}
 	if metroOk {
-		createRequest.Metro = metroRaw.(string)
-		createRequest.VXLAN = vxlanRaw.(int)
+		createRequest.Metro = metalv1.PtrString(metroRaw.(string))
+		createRequest.Vxlan = metalv1.PtrInt32(int32(vxlanRaw.(int)))
 	}
 	if facOk {
 		createRequest.Facility = facRaw.(string)
 	}
-	vlan, _, err := client.ProjectVirtualNetworks.Create(createRequest)
+	vlan, _, err := client.VLANsApi.CreateVirtualNetwork(ctx, d.Get("project_id").(string)).VirtualNetworkCreateInput(createRequest).Execute()
 	if err != nil {
-		return equinix_errors.FriendlyError(err)
+		return diag.FromErr(equinix_errors.FriendlyError(err))
 	}
-	d.SetId(vlan.ID)
-	return resourceMetalVlanRead(d, meta)
+	d.SetId(vlan.GetId())
+	return resourceMetalVlanRead(ctx, d, meta)
 }
 
-func resourceMetalVlanRead(d *schema.ResourceData, meta interface{}) error {
-	meta.(*config.Config).AddModuleToMetalUserAgent(d)
-	client := meta.(*config.Config).Metal
+func resourceMetalVlanRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	meta.(*config.Config).AddModuleToMetalGoUserAgent(d)
+	client := meta.(*config.Config).Metalgo
 
-	vlan, _, err := client.ProjectVirtualNetworks.Get(d.Id(),
-		&packngo.GetOptions{Includes: []string{"assigned_to"}})
+	vlan, _, err := client.VLANsApi.GetVirtualNetwork(ctx, d.Id()).
+		Include([]string{"assigned_to"}).Execute()
 	if err != nil {
 		err = equinix_errors.FriendlyError(err)
 		if equinix_errors.IsNotFound(err) {
 			d.SetId("")
 			return nil
 		}
-		return err
+		return diag.FromErr(err)
 
 	}
 	d.Set("description", vlan.Description)
-	d.Set("project_id", vlan.Project.ID)
-	d.Set("vxlan", vlan.VXLAN)
-	d.Set("facility", vlan.FacilityCode)
+	d.Set("project_id", vlan.AssignedTo.GetId()) // assigned_to is a project but specced as an href
+	d.Set("vxlan", vlan.GetVxlan())
+	d.Set("facility", vlan.FacilityCode) // vlan spec does not include facility_code; should we remove it?
 	d.Set("metro", vlan.MetroCode)
 	return nil
 }
 
-func resourceMetalVlanDelete(d *schema.ResourceData, meta interface{}) error {
-	meta.(*config.Config).AddModuleToMetalUserAgent(d)
-	client := meta.(*config.Config).Metal
+func resourceMetalVlanDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	meta.(*config.Config).AddModuleToMetalGoUserAgent(d)
+	client := meta.(*config.Config).Metalgo
 
 	id := d.Id()
-	vlan, resp, err := client.ProjectVirtualNetworks.Get(id, &packngo.GetOptions{Includes: []string{"instances", "instances.network_ports.virtual_networks", "internet_gateway"}})
-	if equinix_errors.IgnoreResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
-		return equinix_errors.FriendlyError(err)
+	vlan, resp, err := client.VLANsApi.GetVirtualNetwork(ctx, id).Include([]string{"instances", "instances.network_ports.virtual_networks", "internet_gateway"}).Execute()
+	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+		return diag.FromErr(equinix_errors.FriendlyError(err))
 	} else if err != nil {
 		// missing vlans are deleted
 		return nil
@@ -153,17 +153,20 @@ func resourceMetalVlanDelete(d *schema.ResourceData, meta interface{}) error {
 
 	// all device ports must be unassigned before delete
 	for _, i := range vlan.Instances {
-		for _, p := range i.NetworkPorts {
+		for _, p := range i.NetworkPorts { // instances is specced as a list of href; should be devices?
 			for _, a := range p.AttachedVirtualNetworks {
 				// a.ID is not set despite including instaces.network_ports.virtual_networks
 				// TODO(displague) packngo should offer GetID() that uses ID or Href
 				aID := path.Base(a.Href)
 
 				if aID == id {
-					_, resp, err := client.Ports.Unassign(p.ID, id)
+					portInput := metalv1.PortAssignInput{
+						Vnid: &id,
+					}
+					_, resp, err := client.PortsApi.UnassignPort(ctx, p.GetId()).PortAssignInput(portInput).Execute()
 
-					if equinix_errors.IgnoreResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
-						return equinix_errors.FriendlyError(err)
+					if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+						return diag.FromErr(equinix_errors.FriendlyError(err))
 					}
 				}
 			}
@@ -171,6 +174,11 @@ func resourceMetalVlanDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// TODO(displague) do we need to unassign gateway connections before delete?
+	_, resp, err = client.VLANsApi.DeleteVirtualNetwork(ctx, id).Execute()
 
-	return equinix_errors.FriendlyError(equinix_errors.IgnoreResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(client.ProjectVirtualNetworks.Delete(id)))
+	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+		return diag.FromErr(equinix_errors.FriendlyError(err))
+	}
+
+	return nil
 }

--- a/internal/resources/metal/vlan/resource_test.go
+++ b/internal/resources/metal/vlan/resource_test.go
@@ -1,6 +1,7 @@
 package vlan_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"testing"
@@ -8,10 +9,10 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/packethost/packngo"
 )
 
 func init() {
@@ -102,7 +103,7 @@ func TestAccMetalVlan_metro(t *testing.T) {
 }
 
 func TestAccMetalVlan_basic(t *testing.T) {
-	var vlan packngo.VirtualNetwork
+	var vlan metalv1.VirtualNetwork
 	rs := acctest.RandString(10)
 	fac := "ny5"
 
@@ -126,7 +127,7 @@ func TestAccMetalVlan_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckMetalVlanExists(n string, vlan *packngo.VirtualNetwork) resource.TestCheckFunc {
+func testAccCheckMetalVlanExists(n string, vlan *metalv1.VirtualNetwork) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -136,13 +137,13 @@ func testAccCheckMetalVlanExists(n string, vlan *packngo.VirtualNetwork) resourc
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		client := acceptance.TestAccProvider.Meta().(*config.Config).Metal
+		client := acceptance.TestAccProvider.Meta().(*config.Config).Metalgo
 
-		foundVlan, _, err := client.ProjectVirtualNetworks.Get(rs.Primary.ID, nil)
+		foundVlan, _, err := client.VLANsApi.GetVirtualNetwork(context.Background(), rs.Primary.ID).Execute()
 		if err != nil {
 			return err
 		}
-		if foundVlan.ID != rs.Primary.ID {
+		if foundVlan.GetId() != rs.Primary.ID {
 			return fmt.Errorf("Record not found: %v - %v", rs.Primary.ID, foundVlan)
 		}
 

--- a/internal/resources/metal/vlan/resource_test.go
+++ b/internal/resources/metal/vlan/resource_test.go
@@ -1,10 +1,11 @@
-package equinix
+package vlan_test
 
 import (
 	"fmt"
 	"log"
 	"testing"
 
+	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -23,7 +24,7 @@ func init() {
 
 func testSweepVlans(region string) error {
 	log.Printf("[DEBUG] Sweeping vlans")
-	config, err := sharedConfigForRegion(region)
+	config, err := acceptance.GetConfigForNonStandardMetalTest()
 	if err != nil {
 		return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting configuration for sweeping vlans: %s", err)
 	}
@@ -34,7 +35,7 @@ func testSweepVlans(region string) error {
 	}
 	pids := []string{}
 	for _, p := range ps {
-		if isSweepableTestResource(p.Name) {
+		if acceptance.IsSweepableTestResource(p.Name) {
 			pids = append(pids, p.ID)
 		}
 	}
@@ -46,7 +47,7 @@ func testSweepVlans(region string) error {
 			continue
 		}
 		for _, d := range ds.VirtualNetworks {
-			if isSweepableTestResource(d.Description) {
+			if acceptance.IsSweepableTestResource(d.Description) {
 				dids = append(dids, d.ID)
 			}
 		}
@@ -82,9 +83,9 @@ func TestAccMetalVlan_metro(t *testing.T) {
 	metro := "sv"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -106,9 +107,9 @@ func TestAccMetalVlan_basic(t *testing.T) {
 	fac := "ny5"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -135,7 +136,7 @@ func testAccCheckMetalVlanExists(n string, vlan *packngo.VirtualNetwork) resourc
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		client := testAccProvider.Meta().(*config.Config).Metal
+		client := acceptance.TestAccProvider.Meta().(*config.Config).Metal
 
 		foundVlan, _, err := client.ProjectVirtualNetworks.Get(rs.Primary.ID, nil)
 		if err != nil {
@@ -152,7 +153,7 @@ func testAccCheckMetalVlanExists(n string, vlan *packngo.VirtualNetwork) resourc
 }
 
 func testAccMetalVlanCheckDestroyed(s *terraform.State) error {
-	client := testAccProvider.Meta().(*config.Config).Metal
+	client := acceptance.TestAccProvider.Meta().(*config.Config).Metal
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_metal_vlan" {
@@ -185,9 +186,9 @@ func TestAccMetalVlan_importBasic(t *testing.T) {
 	fac := "ny5"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
This refactors the VLAN resource and data source to use equinix-sdk-go instead of packngo.  As part of this refactoring I've moved the VLAN resource and data source to an isolated package.

PR is in draft for now because there are a number of spec issues that need to be addressed and I want to get a feel for how manageable it is to move resources & change the SDK in one PR.

Part of #402 
Part of #106 