### PR TITLE
chore: fix NE path mappings and default owners in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
 #
-*                       @equinix/governor-metal-client-interfaces
+*                       @equinix/governor-devrel-engineering
 /cmd/migration-tool     @equinix/governor-metal-client-interfaces
 *metal*                 @t0mk @equinix/governor-metal-client-interfaces
 *fabric*                @equinix/governor-digin-fabric

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,11 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
 #
-*                   @equinix/governor-metal-client-interfaces
-/cmd/migration-tool @equinix/governor-metal-client-interfaces
-*metal*             @t0mk @equinix/governor-metal-client-interfaces
-*fabric*            @equinix/governor-digin-fabric
-*ecx*               @equinix/governor-digin-fabric
-*connection_e2e*    @equinix/governor-digin-fabric
-*equinix_network*   @equinix/governor-ne-network-edge-engineering
-**/edge-networking  @equinix/governor-ne-network-edge-engineering
+*                       @equinix/governor-metal-client-interfaces
+/cmd/migration-tool     @equinix/governor-metal-client-interfaces
+*metal*                 @t0mk @equinix/governor-metal-client-interfaces
+*fabric*                @equinix/governor-digin-fabric
+*ecx*                   @equinix/governor-digin-fabric
+*connection_e2e*        @equinix/governor-digin-fabric
+*resource_network_*     @equinix/governor-ne-network-edge-engineering
+*data_source_network_*  @equinix/governor-ne-network-edge-engineering
+**/edge-networking      @equinix/governor-ne-network-edge-engineering


### PR DESCRIPTION
One of the path mappings specified for the Network Edge (NE) team was `*equinix_network*` which didn't match any files.  This replaces that line with 2 lines to match NE resources and data sources.  We could use `*network*`, but that would catch `resource_metal_device_network_type.go`.

This also updates the default owners for code in this repo to DevRel Engineering, since we should be responsible for any code in this repo that is not specific to a particular service.