### PR TITLE
chore: update GHA workflows to use hashicorp/setup-terraform action

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -97,14 +97,15 @@ jobs:
       run: |
         go mod download
 
+    - uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: ${{ matrix.terraform }}
+        terraform_wrapper: false
+
     - name: TF acceptance tests
       timeout-minutes: 180
       env:
         TF_ACC: "1"
-        TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
-        # TF_SCHEMA_PANIC_ON_ERROR: "1"
-        # TF_LOG: "DEBUG"
-        #
         EQUINIX_API_TOKEN: ${{ secrets.EQUINIX_API_TOKEN }}
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
         TF_ACC_METAL_DEDICATED_CONNECTION_ID: ${{ secrets.TF_ACC_METAL_DEDICATED_CONNECTION_ID }}

--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -99,11 +99,15 @@ jobs:
         run: |
           go mod download
 
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+
       - name: TF Fabric PNFV acceptance tests
         timeout-minutes: 180
         env:
           TF_ACC: "1"
-          TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
           TF_ACC_FABRIC_CONNECTIONS_TEST_DATA: ${{ secrets.TF_ACC_FABRIC_CONNECTIONS_TEST_DATA }}
           TF_ACC_FABRIC_DEDICATED_PORTS: ${{ secrets.TF_ACC_FABRIC_DEDICATED_PORTS }}
           EQUINIX_API_CLIENTID: ${{ secrets.EQUINIX_API_CLIENTID_PNFV }}
@@ -163,11 +167,15 @@ jobs:
         run: |
           go mod download
 
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+
       - name: TF Fabric PFCR acceptance tests
         timeout-minutes: 180
         env:
           TF_ACC: "1"
-          TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
           TF_ACC_FABRIC_CONNECTIONS_TEST_DATA: ${{ secrets.TF_ACC_FABRIC_CONNECTIONS_TEST_DATA }}
           TF_ACC_FABRIC_DEDICATED_PORTS: ${{ secrets.TF_ACC_FABRIC_DEDICATED_PORTS }}
           EQUINIX_API_CLIENTID: ${{ secrets.EQUINIX_API_CLIENTID_PFCR }}


### PR DESCRIPTION
Relates to #542 

We've seen an increase in `text file busy` failures during test runs on some PRs.  After searching for that error message in GitHub issues for other providers, I landed on https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests#github-actions-workflow, which recommends using [the hashicorp/setup-terraform action](https://github.com/hashicorp/setup-terraform) in GitHub Actions workflows.

This updates our acceptance test workflows to use the setup action to install terraform, in the hopes that this reduces or eliminates the `text file busy` errors.