### PR TITLE
refactor: Migrate VRF to equinix-sdk-go and move into separate package

### DIFF
--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/equinix/terraform-provider-equinix/internal/config"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/metal_connection"
 	metal_project "github.com/equinix/terraform-provider-equinix/internal/resources/metal/project"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vrf"
 
 	"github.com/equinix/ecx-go/v2"
-	"github.com/equinix/terraform-provider-equinix/internal/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -113,7 +114,7 @@ func Provider() *schema.Provider {
 			"equinix_metal_spot_market_request":  dataSourceMetalSpotMarketRequest(),
 			"equinix_metal_virtual_circuit":      dataSourceMetalVirtualCircuit(),
 			"equinix_metal_vlan":                 dataSourceMetalVlan(),
-			"equinix_metal_vrf":                  dataSourceMetalVRF(),
+			"equinix_metal_vrf":                  vrf.DataSource(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"equinix_ecx_l2_connection":          resourceECXL2Connection(),
@@ -144,7 +145,7 @@ func Provider() *schema.Provider {
 			"equinix_metal_spot_market_request":  resourceMetalSpotMarketRequest(),
 			"equinix_metal_vlan":                 resourceMetalVlan(),
 			"equinix_metal_virtual_circuit":      resourceMetalVirtualCircuit(),
-			"equinix_metal_vrf":                  resourceMetalVRF(),
+			"equinix_metal_vrf":                  vrf.Resource(),
 			"equinix_metal_bgp_session":          resourceMetalBGPSession(),
 			"equinix_metal_port_vlan_attachment": resourceMetalPortVlanAttachment(),
 			"equinix_metal_gateway":              resourceMetalGateway(),

--- a/equinix/resource_metal_virtual_circuit_acc_test.go
+++ b/equinix/resource_metal_virtual_circuit_acc_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/packethost/packngo"
 )
 
+const (
+	metalDedicatedConnIDEnvVar = "TF_ACC_METAL_DEDICATED_CONNECTION_ID"
+)
+
 func init() {
 	resource.AddTestSweepers("equinix_metal_virtual_circuit", &resource.Sweeper{
 		Name:         "equinix_metal_virtual_circuit",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/equinix-labs/fabric-go v0.7.1
 	github.com/equinix/ecx-go/v2 v2.3.1
-	github.com/equinix/equinix-sdk-go v0.31.0
+	github.com/equinix/equinix-sdk-go v0.32.0
 	github.com/equinix/ne-go v1.14.0
 	github.com/equinix/oauth2-go v1.0.0
 	github.com/equinix/rest-go v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/equinix-labs/fabric-go v0.7.1 h1:4yk0IKXMcc72rkRVbcYHokAEc1uUB06t6NXK
 github.com/equinix-labs/fabric-go v0.7.1/go.mod h1:oqgGS3GOI8hHGPJKsAwDOEX0qRHl52sJGvwA/zMSd90=
 github.com/equinix/ecx-go/v2 v2.3.1 h1:gFcAIeyaEUw7S8ebqApmT7E/S7pC7Ac3wgScp89fkPU=
 github.com/equinix/ecx-go/v2 v2.3.1/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
-github.com/equinix/equinix-sdk-go v0.31.0 h1:BVD67nmpPEutsCGkYDuy0rykGNeQ5H3FIX+Dz5DpP7w=
-github.com/equinix/equinix-sdk-go v0.31.0/go.mod h1:qnpdRzVftHFNaJFk1VSIrAOTLrIoeDrxzUr3l8ARyvQ=
+github.com/equinix/equinix-sdk-go v0.32.0 h1:zUn0Em5FJe6f6bntftrDBpO9L+XhbpFMPuQ7RKEOgXM=
+github.com/equinix/equinix-sdk-go v0.32.0/go.mod h1:qnpdRzVftHFNaJFk1VSIrAOTLrIoeDrxzUr3l8ARyvQ=
 github.com/equinix/ne-go v1.14.0 h1:hTHN+jTHiOZ9yeG0omUOWptJL+UuFjRzhLOABvp9B90=
 github.com/equinix/ne-go v1.14.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=

--- a/internal/resources/metal/project_ssh_key/datasource_test.go
+++ b/internal/resources/metal/project_ssh_key/datasource_test.go
@@ -49,7 +49,7 @@ func TestAccDataSourceMetalProjectSSHKey_bySearch(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceMetalProjectSSHKeyDataSource_yID(t *testing.T) {
+func TestAccDataSourceMetalProjectSSHKeyDataSource_byID(t *testing.T) {
 	datasourceName := "data.equinix_metal_project_ssh_key.foobar"
 
 	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("")

--- a/internal/resources/metal/vrf/datasource.go
+++ b/internal/resources/metal/vrf/datasource.go
@@ -1,4 +1,4 @@
-package equinix
+package vrf
 
 import (
 	"context"
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceMetalVRF() *schema.Resource {
+func DataSource() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceMetalVRFRead,
 

--- a/internal/resources/metal/vrf/datasource_test.go
+++ b/internal/resources/metal/vrf/datasource_test.go
@@ -51,8 +51,6 @@ resource "equinix_metal_project" "test" {
 resource "equinix_metal_vrf" "test" {
 	name = "tfacc-vrf-%d"
 	metro = "%s"
-	local_asn = "65000"
-	ip_ranges = ["192.168.100.0/25"]
 	project_id = equinix_metal_project.test.id
 }
 

--- a/internal/resources/metal/vrf/datasource_test.go
+++ b/internal/resources/metal/vrf/datasource_test.go
@@ -1,0 +1,119 @@
+package vrf_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
+
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+func TestAccDataSourceMetalVrfDataSource_byID(t *testing.T) {
+	var vrf metalv1.Vrf
+	rInt := acctest.RandInt()
+
+	datasourceName := "data.equinix_metal_vrf.foobar"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders:         acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories:  acceptance.ProtoV5ProviderFactories,
+		PreventPostDestroyRefresh: true,
+		CheckDestroy:              testAccMetalVRFCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMetalVrfDataSourceConfig_byID(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("equinix_metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_vrf.foobar", "name", datasourceName),
+					resource.TestCheckResourceAttrSet(
+						"equinix_metal_vrf.foobar", "local_asn"),
+				),
+				// Why was follwing flag set? The plan is applied and then it's empty.
+				// It's causing errors in acceptance tests. Was this because of some API bug?
+				// ExpectNonEmptyPlan: true,
+			},
+			{
+				Config:      testAccDataSourceMetalVrfDataSourceConfig_byID(rInt),
+				ExpectError: regexp.MustCompile("was not found"),
+			},
+			{
+				// Exit the tests with an empty state and a valid config
+				// following the previous error config. This is needed for the
+				// destroy step to succeed.
+				Config: `/* this config intentionally left blank */`,
+			},
+		},
+	})
+}
+
+func testAccDataSourceMetalVrfDataSourceConfig_byID(r int) string {
+	testMetro := "da"
+
+	config := fmt.Sprintf(`
+resource "equinix_metal_project" "test" {
+    name = "tfacc-vrfs-%d"
+}
+
+resource "equinix_metal_vrf" "test" {
+	name = "tfacc-vrf-%d"
+	metro = "%s"
+	project_id = "${equinix_metal_project.test.id}"
+}
+
+data "equinix_metal_vrf" "foobar" {
+	vrf_id = equinix_metal_vrf.test.id
+}`, r, r, testMetro)
+
+	return config
+}
+
+// Test to verify that switching from SDKv2 to the Framework has not affected provider's behavior
+// TODO (ocobles): once migrated, this test may be removed
+func TestAccDataSourceMetalVrf_upgradeFromVersion(t *testing.T) {
+	var vrf metalv1.Vrf
+	rInt := acctest.RandInt()
+
+	datasourceName := "data.equinix_metal_vrf.foobar"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { acceptance.TestAccPreCheckMetal(t) },
+		PreventPostDestroyRefresh: true,
+		ExternalProviders:         acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories:  acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:              testAccMetalVRFCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"equinix": {
+						VersionConstraint: "1.24.0", // latest version with resource defined on SDKv2
+						Source:            "equinix/equinix",
+					},
+				},
+				Config: testAccDataSourceMetalVrfDataSourceConfig_byID(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("equinix_metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_vrf.foobar", "name", datasourceName),
+					resource.TestCheckResourceAttrSet(
+						"equinix_metal_vrf.foobar", "local_asn"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+				Config:                   testAccDataSourceMetalVrfDataSourceConfig_byID(rInt),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/resources/metal/vrf/resource.go
+++ b/internal/resources/metal/vrf/resource.go
@@ -1,4 +1,4 @@
-package equinix
+package vrf
 
 import (
 	"context"
@@ -8,13 +8,13 @@ import (
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/packethost/packngo"
 )
 
-func resourceMetalVRF() *schema.Resource {
+func Resource() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout:   resourceMetalVRFRead,
 		CreateWithoutTimeout: resourceMetalVRFCreate,
@@ -64,50 +64,53 @@ func resourceMetalVRF() *schema.Resource {
 
 func resourceMetalVRFCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	meta.(*config.Config).AddModuleToMetalUserAgent(d)
-	client := meta.(*config.Config).Metal
+	client := meta.(*config.Config).Metalgo
 
-	createRequest := &packngo.VRFCreateRequest{
+	createRequest := metalv1.VrfCreateInput{
 		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
+		Description: metalv1.PtrString(d.Get("description").(string)),
 		Metro:       d.Get("metro").(string),
-		LocalASN:    d.Get("local_asn").(int),
-		IPRanges:    converters.SetToStringList(d.Get("ip_ranges").(*schema.Set)),
+		LocalAsn:    metalv1.PtrInt32(d.Get("local_asn").(int32)),
+		IpRanges:    converters.SetToStringList(d.Get("ip_ranges").(*schema.Set)),
 	}
 
 	projectId := d.Get("project_id").(string)
-	vrf, _, err := client.VRFs.Create(projectId, createRequest)
+	vrf, _, err := client.VRFsApi.
+		CreateVrf(ctx, projectId).
+		VrfCreateInput(createRequest).
+		Execute()
 	if err != nil {
 		return diag.FromErr(equinix_errors.FriendlyError(err))
 	}
 
-	d.SetId(vrf.ID)
+	d.SetId(vrf.GetId())
 
 	return resourceMetalVRFRead(ctx, d, meta)
 }
 
 func resourceMetalVRFUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	meta.(*config.Config).AddModuleToMetalUserAgent(d)
-	client := meta.(*config.Config).Metal
+	client := meta.(*config.Config).Metalgo
 
-	sPtr := func(s string) *string { return &s }
-	iPtr := func(i int) *int { return &i }
-
-	updateRequest := &packngo.VRFUpdateRequest{}
+	updateRequest := metalv1.VrfUpdateInput{}
 	if d.HasChange("name") {
-		updateRequest.Name = sPtr(d.Get("name").(string))
+		updateRequest.SetName(d.Get("name").(string))
 	}
 	if d.HasChange("description") {
-		updateRequest.Description = sPtr(d.Get("description").(string))
+		updateRequest.SetDescription(d.Get("description").(string))
 	}
 	if d.HasChange("local_asn") {
-		updateRequest.LocalASN = iPtr(d.Get("local_asn").(int))
+		updateRequest.SetLocalAsn(d.Get("local_asn").(int32))
 	}
 	if d.HasChange("ip_ranges") {
 		ipRanges := converters.SetToStringList(d.Get("ip_ranges").(*schema.Set))
-		updateRequest.IPRanges = &ipRanges
+		updateRequest.SetIpRanges(ipRanges)
 	}
 
-	_, _, err := client.VRFs.Update(d.Id(), updateRequest)
+	_, _, err := client.VRFsApi.
+		UpdateVrf(ctx, d.Id()).
+		VrfUpdateInput(updateRequest).
+		Execute()
 	if err != nil {
 		return diag.FromErr(equinix_errors.FriendlyError(err))
 	}
@@ -117,11 +120,12 @@ func resourceMetalVRFUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceMetalVRFRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	meta.(*config.Config).AddModuleToMetalUserAgent(d)
-	client := meta.(*config.Config).Metal
+	client := meta.(*config.Config).Metalgo
 
-	getOpts := &packngo.GetOptions{Includes: []string{"project", "metro"}}
-
-	vrf, _, err := client.VRFs.Get(d.Id(), getOpts)
+	vrf, _, err := client.VRFsApi.
+		FindVrfById(ctx, d.Id()).
+		Include([]string{"project", "metro"}).
+		Execute()
 	if err != nil {
 		if equinix_errors.IsNotFound(err) || equinix_errors.IsForbidden(err) {
 			log.Printf("[WARN] VRF (%s) not accessible, removing from state", d.Id())
@@ -132,12 +136,12 @@ func resourceMetalVRFRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 	m := map[string]interface{}{
-		"name":        vrf.Name,
-		"description": vrf.Description,
-		"metro":       vrf.Metro.Code,
-		"local_asn":   vrf.LocalASN,
-		"ip_ranges":   vrf.IPRanges,
-		"project_id":  vrf.Project.ID,
+		"name":        vrf.GetName(),
+		"description": vrf.GetDescription(),
+		"metro":       vrf.Metro.GetCode(),
+		"local_asn":   vrf.GetLocalAsn(),
+		"ip_ranges":   vrf.GetIpRanges(),
+		"project_id":  vrf.Project.GetId(),
 	}
 
 	return diag.FromErr(equinix_schema.SetMap(d, m))

--- a/internal/resources/metal/vrf/resource.go
+++ b/internal/resources/metal/vrf/resource.go
@@ -70,7 +70,7 @@ func resourceMetalVRFCreate(ctx context.Context, d *schema.ResourceData, meta in
 		Name:        d.Get("name").(string),
 		Description: metalv1.PtrString(d.Get("description").(string)),
 		Metro:       d.Get("metro").(string),
-		LocalAsn:    metalv1.PtrInt32(d.Get("local_asn").(int32)),
+		LocalAsn:    metalv1.PtrInt32(int32(d.Get("local_asn").(int))),
 		IpRanges:    converters.SetToStringList(d.Get("ip_ranges").(*schema.Set)),
 	}
 
@@ -100,7 +100,7 @@ func resourceMetalVRFUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		updateRequest.SetDescription(d.Get("description").(string))
 	}
 	if d.HasChange("local_asn") {
-		updateRequest.SetLocalAsn(d.Get("local_asn").(int32))
+		updateRequest.SetLocalAsn(int32(d.Get("local_asn").(int)))
 	}
 	if d.HasChange("ip_ranges") {
 		ipRanges := converters.SetToStringList(d.Get("ip_ranges").(*schema.Set))

--- a/internal/resources/metal/vrf/resource.go
+++ b/internal/resources/metal/vrf/resource.go
@@ -70,8 +70,11 @@ func resourceMetalVRFCreate(ctx context.Context, d *schema.ResourceData, meta in
 		Name:        d.Get("name").(string),
 		Description: metalv1.PtrString(d.Get("description").(string)),
 		Metro:       d.Get("metro").(string),
-		LocalAsn:    metalv1.PtrInt32(int32(d.Get("local_asn").(int))),
 		IpRanges:    converters.SetToStringList(d.Get("ip_ranges").(*schema.Set)),
+	}
+
+	if value, ok := d.GetOk("local_asn"); ok {
+		createRequest.LocalAsn = metalv1.PtrInt32(int32(value.(int)))
 	}
 
 	projectId := d.Get("project_id").(string)

--- a/internal/resources/metal/vrf/resource_test.go
+++ b/internal/resources/metal/vrf/resource_test.go
@@ -237,7 +237,7 @@ func TestAccMetalVRFConfig_withConnection(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/metal/vrf/resource_test.go
+++ b/internal/resources/metal/vrf/resource_test.go
@@ -109,10 +109,10 @@ func TestAccMetalVRF_withIPRanges(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalVRFCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalVRFConfig_basic(rInt),
@@ -152,10 +152,10 @@ func TestAccMetalVRF_withIPReservations(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalVRFCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalVRFConfig_withIPRanges(rInt),
@@ -194,10 +194,10 @@ func TestAccMetalVRF_withGateway(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalVRFCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalVRFConfig_withIPReservations(rInt),
@@ -459,4 +459,33 @@ func testAccMetalVRFConfig_withVCGateway(r, nniVlan int) string {
 		metal_ip = "192.168.100.16"
 		customer_ip = "192.168.100.17"
 	}`, testConnection, r, r, nniVlan)
+}
+
+func TestAccMetalVRF_upgrade(t *testing.T) {
+	var vrf metalv1.Vrf
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalVRFCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalVRFConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("equinix_metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_vrf.test", "name", fmt.Sprintf("tfacc-vrf-%d", rInt)),
+					resource.TestCheckResourceAttrSet(
+						"equinix_metal_vrf.test", "local_asn"),
+				),
+			},
+			{
+				ResourceName:      "equinix_metal_vrf.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }

--- a/internal/resources/metal/vrf/resource_test.go
+++ b/internal/resources/metal/vrf/resource_test.go
@@ -1,18 +1,20 @@
-package equinix
+package vrf_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"strconv"
 	"testing"
 
+	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/packethost/packngo"
 )
 
 const (
@@ -34,7 +36,7 @@ func init() {
 
 func testSweepVRFs(region string) error {
 	log.Printf("[DEBUG] Sweeping VRFs")
-	config, err := sharedConfigForRegion(region)
+	config, err := acceptance.GetConfigForNonStandardMetalTest()
 	if err != nil {
 		return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting configuration for sweeping VRFs: %s", err)
 	}
@@ -45,7 +47,7 @@ func testSweepVRFs(region string) error {
 	}
 	pids := []string{}
 	for _, p := range ps {
-		if isSweepableTestResource(p.Name) {
+		if acceptance.IsSweepableTestResource(p.Name) {
 			pids = append(pids, p.ID)
 		}
 	}
@@ -57,7 +59,7 @@ func testSweepVRFs(region string) error {
 			continue
 		}
 		for _, d := range ds {
-			if isSweepableTestResource(d.Name) {
+			if acceptance.IsSweepableTestResource(d.Name) {
 				dids = append(dids, d.ID)
 			}
 		}
@@ -74,13 +76,13 @@ func testSweepVRFs(region string) error {
 }
 
 func TestAccMetalVRF_basic(t *testing.T) {
-	var vrf packngo.VRF
+	var vrf metalv1.Vrf
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -103,13 +105,13 @@ func TestAccMetalVRF_basic(t *testing.T) {
 }
 
 func TestAccMetalVRF_withIPRanges(t *testing.T) {
-	var vrf packngo.VRF
+	var vrf metalv1.Vrf
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -146,13 +148,13 @@ func TestAccMetalVRF_withIPRanges(t *testing.T) {
 }
 
 func TestAccMetalVRF_withIPReservations(t *testing.T) {
-	var vrf packngo.VRF
+	var vrf metalv1.Vrf
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -188,13 +190,13 @@ func TestAccMetalVRF_withIPReservations(t *testing.T) {
 }
 
 func TestAccMetalVRF_withGateway(t *testing.T) {
-	var vrf packngo.VRF
+	var vrf metalv1.Vrf
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -229,14 +231,14 @@ func TestAccMetalVRF_withGateway(t *testing.T) {
 }
 
 func TestAccMetalVRFConfig_withConnection(t *testing.T) {
-	var vrf packngo.VRF
+	var vrf metalv1.Vrf
 	rInt := acctest.RandInt()
 	nniVlan := acctest.RandIntRange(1024, 1093)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		Providers:         testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders: acceptance.TestExternalProviders,
+		Providers:         acceptance.TestAccProviders,
 		CheckDestroy:      testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -302,13 +304,13 @@ func TestAccMetalVRFConfig_withConnection(t *testing.T) {
 }
 
 func testAccMetalVRFCheckDestroyed(s *terraform.State) error {
-	client := testAccProvider.Meta().(*config.Config).Metal
+	client := acceptance.TestAccProvider.Meta().(*config.Config).Metalgo
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_metal_vrf" {
 			continue
 		}
-		if _, _, err := client.VRFs.Get(rs.Primary.ID, nil); err == nil {
+		if _, _, err := client.VRFsApi.FindVrfById(context.Background(), rs.Primary.ID).Execute(); err == nil {
 			return fmt.Errorf("Metal VRF still exists")
 		}
 	}
@@ -316,7 +318,7 @@ func testAccMetalVRFCheckDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccMetalVRFExists(n string, vrf *packngo.VRF) resource.TestCheckFunc {
+func testAccMetalVRFExists(n string, vrf *metalv1.Vrf) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -326,13 +328,13 @@ func testAccMetalVRFExists(n string, vrf *packngo.VRF) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		client := testAccProvider.Meta().(*config.Config).Metal
+		client := acceptance.TestAccProvider.Meta().(*config.Config).Metalgo
 
-		foundResource, _, err := client.VRFs.Get(rs.Primary.ID, nil)
+		foundResource, _, err := client.VRFsApi.FindVrfById(context.Background(), rs.Primary.ID).Execute()
 		if err != nil {
 			return err
 		}
-		if foundResource.ID != rs.Primary.ID {
+		if foundResource.GetId() != rs.Primary.ID {
 			return fmt.Errorf("Record not found: %v - %v", rs.Primary.ID, foundResource)
 		}
 

--- a/internal/resources/metal/vrf/resource_test.go
+++ b/internal/resources/metal/vrf/resource_test.go
@@ -8,10 +8,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
-
-	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -459,33 +458,4 @@ func testAccMetalVRFConfig_withVCGateway(r, nniVlan int) string {
 		metal_ip = "192.168.100.16"
 		customer_ip = "192.168.100.17"
 	}`, testConnection, r, r, nniVlan)
-}
-
-func TestAccMetalVRF_upgrade(t *testing.T) {
-	var vrf metalv1.Vrf
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccMetalVRFCheckDestroyed,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccMetalVRFConfig_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccMetalVRFExists("equinix_metal_vrf.test", &vrf),
-					resource.TestCheckResourceAttr(
-						"equinix_metal_vrf.test", "name", fmt.Sprintf("tfacc-vrf-%d", rInt)),
-					resource.TestCheckResourceAttrSet(
-						"equinix_metal_vrf.test", "local_asn"),
-				),
-			},
-			{
-				ResourceName:      "equinix_metal_vrf.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
 }


### PR DESCRIPTION
This updates the Equinix Metal project resource and data source from the deprecated packngo SDK to equinix-sdk-go and moves them into separate package required for supporting plugin framework

Relates to https://github.com/equinix/terraform-provider-equinix/issues/402