### PR TITLE
chore: capture test coverage for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Go Tests
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    branches:
+    - main
+
 
 jobs:
 
@@ -27,4 +31,11 @@ jobs:
       run: go build -v .
 
     - name: TF tests
-      run: go test -v -cover -parallel 4 $(go list ./... |grep -v 'tests')
+      run: go test -v --coverprofile coverage.txt -covermode=atomic -parallel 4 $(go list ./... |grep -v 'tests')
+
+    - name: Upload coverage to Codecov
+      if: ${{ always() }}
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.txt


### PR DESCRIPTION
I'm pretty sure we were capturing this previously because all tests (unit and integration) were running in the same workflow.  In any case, this captures the unit test coverage because it's at least as useful to track as the integration test coverage.

From what I can see in CodeCov docs, the unit and integration reports we upload for a particular commit will be merged automatically into one report, so we'll get a better picture of how well our code is covered.

This also updates the unit test workflow to trigger on every push to main; since these tests are lightweight and siolated, it's safe to run them frequently.  And it ensures that our test status badge in the README stays up-to-date!