### PR TITLE
fix: Include project id in client side filter for data source network account

### DIFF
--- a/docs/data-sources/equinix_network_account.md
+++ b/docs/data-sources/equinix_network_account.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `status` - (Optional) Account status for filtering. Possible values are: `Active`, `Processing`,
 `Submitted`, `Staged`.
 * `project_id` - (Optional) Unique Identifier for the project resource where the account is scoped to.If you
-leave it out, all the billing accounts are returned under all projects in your organization and search criteria will return more than one account.
+leave it out, all the billing accounts under all projects in your organization will be returned and it may return more than one account.
 
 ## Attributes Reference
 

--- a/docs/data-sources/equinix_network_account.md
+++ b/docs/data-sources/equinix_network_account.md
@@ -17,6 +17,8 @@ in corresponding metro location.
 data "equinix_network_account" "dc" {
   metro_code = "DC"
   status     = "Active"
+  project_id = "a86d7112-d740-4758-9c9c-31e66373746b"
+" 
 }
 
 output "number" {
@@ -32,6 +34,8 @@ The following arguments are supported:
 * `name` - (Optional) Account name for filtering.
 * `status` - (Optional) Account status for filtering. Possible values are: `Active`, `Processing`,
 `Submitted`, `Staged`.
+* `project_id` - (Optional) Unique Identifier for the project resource where the account is scoped to.If you
+leave it out, all the billing accounts are returned under all projects in your organization and search criteria will return more than one account.
 
 ## Attributes Reference
 

--- a/equinix/data_source_network_account.go
+++ b/equinix/data_source_network_account.go
@@ -71,7 +71,6 @@ func dataSourceNetworkAccount() *schema.Resource {
 				Type:         schema.TypeString,
 				Computed:     true,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IsUUID,
 				Description:  networkAccountDescriptions["ProjectID"],
 			},

--- a/equinix/data_source_network_account_acc_test.go
+++ b/equinix/data_source_network_account_acc_test.go
@@ -14,6 +14,7 @@ func TestAccDataSourceNetworkAccount_basic(t *testing.T) {
 		"resourceName": "tf-account",
 		"metro_code":   metro.(string),
 		"status":       "active",
+		"project_id":   "92cbcfd9-347b-4da5-901d-2cea82575941",
 	}
 	resourceName := fmt.Sprintf("data.equinix_network_account.%s", context["resourceName"].(string))
 	resource.ParallelTest(t, resource.TestCase{
@@ -27,6 +28,7 @@ func TestAccDataSourceNetworkAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "number"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 					resource.TestCheckResourceAttrSet(resourceName, "ucm_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 				),
 			},
 		},

--- a/equinix/resource_fabric_routing_protocol_acc_test.go
+++ b/equinix/resource_fabric_routing_protocol_acc_test.go
@@ -14,26 +14,70 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAccFabricCreateDirectRoutingProtocol(t *testing.T) {
+// Note:
+// Keeping data "equinix_fabric_routing_protocol" tests in this file
+// due to the long setup times required for RP tests.
+// The FCR, Connection and RPs will already be created in the resource test, so the
+// data_source tests will just leverage the RPs there to retrieve the data and check results
+
+func TestAccFabricCreateDirectRoutingProtocol_PFCR_A(t *testing.T) {
+	ports := GetFabricEnvPorts(t)
+
+	var portUuid string
+
+	if len(ports) > 0 {
+		portUuid = ports["pfcr"]["dot1q"][1].Uuid
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: checkRoutingProtocolDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFabricCreateRoutingProtocolDirectConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.1/30", "172::1:1/126"),
+				Config: testAccFabricCreateRoutingProtocolConfig("RP_Conn_Test_PFCR", portUuid),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "direct_ipv4.*", map[string]string{
-						"equinix_iface_ip": fmt.Sprintf("190.1.1.1/30"),
-					}),
-				),
-				ExpectNonEmptyPlan: true,
-			}, {
-				Config: testAccFabricCreateRoutingProtocolDirectConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.1/26", "172::1:1/126"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "direct_ipv4.*", map[string]string{
-						"equinix_iface_ip": fmt.Sprintf("190.1.1.1/26"),
-					}),
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.direct", "id"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "type", "DIRECT"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "state", "PROVISIONED"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.direct", "change.0.uuid"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "change.0.type", "ROUTING_PROTOCOL_CREATION"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "direct_ipv4.0.equinix_iface_ip", "190.1.1.1/30"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "direct_ipv6.0.equinix_iface_ip", "190::1:1/126"),
+
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.bgp", "id"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "type", "BGP"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "state", "PROVISIONED"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.bgp", "change.0.uuid"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "change.0.type", "ROUTING_PROTOCOL_CREATION"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.customer_peer_ip", "190.1.1.2"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.equinix_peer_ip", "190.1.1.1"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.enabled", "true"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.customer_peer_ip", "190::1:2"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.equinix_peer_ip", "190::1:1"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.enabled", "true"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "customer_asn", "100"),
+
+					resource.TestCheckResourceAttrSet("data.equinix_fabric_routing_protocol.direct", "id"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "type", "DIRECT"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "state", "PROVISIONED"),
+					resource.TestCheckResourceAttrSet("data.equinix_fabric_routing_protocol.direct", "change.0.uuid"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "change.0.type", "ROUTING_PROTOCOL_CREATION"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "direct_ipv4.0.equinix_iface_ip", "190.1.1.1/30"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "direct_ipv6.0.equinix_iface_ip", "190::1:1/126"),
+
+					resource.TestCheckResourceAttrSet("data.equinix_fabric_routing_protocol.bgp", "id"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "type", "BGP"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "state", "PROVISIONED"),
+					resource.TestCheckResourceAttrSet("data.equinix_fabric_routing_protocol.bgp", "change.0.uuid"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "change.0.type", "ROUTING_PROTOCOL_CREATION"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.customer_peer_ip", "190.1.1.2"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.equinix_peer_ip", "190.1.1.1"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.customer_peer_ip", "190::1:2"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.equinix_peer_ip", "190::1:1"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "customer_asn", "100"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -41,62 +85,114 @@ func TestAccFabricCreateDirectRoutingProtocol(t *testing.T) {
 	})
 }
 
-func testAccFabricCreateRoutingProtocolDirectConfig(connectionUuid string, ipv4 string, ipv6 string) string {
-	return fmt.Sprintf(`	resource "equinix_fabric_routing_protocol" "test" {
-		connection_uuid = "%s"
+func testAccFabricCreateRoutingProtocolConfig(name, portUuid string) string {
+	return fmt.Sprintf(`
 
-		type = "DIRECT"
-		name = "fabric_tf_acc_test_rpDirect"
-		direct_ipv4{
-			equinix_iface_ip = "%s"
-		}
-		direct_ipv6{
-			equinix_iface_ip = "%s"
-		}
-	}`, connectionUuid, ipv4, ipv6)
+resource "equinix_fabric_cloud_router" "this" {
+	type = "XF_ROUTER"
+	name = "RP_Test_PFCR"
+	location{
+		metro_code  = "SV"
+	}
+	order{
+		purchase_order_number = "1-234567"
+	}
+	notifications{
+		type = "ALL"
+		emails = ["test@equinix.com", "test1@equinix.com"]
+	}
+	project{
+		project_id = "291639000636552"
+	}
+	account {
+		account_number = 201257
+	}
+	package {
+		code = "STANDARD"
+	}
 }
 
-func TestAccFabricCreateBgpRoutingProtocol(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: checkRoutingProtocolDelete,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFabricCreateRoutingProtocolBgpConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.2", ""),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "bgp_ipv4.*", map[string]string{
-						"customer_peer_ip": fmt.Sprintf("190.1.1.2"),
-					}),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-			{
-				Config: testAccFabricCreateRoutingProtocolBgpConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.3", "172::1:2"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "bgp_ipv4.*", map[string]string{
-						"customer_peer_ip": fmt.Sprintf("190.1.1.3"),
-					}),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
+resource "equinix_fabric_connection" "this" {
+	type = "IP_VC"
+	name = "%s"
+	notifications{
+		type = "ALL"
+		emails = ["test@equinix.com","test1@equinix.com"]
+	}
+	order {
+		purchase_order_number = "123485"
+	}
+	bandwidth = 50
+	redundancy {
+		priority= "PRIMARY"
+	}
+	a_side {
+		access_point {
+			type = "CLOUD_ROUTER"
+			router {
+				uuid = equinix_fabric_cloud_router.this.id
+			}
+		}
+	}
+	project{
+		project_id = "291639000636552"
+	}
+	z_side {
+		access_point {
+			type = "COLO"
+			port{
+				uuid = "%s"
+			}
+			link_protocol {
+				type= "DOT1Q"
+				vlan_tag= 2152
+			}
+			location {
+				metro_code = "SV"
+			}
+		}
+	}
 }
 
-func testAccFabricCreateRoutingProtocolBgpConfig(connectionUuid string, ipv4 string, ipv6 string) string {
-	return fmt.Sprintf(`	resource "equinix_fabric_routing_protocol" "test" {
-		connection_uuid = "%s"
+resource "equinix_fabric_routing_protocol" "direct" {
+	connection_uuid = equinix_fabric_connection.this.id
+	type = "DIRECT"
+	name = "rp_direct_PFCR"
+	direct_ipv4{
+		equinix_iface_ip = "190.1.1.1/30"
+	}
+	direct_ipv6{
+		equinix_iface_ip = "190::1:1/126"
+	}
+}
 
-		type = "BGP"
-		bgp_ipv4{
-			customer_peer_ip = "%s"
-		}
-		bgp_ipv6{
-			customer_peer_ip = "%s"
-		}
-		customer_asn = "100"
-	}`, connectionUuid, ipv4, ipv6)
+resource "equinix_fabric_routing_protocol" "bgp" {
+	depends_on = [
+      equinix_fabric_routing_protocol.direct
+  	]
+	connection_uuid = equinix_fabric_connection.this.id
+	type = "BGP"
+	name = "rp_bgp_PFCR"
+	bgp_ipv4{
+		customer_peer_ip = "190.1.1.2"
+	}
+	bgp_ipv6{
+		customer_peer_ip = "190::1:2"
+	}
+	customer_asn = "100"
+}
+
+data "equinix_fabric_routing_protocol" "direct" {
+	connection_uuid = equinix_fabric_connection.this.id
+	uuid = equinix_fabric_routing_protocol.direct.id
+}
+
+data "equinix_fabric_routing_protocol" "bgp" {
+	connection_uuid = equinix_fabric_connection.this.id
+	uuid = equinix_fabric_routing_protocol.bgp.id
+}
+
+`, name, portUuid)
 }
 
 func checkRoutingProtocolDelete(s *terraform.State) error {
@@ -112,29 +208,4 @@ func checkRoutingProtocolDelete(s *terraform.State) error {
 		}
 	}
 	return nil
-}
-
-func TestAccFabricReadRoutingProtocolByUuid(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
-		Providers: acceptance.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFabricReadRoutingProtocolConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "00f48313-ab13-4524-aaad-93c31b5b8848"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"equinix_fabric_routing_protocol.test", "type", fmt.Sprint("DIRECT")),
-					resource.TestCheckResourceAttr(
-						"equinix_fabric_routing_protocol.test", "state", fmt.Sprint("PROVISIONED")),
-				),
-			},
-		},
-	})
-}
-
-func testAccFabricReadRoutingProtocolConfig(connectionUuid string, routingProtocolUuid string) string {
-	return fmt.Sprintf(`data "equinix_fabric_routing_protocol" "test" {
-	connection_uuid = "%s"
-	uuid = "%s"
-	}`, connectionUuid, routingProtocolUuid)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/equinix-labs/fabric-go v0.7.1
 	github.com/equinix/ecx-go/v2 v2.3.1
 	github.com/equinix/equinix-sdk-go v0.32.0
-	github.com/equinix/ne-go v1.14.0
+	github.com/equinix/ne-go v1.15.0
 	github.com/equinix/oauth2-go v1.0.0
 	github.com/equinix/rest-go v1.3.0
 	github.com/google/uuid v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,7 @@ github.com/equinix/equinix-sdk-go v0.32.0 h1:zUn0Em5FJe6f6bntftrDBpO9L+XhbpFMPuQ
 github.com/equinix/equinix-sdk-go v0.32.0/go.mod h1:qnpdRzVftHFNaJFk1VSIrAOTLrIoeDrxzUr3l8ARyvQ=
 github.com/equinix/ne-go v1.14.0 h1:hTHN+jTHiOZ9yeG0omUOWptJL+UuFjRzhLOABvp9B90=
 github.com/equinix/ne-go v1.14.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
+github.com/equinix/ne-go v1.15.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=
 github.com/equinix/oauth2-go v1.0.0/go.mod h1:4pulXvUNMktJlewLPnUeJyMW52iCoF1aM+A/Z5xY1ws=
 github.com/equinix/rest-go v1.3.0 h1:m38scYTOfV6N+gcrwchgVDutDffYd+QoYCMm9Jn6jyk=

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,7 @@ github.com/equinix/ecx-go/v2 v2.3.1 h1:gFcAIeyaEUw7S8ebqApmT7E/S7pC7Ac3wgScp89fk
 github.com/equinix/ecx-go/v2 v2.3.1/go.mod h1:FvCdZ3jXU8Z4CPKig2DT+4J2HdwgRK17pIcznM7RXyk=
 github.com/equinix/equinix-sdk-go v0.32.0 h1:zUn0Em5FJe6f6bntftrDBpO9L+XhbpFMPuQ7RKEOgXM=
 github.com/equinix/equinix-sdk-go v0.32.0/go.mod h1:qnpdRzVftHFNaJFk1VSIrAOTLrIoeDrxzUr3l8ARyvQ=
-github.com/equinix/ne-go v1.14.0 h1:hTHN+jTHiOZ9yeG0omUOWptJL+UuFjRzhLOABvp9B90=
-github.com/equinix/ne-go v1.14.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
+github.com/equinix/ne-go v1.15.0 h1:wWpniWX+m9Izv6qS/EzPBS8Zqp006Ay2dcRuHxN5/Z8=
 github.com/equinix/ne-go v1.15.0/go.mod h1:eHkkxM4nbTB7DZ9X9zGnwfYnxIJWIsU3aHA+FAoZ1EI=
 github.com/equinix/oauth2-go v1.0.0 h1:fHtAPGq82PdgtK5vEThs8Vwz6f7D/8SX4tE3NJu+KcU=
 github.com/equinix/oauth2-go v1.0.0/go.mod h1:4pulXvUNMktJlewLPnUeJyMW52iCoF1aM+A/Z5xY1ws=


### PR DESCRIPTION
Feat: Include project id in client side filter for data source network account
Issue link : https://github.com/equinix/terraform-provider-equinix/issues/471
ne-go PR- https://github.com/equinix/ne-go/pull/29
