### PR TITLE
test: equinix_fabric_routing_protocol resource and data source

### DIFF
--- a/equinix/resource_fabric_connection.go
+++ b/equinix/resource_fabric_connection.go
@@ -876,7 +876,7 @@ func waitUntilConnectionIsCreated(uuid string, meta interface{}, ctx context.Con
 			}
 			return dbConn, string(*dbConn.State), nil
 		},
-		Timeout:    5 * time.Minute,
+		Timeout:    10 * time.Minute,
 		Delay:      30 * time.Second,
 		MinTimeout: 30 * time.Second,
 	}

--- a/equinix/resource_fabric_connection.go
+++ b/equinix/resource_fabric_connection.go
@@ -876,7 +876,7 @@ func waitUntilConnectionIsCreated(uuid string, meta interface{}, ctx context.Con
 			}
 			return dbConn, string(*dbConn.State), nil
 		},
-		Timeout:    10 * time.Minute,
+		Timeout:    5 * time.Minute,
 		Delay:      30 * time.Second,
 		MinTimeout: 30 * time.Second,
 	}

--- a/equinix/resource_fabric_routing_protocol_acc_test.go
+++ b/equinix/resource_fabric_routing_protocol_acc_test.go
@@ -14,26 +14,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAccFabricCreateDirectRoutingProtocol(t *testing.T) {
+func TestAccFabricCreateDirectRoutingProtocol_PFCR_A(t *testing.T) {
+	ports := GetFabricEnvPorts(t)
+	var portUuid string
+	if len(ports) > 0 {
+		portUuid = ports["pfcr"]["dot1q"][1].Uuid
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: checkRoutingProtocolDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFabricCreateRoutingProtocolDirectConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.1/30", "172::1:1/126"),
+				Config: testAccFabricCreateRoutingProtocolConfig("fcr_test_PFCR", portUuid, "190.1.1.1", "172::1:1"),
+				//Config: testAccFabricCreateRoutingProtocolConfig("fcr_test_PFCR", portUuid),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "direct_ipv4.*", map[string]string{
-						"equinix_iface_ip": fmt.Sprintf("190.1.1.1/30"),
-					}),
-				),
-				ExpectNonEmptyPlan: true,
-			}, {
-				Config: testAccFabricCreateRoutingProtocolDirectConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.1/26", "172::1:1/126"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "direct_ipv4.*", map[string]string{
-						"equinix_iface_ip": fmt.Sprintf("190.1.1.1/26"),
-					}),
+					resource.TestCheckTypeSetElemAttr("equinix_fabric_routing_protocol.test", "anything.*", "Anything"),
+					//resource.TestCheckResourceAttr(
+					//	"equinix_fabric_connection.test", "name", "fcr_test_PFCR"),
+					//resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "direct_ipv4.*", map[string]string{
+					//	"equinix_iface_ip": fmt.Sprintf("190.1.1.1/30"),
+					//}),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -41,63 +43,260 @@ func TestAccFabricCreateDirectRoutingProtocol(t *testing.T) {
 	})
 }
 
-func testAccFabricCreateRoutingProtocolDirectConfig(connectionUuid string, ipv4 string, ipv6 string) string {
-	return fmt.Sprintf(`	resource "equinix_fabric_routing_protocol" "test" {
-		connection_uuid = "%s"
+//func testAccFabricCreateRoutingProtocolConfig(name, portUuid string) string {
+//	return fmt.Sprintf(`
+//
+//resource "equinix_fabric_cloud_router" "this" {
+//	type = "XF_ROUTER"
+//	name = "Test_PFCR"
+//	location{
+//		metro_code  = "SV"
+//	}
+//	order{
+//		purchase_order_number = "1-234567"
+//	}
+//	notifications{
+//		type = "ALL"
+//		emails = ["test@equinix.com", "test1@equinix.com"]
+//	}
+//	project{
+//		project_id = "291639000636552"
+//	}
+//	account {
+//		account_number = 201257
+//	}
+//	package {
+//		code = "STANDARD"
+//	}
+//}
+//
+//resource "equinix_fabric_connection" "test" {
+//	type = "IP_VC"
+//	name = "%s"
+//	notifications{
+//		type = "ALL"
+//		emails = ["test@equinix.com","test1@equinix.com"]
+//	}
+//	order {
+//		purchase_order_number = "123485"
+//	}
+//	bandwidth = 50
+//	redundancy {
+//		priority= "PRIMARY"
+//	}
+//	a_side {
+//		access_point {
+//			type = "CLOUD_ROUTER"
+//			router {
+//				uuid = equinix_fabric_cloud_router.this.id
+//			}
+//		}
+//	}
+//	project{
+//		project_id = "291639000636552"
+//	}
+//	z_side {
+//		access_point {
+//			type = "COLO"
+//			port{
+//				uuid = "%s"
+//			}
+//			link_protocol {
+//				type= "DOT1Q"
+//				vlan_tag= 2325
+//			}
+//			location {
+//				metro_code = "SV"
+//			}
+//		}
+//	}
+//}`, name, portUuid)
+//}
 
-		type = "DIRECT"
-		name = "fabric_tf_acc_test_rpDirect"
-		direct_ipv4{
-			equinix_iface_ip = "%s"
-		}
-		direct_ipv6{
-			equinix_iface_ip = "%s"
-		}
-	}`, connectionUuid, ipv4, ipv6)
+func testAccFabricCreateRoutingProtocolConfig(name, portUuid, ip4, ip6 string) string {
+	return fmt.Sprintf(`
+
+resource "equinix_fabric_cloud_router" "this" {
+	type = "XF_ROUTER"
+	name = "Test_PFCR"
+	location{
+		metro_code  = "SV"
+	}
+	order{
+		purchase_order_number = "1-234567"
+	}
+	notifications{
+		type = "ALL"
+		emails = ["test@equinix.com", "test1@equinix.com"]
+	}
+	project{
+		project_id = "291639000636552"
+	}
+	account {
+		account_number = 201257
+	}
+	package {
+		code = "STANDARD"
+	}
 }
 
-func TestAccFabricCreateBgpRoutingProtocol(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: checkRoutingProtocolDelete,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFabricCreateRoutingProtocolBgpConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.2", ""),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "bgp_ipv4.*", map[string]string{
-						"customer_peer_ip": fmt.Sprintf("190.1.1.2"),
-					}),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-			{
-				Config: testAccFabricCreateRoutingProtocolBgpConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.3", "172::1:2"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "bgp_ipv4.*", map[string]string{
-						"customer_peer_ip": fmt.Sprintf("190.1.1.3"),
-					}),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
+resource "equinix_fabric_connection" "this" {
+	type = "IP_VC"
+	name = "%s"
+	notifications{
+		type = "ALL"
+		emails = ["test@equinix.com","test1@equinix.com"]
+	}
+	order {
+		purchase_order_number = "123485"
+	}
+	bandwidth = 50
+	redundancy {
+		priority= "PRIMARY"
+	}
+	a_side {
+		access_point {
+			type = "CLOUD_ROUTER"
+			router {
+				uuid = equinix_fabric_cloud_router.this.id
+			}
+		}
+	}
+	project{
+		project_id = "291639000636552"
+	}
+	z_side {
+		access_point {
+			type = "COLO"
+			port{
+				uuid = "%s"
+			}
+			link_protocol {
+				type= "DOT1Q"
+				vlan_tag= 2328
+			}
+			location {
+				metro_code = "SV"
+			}
+		}
+	}
 }
 
-func testAccFabricCreateRoutingProtocolBgpConfig(connectionUuid string, ipv4 string, ipv6 string) string {
-	return fmt.Sprintf(`	resource "equinix_fabric_routing_protocol" "test" {
-		connection_uuid = "%s"
-
-		type = "BGP"
-		bgp_ipv4{
-			customer_peer_ip = "%s"
-		}
-		bgp_ipv6{
-			customer_peer_ip = "%s"
-		}
-		customer_asn = "100"
-	}`, connectionUuid, ipv4, ipv6)
+resource "equinix_fabric_routing_protocol" "this" {
+	connection_uuid = equinix_fabric_connection.this.id
+	bgp_ipv4{
+		customer_peer_ip = "%s"
+	}
+	bgp_ipv6{
+		customer_peer_ip = "%s"
+	}
+	type = "BGP"
+	name = "fabric_tf_acc_test_rpDirect"
+	customer_asn = "100"
+}`, name, portUuid, ip4, ip6)
 }
+
+//resource "equinix_fabric_routing_protocol" "test" {
+//connection_uuid = "equinix_fabric_connection.this.uuid"
+//type = "BGP"
+//bgp_ipv4{
+//customer_peer_ip = "%s"
+//}
+//bgp_ipv6{
+//customer_peer_ip = "%s"
+//}
+//customer_asn = "100"
+//}
+//
+//data "equinix_fabric_routing_protocol" "test" {
+//	connection_uuid = equinix_fabric_routing_protocol.test.uuid
+//}`, name, portUuid, ip4, ip6)
+//}
+
+//func TestAccFabricCreateDirectRoutingProtocol(t *testing.T) {
+//	resource.ParallelTest(t, resource.TestCase{
+//		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+//		Providers:    acceptance.TestAccProviders,
+//		CheckDestroy: checkRoutingProtocolDelete,
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccFabricCreateRoutingProtocolDirectConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.1/30", "172::1:1/126"),
+//				Check: resource.ComposeTestCheckFunc(
+//					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "direct_ipv4.*", map[string]string{
+//						"equinix_iface_ip": fmt.Sprintf("190.1.1.1/30"),
+//					}),
+//				),
+//				ExpectNonEmptyPlan: true,
+//			}, {
+//				Config: testAccFabricCreateRoutingProtocolDirectConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.1/26", "172::1:1/126"),
+//				Check: resource.ComposeTestCheckFunc(
+//					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "direct_ipv4.*", map[string]string{
+//						"equinix_iface_ip": fmt.Sprintf("190.1.1.1/26"),
+//					}),
+//				),
+//				ExpectNonEmptyPlan: true,
+//			},
+//		},
+//	})
+//}
+
+//func testAccFabricCreateRoutingProtocolDirectConfig(connectionUuid string, ipv4 string, ipv6 string) string {
+//	return fmt.Sprintf(`	resource "equinix_fabric_routing_protocol" "test" {
+//		connection_uuid = "%s"
+//
+//		type = "DIRECT"
+//		name = "fabric_tf_acc_test_rpDirect"
+//		direct_ipv4{
+//			equinix_iface_ip = "%s"
+//		}
+//		direct_ipv6{
+//			equinix_iface_ip = "%s"
+//		}
+//	}`, connectionUuid, ipv4, ipv6)
+//}
+//
+//func TestAccFabricCreateBgpRoutingProtocol(t *testing.T) {
+//	resource.ParallelTest(t, resource.TestCase{
+//		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+//		Providers:    acceptance.TestAccProviders,
+//		CheckDestroy: checkRoutingProtocolDelete,
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccFabricCreateRoutingProtocolBgpConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.2", ""),
+//				Check: resource.ComposeTestCheckFunc(
+//					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "bgp_ipv4.*", map[string]string{
+//						"customer_peer_ip": fmt.Sprintf("190.1.1.2"),
+//					}),
+//				),
+//				ExpectNonEmptyPlan: true,
+//			},
+//			{
+//				Config: testAccFabricCreateRoutingProtocolBgpConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.3", "172::1:2"),
+//				Check: resource.ComposeTestCheckFunc(
+//					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "bgp_ipv4.*", map[string]string{
+//						"customer_peer_ip": fmt.Sprintf("190.1.1.3"),
+//					}),
+//				),
+//				ExpectNonEmptyPlan: true,
+//			},
+//		},
+//	})
+//}
+
+//func testAccFabricCreateRoutingProtocolBgpConfig(connectionUuid string, ipv4 string, ipv6 string) string {
+//	return fmt.Sprintf(`	resource "equinix_fabric_routing_protocol" "test" {
+//		connection_uuid = "%s"
+//
+//		type = "BGP"
+//		bgp_ipv4{
+//			customer_peer_ip = "%s"
+//		}
+//		bgp_ipv6{
+//			customer_peer_ip = "%s"
+//		}
+//		customer_asn = "100"
+//	}`, connectionUuid, ipv4, ipv6)
+//}
 
 func checkRoutingProtocolDelete(s *terraform.State) error {
 	ctx := context.Background()
@@ -114,27 +313,27 @@ func checkRoutingProtocolDelete(s *terraform.State) error {
 	return nil
 }
 
-func TestAccFabricReadRoutingProtocolByUuid(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
-		Providers: acceptance.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFabricReadRoutingProtocolConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "00f48313-ab13-4524-aaad-93c31b5b8848"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"equinix_fabric_routing_protocol.test", "type", fmt.Sprint("DIRECT")),
-					resource.TestCheckResourceAttr(
-						"equinix_fabric_routing_protocol.test", "state", fmt.Sprint("PROVISIONED")),
-				),
-			},
-		},
-	})
-}
-
-func testAccFabricReadRoutingProtocolConfig(connectionUuid string, routingProtocolUuid string) string {
-	return fmt.Sprintf(`data "equinix_fabric_routing_protocol" "test" {
-	connection_uuid = "%s"
-	uuid = "%s"
-	}`, connectionUuid, routingProtocolUuid)
-}
+//func TestAccFabricReadRoutingProtocolByUuid(t *testing.T) {
+//	resource.ParallelTest(t, resource.TestCase{
+//		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+//		Providers: acceptance.TestAccProviders,
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccFabricReadRoutingProtocolConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "00f48313-ab13-4524-aaad-93c31b5b8848"),
+//				Check: resource.ComposeTestCheckFunc(
+//					resource.TestCheckResourceAttr(
+//						"equinix_fabric_routing_protocol.test", "type", fmt.Sprint("DIRECT")),
+//					resource.TestCheckResourceAttr(
+//						"equinix_fabric_routing_protocol.test", "state", fmt.Sprint("PROVISIONED")),
+//				),
+//			},
+//		},
+//	})
+//}
+//
+//func testAccFabricReadRoutingProtocolConfig(connectionUuid string, routingProtocolUuid string) string {
+//	return fmt.Sprintf(`data "equinix_fabric_routing_protocol" "test" {
+//	connection_uuid = "%s"
+//	uuid = "%s"
+//	}`, connectionUuid, routingProtocolUuid)
+//}

--- a/equinix/resource_fabric_routing_protocol_acc_test.go
+++ b/equinix/resource_fabric_routing_protocol_acc_test.go
@@ -27,7 +27,7 @@ func TestAccFabricCreateDirectRoutingProtocol_PFCR_A(t *testing.T) {
 		CheckDestroy: checkRoutingProtocolDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFabricCreateRoutingProtocolConfig("fcr_test_PFCR", portUuid, "190.1.1.1", "172::1:1"),
+				Config: testAccFabricCreateRoutingProtocolConfig("fcr_test_PFCR", portUuid, "190.1.1.1/30", "190::1:1/126"),
 				//Config: testAccFabricCreateRoutingProtocolConfig("fcr_test_PFCR", portUuid),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckTypeSetElemAttr("equinix_fabric_routing_protocol.test", "anything.*", "Anything"),
@@ -173,7 +173,7 @@ resource "equinix_fabric_connection" "this" {
 			}
 			link_protocol {
 				type= "DOT1Q"
-				vlan_tag= 2328
+				vlan_tag= 2334
 			}
 			location {
 				metro_code = "SV"
@@ -184,15 +184,14 @@ resource "equinix_fabric_connection" "this" {
 
 resource "equinix_fabric_routing_protocol" "this" {
 	connection_uuid = equinix_fabric_connection.this.id
-	bgp_ipv4{
-		customer_peer_ip = "%s"
+	direct_ipv4{
+		equinix_iface_ip = "%s"
 	}
-	bgp_ipv6{
-		customer_peer_ip = "%s"
+	direct_ipv6{
+		equinix_iface_ip = "%s"
 	}
-	type = "BGP"
+	type = "DIRECT"
 	name = "fabric_tf_acc_test_rpDirect"
-	customer_asn = "100"
 }`, name, portUuid, ip4, ip6)
 }
 

--- a/equinix/resource_fabric_routing_protocol_acc_test.go
+++ b/equinix/resource_fabric_routing_protocol_acc_test.go
@@ -16,7 +16,9 @@ import (
 
 func TestAccFabricCreateDirectRoutingProtocol_PFCR_A(t *testing.T) {
 	ports := GetFabricEnvPorts(t)
+
 	var portUuid string
+
 	if len(ports) > 0 {
 		portUuid = ports["pfcr"]["dot1q"][1].Uuid
 	}
@@ -27,15 +29,28 @@ func TestAccFabricCreateDirectRoutingProtocol_PFCR_A(t *testing.T) {
 		CheckDestroy: checkRoutingProtocolDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFabricCreateRoutingProtocolConfig("fcr_test_PFCR", portUuid, "190.1.1.1/30", "190::1:1/126"),
-				//Config: testAccFabricCreateRoutingProtocolConfig("fcr_test_PFCR", portUuid),
+				Config: testAccFabricCreateRoutingProtocolConfig("fcr_test_PFCR", portUuid),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemAttr("equinix_fabric_routing_protocol.test", "anything.*", "Anything"),
-					//resource.TestCheckResourceAttr(
-					//	"equinix_fabric_connection.test", "name", "fcr_test_PFCR"),
-					//resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "direct_ipv4.*", map[string]string{
-					//	"equinix_iface_ip": fmt.Sprintf("190.1.1.1/30"),
-					//}),
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.direct", "uuid"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "type", "DIRECT"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "state", "PROVISIONED"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.direct", "change.0.uuid"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "change.0.type", "ROUTING_PROTOCOL_CREATION"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "direct_ipv4.0.equinix_iface_ip", "190.1.1.1/30"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "direct_ipv6.0.equinix_iface_ip", "190::1:1/126"),
+
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.bgp", "uuid"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "type", "BGP"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "state", "PROVISIONED"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.bgp", "change.0.uuid"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "change.0.type", "ROUTING_PROTOCOL_CREATION"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv4.0.customerPeerIp", "190.1.1.2"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv4.0.equinixPeerIp", "190.1.1.1"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv4.0.enabled", "true"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv6.0.customerPeerIp", "190::1:2"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv6.0.equinixPeerIp", "190::1:1"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv6.0.enabled", "true"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "customerAsn", "100"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -43,77 +58,7 @@ func TestAccFabricCreateDirectRoutingProtocol_PFCR_A(t *testing.T) {
 	})
 }
 
-//func testAccFabricCreateRoutingProtocolConfig(name, portUuid string) string {
-//	return fmt.Sprintf(`
-//
-//resource "equinix_fabric_cloud_router" "this" {
-//	type = "XF_ROUTER"
-//	name = "Test_PFCR"
-//	location{
-//		metro_code  = "SV"
-//	}
-//	order{
-//		purchase_order_number = "1-234567"
-//	}
-//	notifications{
-//		type = "ALL"
-//		emails = ["test@equinix.com", "test1@equinix.com"]
-//	}
-//	project{
-//		project_id = "291639000636552"
-//	}
-//	account {
-//		account_number = 201257
-//	}
-//	package {
-//		code = "STANDARD"
-//	}
-//}
-//
-//resource "equinix_fabric_connection" "test" {
-//	type = "IP_VC"
-//	name = "%s"
-//	notifications{
-//		type = "ALL"
-//		emails = ["test@equinix.com","test1@equinix.com"]
-//	}
-//	order {
-//		purchase_order_number = "123485"
-//	}
-//	bandwidth = 50
-//	redundancy {
-//		priority= "PRIMARY"
-//	}
-//	a_side {
-//		access_point {
-//			type = "CLOUD_ROUTER"
-//			router {
-//				uuid = equinix_fabric_cloud_router.this.id
-//			}
-//		}
-//	}
-//	project{
-//		project_id = "291639000636552"
-//	}
-//	z_side {
-//		access_point {
-//			type = "COLO"
-//			port{
-//				uuid = "%s"
-//			}
-//			link_protocol {
-//				type= "DOT1Q"
-//				vlan_tag= 2325
-//			}
-//			location {
-//				metro_code = "SV"
-//			}
-//		}
-//	}
-//}`, name, portUuid)
-//}
-
-func testAccFabricCreateRoutingProtocolConfig(name, portUuid, ip4, ip6 string) string {
+func testAccFabricCreateRoutingProtocolConfig(name, portUuid string) string {
 	return fmt.Sprintf(`
 
 resource "equinix_fabric_cloud_router" "this" {
@@ -173,7 +118,7 @@ resource "equinix_fabric_connection" "this" {
 			}
 			link_protocol {
 				type= "DOT1Q"
-				vlan_tag= 2334
+				vlan_tag= 2152
 			}
 			location {
 				metro_code = "SV"
@@ -182,120 +127,33 @@ resource "equinix_fabric_connection" "this" {
 	}
 }
 
-resource "equinix_fabric_routing_protocol" "this" {
+resource "equinix_fabric_routing_protocol" "direct" {
 	connection_uuid = equinix_fabric_connection.this.id
 	direct_ipv4{
-		equinix_iface_ip = "%s"
+		equinix_iface_ip = "190.1.1.1/30"
 	}
 	direct_ipv6{
-		equinix_iface_ip = "%s"
+		equinix_iface_ip = "190::1:1/126"
 	}
 	type = "DIRECT"
 	name = "fabric_tf_acc_test_rpDirect"
-}`, name, portUuid, ip4, ip6)
 }
 
-//resource "equinix_fabric_routing_protocol" "test" {
-//connection_uuid = "equinix_fabric_connection.this.uuid"
-//type = "BGP"
-//bgp_ipv4{
-//customer_peer_ip = "%s"
-//}
-//bgp_ipv6{
-//customer_peer_ip = "%s"
-//}
-//customer_asn = "100"
-//}
-//
-//data "equinix_fabric_routing_protocol" "test" {
-//	connection_uuid = equinix_fabric_routing_protocol.test.uuid
-//}`, name, portUuid, ip4, ip6)
-//}
-
-//func TestAccFabricCreateDirectRoutingProtocol(t *testing.T) {
-//	resource.ParallelTest(t, resource.TestCase{
-//		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-//		Providers:    acceptance.TestAccProviders,
-//		CheckDestroy: checkRoutingProtocolDelete,
-//		Steps: []resource.TestStep{
-//			{
-//				Config: testAccFabricCreateRoutingProtocolDirectConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.1/30", "172::1:1/126"),
-//				Check: resource.ComposeTestCheckFunc(
-//					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "direct_ipv4.*", map[string]string{
-//						"equinix_iface_ip": fmt.Sprintf("190.1.1.1/30"),
-//					}),
-//				),
-//				ExpectNonEmptyPlan: true,
-//			}, {
-//				Config: testAccFabricCreateRoutingProtocolDirectConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.1/26", "172::1:1/126"),
-//				Check: resource.ComposeTestCheckFunc(
-//					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "direct_ipv4.*", map[string]string{
-//						"equinix_iface_ip": fmt.Sprintf("190.1.1.1/26"),
-//					}),
-//				),
-//				ExpectNonEmptyPlan: true,
-//			},
-//		},
-//	})
-//}
-
-//func testAccFabricCreateRoutingProtocolDirectConfig(connectionUuid string, ipv4 string, ipv6 string) string {
-//	return fmt.Sprintf(`	resource "equinix_fabric_routing_protocol" "test" {
-//		connection_uuid = "%s"
-//
-//		type = "DIRECT"
-//		name = "fabric_tf_acc_test_rpDirect"
-//		direct_ipv4{
-//			equinix_iface_ip = "%s"
-//		}
-//		direct_ipv6{
-//			equinix_iface_ip = "%s"
-//		}
-//	}`, connectionUuid, ipv4, ipv6)
-//}
-//
-//func TestAccFabricCreateBgpRoutingProtocol(t *testing.T) {
-//	resource.ParallelTest(t, resource.TestCase{
-//		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-//		Providers:    acceptance.TestAccProviders,
-//		CheckDestroy: checkRoutingProtocolDelete,
-//		Steps: []resource.TestStep{
-//			{
-//				Config: testAccFabricCreateRoutingProtocolBgpConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.2", ""),
-//				Check: resource.ComposeTestCheckFunc(
-//					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "bgp_ipv4.*", map[string]string{
-//						"customer_peer_ip": fmt.Sprintf("190.1.1.2"),
-//					}),
-//				),
-//				ExpectNonEmptyPlan: true,
-//			},
-//			{
-//				Config: testAccFabricCreateRoutingProtocolBgpConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "190.1.1.3", "172::1:2"),
-//				Check: resource.ComposeTestCheckFunc(
-//					resource.TestCheckTypeSetElemNestedAttrs("equinix_fabric_routing_protocol.test", "bgp_ipv4.*", map[string]string{
-//						"customer_peer_ip": fmt.Sprintf("190.1.1.3"),
-//					}),
-//				),
-//				ExpectNonEmptyPlan: true,
-//			},
-//		},
-//	})
-//}
-
-//func testAccFabricCreateRoutingProtocolBgpConfig(connectionUuid string, ipv4 string, ipv6 string) string {
-//	return fmt.Sprintf(`	resource "equinix_fabric_routing_protocol" "test" {
-//		connection_uuid = "%s"
-//
-//		type = "BGP"
-//		bgp_ipv4{
-//			customer_peer_ip = "%s"
-//		}
-//		bgp_ipv6{
-//			customer_peer_ip = "%s"
-//		}
-//		customer_asn = "100"
-//	}`, connectionUuid, ipv4, ipv6)
-//}
+resource "equinix_fabric_routing_protocol" "bgp" {
+	depends_on = [
+    equinix_fabric_routing_protocol.direct
+  	]
+	connection_uuid = equinix_fabric_connection.this.id
+	bgp_ipv4{
+		customer_peer_ip = "190.1.1.2"
+	}
+	bgp_ipv6{
+		customer_peer_ip = "190::1:2"
+	}
+	type = "BGP"
+	customer_asn = "100"
+}`, name, portUuid)
+}
 
 func checkRoutingProtocolDelete(s *terraform.State) error {
 	ctx := context.Background()

--- a/equinix/resource_fabric_routing_protocol_acc_test.go
+++ b/equinix/resource_fabric_routing_protocol_acc_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+// Note:
+// Keeping data "equinix_fabric_routing_protocol" tests in this file
+// due to the long setup times required for RP tests.
+// The FCR, Connection and RPs will already be created in the resource test, so the
+// data_source tests will just leverage the RPs there to retrieve the data and check results
+
 func TestAccFabricCreateDirectRoutingProtocol_PFCR_A(t *testing.T) {
 	ports := GetFabricEnvPorts(t)
 
@@ -29,9 +35,9 @@ func TestAccFabricCreateDirectRoutingProtocol_PFCR_A(t *testing.T) {
 		CheckDestroy: checkRoutingProtocolDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFabricCreateRoutingProtocolConfig("fcr_test_PFCR", portUuid),
+				Config: testAccFabricCreateRoutingProtocolConfig("RP_Conn_Test_PFCR", portUuid),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.direct", "uuid"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.direct", "id"),
 					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "type", "DIRECT"),
 					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "state", "PROVISIONED"),
 					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.direct", "change.0.uuid"),
@@ -39,18 +45,39 @@ func TestAccFabricCreateDirectRoutingProtocol_PFCR_A(t *testing.T) {
 					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "direct_ipv4.0.equinix_iface_ip", "190.1.1.1/30"),
 					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.direct", "direct_ipv6.0.equinix_iface_ip", "190::1:1/126"),
 
-					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.bgp", "uuid"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.bgp", "id"),
 					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "type", "BGP"),
 					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "state", "PROVISIONED"),
 					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.bgp", "change.0.uuid"),
 					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "change.0.type", "ROUTING_PROTOCOL_CREATION"),
-					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv4.0.customerPeerIp", "190.1.1.2"),
-					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv4.0.equinixPeerIp", "190.1.1.1"),
-					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv4.0.enabled", "true"),
-					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv6.0.customerPeerIp", "190::1:2"),
-					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv6.0.equinixPeerIp", "190::1:1"),
-					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgpIpv6.0.enabled", "true"),
-					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "customerAsn", "100"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.customer_peer_ip", "190.1.1.2"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.equinix_peer_ip", "190.1.1.1"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.enabled", "true"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.customer_peer_ip", "190::1:2"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.equinix_peer_ip", "190::1:1"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.enabled", "true"),
+					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "customer_asn", "100"),
+
+					resource.TestCheckResourceAttrSet("data.equinix_fabric_routing_protocol.direct", "id"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "type", "DIRECT"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "state", "PROVISIONED"),
+					resource.TestCheckResourceAttrSet("data.equinix_fabric_routing_protocol.direct", "change.0.uuid"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "change.0.type", "ROUTING_PROTOCOL_CREATION"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "direct_ipv4.0.equinix_iface_ip", "190.1.1.1/30"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "direct_ipv6.0.equinix_iface_ip", "190::1:1/126"),
+
+					resource.TestCheckResourceAttrSet("data.equinix_fabric_routing_protocol.bgp", "id"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "type", "BGP"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "state", "PROVISIONED"),
+					resource.TestCheckResourceAttrSet("data.equinix_fabric_routing_protocol.bgp", "change.0.uuid"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "change.0.type", "ROUTING_PROTOCOL_CREATION"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.customer_peer_ip", "190.1.1.2"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.equinix_peer_ip", "190.1.1.1"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv4.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.customer_peer_ip", "190::1:2"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.equinix_peer_ip", "190::1:1"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.enabled", "true"),
+					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "customer_asn", "100"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -63,7 +90,7 @@ func testAccFabricCreateRoutingProtocolConfig(name, portUuid string) string {
 
 resource "equinix_fabric_cloud_router" "this" {
 	type = "XF_ROUTER"
-	name = "Test_PFCR"
+	name = "RP_Test_PFCR"
 	location{
 		metro_code  = "SV"
 	}
@@ -129,30 +156,43 @@ resource "equinix_fabric_connection" "this" {
 
 resource "equinix_fabric_routing_protocol" "direct" {
 	connection_uuid = equinix_fabric_connection.this.id
+	type = "DIRECT"
+	name = "rp_direct_PFCR"
 	direct_ipv4{
 		equinix_iface_ip = "190.1.1.1/30"
 	}
 	direct_ipv6{
 		equinix_iface_ip = "190::1:1/126"
 	}
-	type = "DIRECT"
-	name = "fabric_tf_acc_test_rpDirect"
 }
 
 resource "equinix_fabric_routing_protocol" "bgp" {
 	depends_on = [
-    equinix_fabric_routing_protocol.direct
+      equinix_fabric_routing_protocol.direct
   	]
 	connection_uuid = equinix_fabric_connection.this.id
+	type = "BGP"
+	name = "rp_bgp_PFCR"
 	bgp_ipv4{
 		customer_peer_ip = "190.1.1.2"
 	}
 	bgp_ipv6{
 		customer_peer_ip = "190::1:2"
 	}
-	type = "BGP"
 	customer_asn = "100"
-}`, name, portUuid)
+}
+
+data "equinix_fabric_routing_protocol" "direct" {
+	connection_uuid = equinix_fabric_connection.this.id
+	uuid = equinix_fabric_routing_protocol.direct.id
+}
+
+data "equinix_fabric_routing_protocol" "bgp" {
+	connection_uuid = equinix_fabric_connection.this.id
+	uuid = equinix_fabric_routing_protocol.bgp.id
+}
+
+`, name, portUuid)
 }
 
 func checkRoutingProtocolDelete(s *terraform.State) error {
@@ -169,28 +209,3 @@ func checkRoutingProtocolDelete(s *terraform.State) error {
 	}
 	return nil
 }
-
-//func TestAccFabricReadRoutingProtocolByUuid(t *testing.T) {
-//	resource.ParallelTest(t, resource.TestCase{
-//		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
-//		Providers: acceptance.TestAccProviders,
-//		Steps: []resource.TestStep{
-//			{
-//				Config: testAccFabricReadRoutingProtocolConfig("99d6bdc8-206f-4bff-a899-0dba708c03db", "00f48313-ab13-4524-aaad-93c31b5b8848"),
-//				Check: resource.ComposeTestCheckFunc(
-//					resource.TestCheckResourceAttr(
-//						"equinix_fabric_routing_protocol.test", "type", fmt.Sprint("DIRECT")),
-//					resource.TestCheckResourceAttr(
-//						"equinix_fabric_routing_protocol.test", "state", fmt.Sprint("PROVISIONED")),
-//				),
-//			},
-//		},
-//	})
-//}
-//
-//func testAccFabricReadRoutingProtocolConfig(connectionUuid string, routingProtocolUuid string) string {
-//	return fmt.Sprintf(`data "equinix_fabric_routing_protocol" "test" {
-//	connection_uuid = "%s"
-//	uuid = "%s"
-//	}`, connectionUuid, routingProtocolUuid)
-//}


### PR DESCRIPTION
* Added acceptance test for routing protocol resource
* Data source tests for routing protocol resource included in resource file because of test setup
* Test setup creates an FCR, and a Connection on that FCR
* Config applies the Direct and BGP routing protocols to the created FCR connection
* Data_Source config retrieves the RPs created in the config
* Test assertions are performed on both the resource and data sources in the same test.
* Go test timeout must be >15m for it to work successfully