### PR TITLE
chore: fix module path used to determine terraform plugin SDK version

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -373,7 +373,7 @@ func generateModuleUserAgentString(d *schema.ResourceData, baseUserAgent string)
 }
 
 func (c *Config) tfSdkUserAgent(suffix string) string {
-	sdkModulePath := "github.com/hashicorp/terraform-plugin-sdk"
+	sdkModulePath := "github.com/hashicorp/terraform-plugin-sdk/v2"
 	baseUserAgent := fmt.Sprintf("HashiCorp Terraform/%s (+https://www.terraform.io) Terraform Plugin SDK/%s",
 		c.TerraformVersion, moduleVersionFromBuild(sdkModulePath))
 	baseUserAgent = appendUserAgentFromEnv(baseUserAgent)


### PR DESCRIPTION
A recent change to differentiate terraform-plugin-sdk traffic from terraform-plugin-framework traffic used the wrong Go module path for the SDK.  This fixes it so we can accurately track plugin-sdk version usage.