### PR TITLE
fix: maintain provider context in resources and datasources

### DIFF
--- a/equinix/data_source_metal_devices.go
+++ b/equinix/data_source_metal_devices.go
@@ -51,7 +51,7 @@ func dataSourceMetalDevices() *schema.Resource {
 	return datalist.NewResource(dataListConfig)
 }
 
-func getDevices(d *schema.ResourceData, meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
+func getDevices(ctx context.Context, d *schema.ResourceData, meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	client := meta.(*config.Config).NewMetalClientForSDK(d)
 	projectID := extra["project_id"].(string)
 	orgID := extra["organization_id"].(string)
@@ -68,7 +68,7 @@ func getDevices(d *schema.ResourceData, meta interface{}, extra map[string]inter
 
 	if len(projectID) > 0 {
 		query := client.DevicesApi.FindProjectDevices(
-			context.Background(), projectID).Include(deviceCommonIncludes)
+			ctx, projectID).Include(deviceCommonIncludes)
 		if len(search) > 0 {
 			query = query.Search(search)
 		}
@@ -77,7 +77,7 @@ func getDevices(d *schema.ResourceData, meta interface{}, extra map[string]inter
 
 	if len(orgID) > 0 {
 		query := client.DevicesApi.FindOrganizationDevices(
-			context.Background(), orgID).Include(deviceCommonIncludes)
+			ctx, orgID).Include(deviceCommonIncludes)
 		if len(search) > 0 {
 			query = query.Search(search)
 		}

--- a/equinix/data_source_metal_plans.go
+++ b/equinix/data_source_metal_plans.go
@@ -1,6 +1,7 @@
 package equinix
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/equinix/terraform-provider-equinix/internal/converters"
@@ -24,7 +25,7 @@ func dataSourceMetalPlans() *schema.Resource {
 	return datalist.NewResource(dataListConfig)
 }
 
-func getPlans(_ *schema.ResourceData, meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
+func getPlans(_ context.Context, _ *schema.ResourceData, meta interface{}, extra map[string]interface{}) ([]interface{}, error) {
 	client := meta.(*config.Config).Metal
 	opts := &packngo.ListOptions{
 		Includes: []string{"available_in", "available_in_metros"},

--- a/equinix/helpers_device.go
+++ b/equinix/helpers_device.go
@@ -110,9 +110,9 @@ func getPorts(ps []metalv1.Port) []map[string]interface{} {
 	return ret
 }
 
-func hwReservationStateRefreshFunc(client *metalv1.APIClient, reservationId, instanceId string) retry.StateRefreshFunc {
+func hwReservationStateRefreshFunc(ctx context.Context, client *metalv1.APIClient, reservationId, instanceId string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		r, _, err := client.HardwareReservationsApi.FindHardwareReservationById(context.TODO(), reservationId).Include([]string{"device"}).Execute()
+		r, _, err := client.HardwareReservationsApi.FindHardwareReservationById(ctx, reservationId).Include([]string{"device"}).Execute()
 		state := deprovisioning
 		switch {
 		case err != nil:
@@ -135,7 +135,7 @@ func waitUntilReservationProvisionable(ctx context.Context, client *metalv1.APIC
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{deprovisioning},
 		Target:     []string{provisionable, reprovisioned},
-		Refresh:    hwReservationStateRefreshFunc(client, reservationId, instanceId),
+		Refresh:    hwReservationStateRefreshFunc(ctx, client, reservationId, instanceId),
 		Timeout:    timeout,
 		Delay:      delay,
 		MinTimeout: minTimeout,

--- a/equinix/resource_metal_device.go
+++ b/equinix/resource_metal_device.go
@@ -570,7 +570,7 @@ func resourceMetalDeviceCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).NewMetalClientForSDK(d)
 
-	device, resp, err := client.DevicesApi.FindDeviceById(context.Background(), d.Id()).Include(deviceCommonIncludes).Execute()
+	device, resp, err := client.DevicesApi.FindDeviceById(ctx, d.Id()).Include(deviceCommonIncludes).Execute()
 	if err != nil {
 		err = equinix_errors.FriendlyErrorForMetalGo(err, resp)
 

--- a/internal/datalist/schema.go
+++ b/internal/datalist/schema.go
@@ -29,7 +29,7 @@ type ResourceConfig struct {
 	// Return all of the records on which the data list resource should operate.
 	// The `meta` argument is the same meta argument passed into the resource's Read
 	// function.
-	GetRecords func(d *schema.ResourceData, meta interface{}, extra map[string]interface{}) ([]interface{}, error)
+	GetRecords func(ctx context.Context, d *schema.ResourceData, meta interface{}, extra map[string]interface{}) ([]interface{}, error)
 
 	// Extra parameters to expose on the datasource alongside `filter` and `sort`.
 	ExtraQuerySchema map[string]*schema.Schema
@@ -89,7 +89,7 @@ func dataListResourceRead(config *ResourceConfig) schema.ReadContextFunc {
 			extra[attr] = d.Get(attr)
 		}
 
-		records, err := config.GetRecords(d, meta, extra)
+		records, err := config.GetRecords(ctx, d, meta, extra)
 		if err != nil {
 			return diag.Errorf("Unable to load records: %s", err)
 		}

--- a/internal/resources/metal/project_ssh_key/datasource.go
+++ b/internal/resources/metal/project_ssh_key/datasource.go
@@ -49,7 +49,7 @@ func (r *DataSource) Read(
 	)
 
 	// Use API client to list SSH keys
-	keysList, _, err := client.SSHKeysApi.FindProjectSSHKeys(context.Background(), projectID).Query(search).Execute()
+	keysList, _, err := client.SSHKeysApi.FindProjectSSHKeys(ctx, projectID).Query(search).Execute()
 	if err != nil {
 		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(

--- a/internal/resources/metal/project_ssh_key/resource.go
+++ b/internal/resources/metal/project_ssh_key/resource.go
@@ -49,7 +49,7 @@ func (r *Resource) Create(
 	projectId := plan.ProjectID.ValueString()
 
 	// Create API resource
-	key, _, err := client.SSHKeysApi.CreateProjectSSHKey(context.Background(), projectId).SSHKeyCreateInput(*createRequest).Execute()
+	key, _, err := client.SSHKeysApi.CreateProjectSSHKey(ctx, projectId).SSHKeyCreateInput(*createRequest).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to create Project SSH Key",
@@ -86,7 +86,7 @@ func (r *Resource) Read(
 	id := state.ID.ValueString()
 
 	// Use API client to get the current state of the resource
-	key, _, err := client.SSHKeysApi.FindSSHKeyById(context.Background(), id).Include(nil).Execute()
+	key, _, err := client.SSHKeysApi.FindSSHKeyById(ctx, id).Include(nil).Execute()
 	if err != nil {
 		err = equinix_errors.FriendlyError(err)
 
@@ -143,7 +143,7 @@ func (r *Resource) Update(
 	}
 
 	// Update the resource
-	key, _, err := client.SSHKeysApi.UpdateSSHKey(context.Background(), id).SSHKeyInput(*updateRequest).Execute()
+	key, _, err := client.SSHKeysApi.UpdateSSHKey(ctx, id).SSHKeyInput(*updateRequest).Execute()
 	if err != nil {
 		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
@@ -181,7 +181,7 @@ func (r *Resource) Delete(
 	id := state.ID.ValueString()
 
 	// Use API client to delete the resource
-	deleteResp, err := client.SSHKeysApi.DeleteSSHKey(context.Background(), id).Execute()
+	deleteResp, err := client.SSHKeysApi.DeleteSSHKey(ctx, id).Execute()
 	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(deleteResp, err) != nil {
 		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(

--- a/internal/resources/metal/ssh_key/resource.go
+++ b/internal/resources/metal/ssh_key/resource.go
@@ -47,7 +47,7 @@ func (r *Resource) Create(
 	}
 
 	// Create API resource
-	key, _, err := client.SSHKeysApi.CreateSSHKey(context.Background()).SSHKeyCreateInput(*createRequest).Execute()
+	key, _, err := client.SSHKeysApi.CreateSSHKey(ctx).SSHKeyCreateInput(*createRequest).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to create SSH Key",
@@ -84,7 +84,7 @@ func (r *Resource) Read(
 	id := state.ID.ValueString()
 
 	// Use API client to get the current state of the resource
-	key, _, err := client.SSHKeysApi.FindSSHKeyById(context.Background(), id).Include(nil).Execute()
+	key, _, err := client.SSHKeysApi.FindSSHKeyById(ctx, id).Include(nil).Execute()
 	if err != nil {
 		err = equinix_errors.FriendlyError(err)
 
@@ -141,7 +141,7 @@ func (r *Resource) Update(
 	}
 
 	// Update the resource
-	key, _, err := client.SSHKeysApi.UpdateSSHKey(context.Background(), id).SSHKeyInput(*updateRequest).Execute()
+	key, _, err := client.SSHKeysApi.UpdateSSHKey(ctx, id).SSHKeyInput(*updateRequest).Execute()
 	if err != nil {
 		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
@@ -179,7 +179,7 @@ func (r *Resource) Delete(
 	id := state.ID.ValueString()
 
 	// Use API client to delete the resource
-	deleteResp, err := client.SSHKeysApi.DeleteSSHKey(context.Background(), id).Execute()
+	deleteResp, err := client.SSHKeysApi.DeleteSSHKey(ctx, id).Execute()
 	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(deleteResp, err) != nil {
 		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
We recently introduced equinix-sdk-go as a context-aware replacement SDK for packngo and _also_ migrated some resources and datasources to use context-aware CRUD lifecycle methods.  In those parallel changes we missed some opportunities to pass the terraform provider context into the SDK.

This updates the provider to replace all non-testing usage of `context.TODO()` and  `context.Background()` with references to the pre-existing terraform provider context.

Relates to #539 