### PR TITLE
chore(ci): skip shared connections when sweeping virtual circuits

### DIFF
--- a/equinix/resource_metal_virtual_circuit_acc_test.go
+++ b/equinix/resource_metal_virtual_circuit_acc_test.go
@@ -44,10 +44,12 @@ func testSweepVirtualCircuits(region string) error {
 			return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting connections list for sweeping VirtualCircuits: %s", err)
 		}
 		for _, conn := range conns {
-			for _, port := range conn.Ports {
-				for _, vc := range port.VirtualCircuits {
-					if isSweepableTestResource(vc.Name) {
-						vcs[vc.ID] = &vc
+			if conn.Type != packngo.ConnectionShared {
+				for _, port := range conn.Ports {
+					for _, vc := range port.VirtualCircuits {
+						if isSweepableTestResource(vc.Name) {
+							vcs[vc.ID] = &vc
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The sweeper step of our end-to-end test workflow sometimes fails because it finds & attempts to delete virtual circuits that belong to shared interconnections.  The API blocks deletion of these circuits because they are API-managed, not user-managed, and can only be deleted by deleting the interconnection itself.  This adds a check to the virtual circuit sweeper so that the sweeper will ignore virtual circuits that belong to shared interconnections.