### PR TITLE
chore(ci): update test provider wiring for missed acceptance tests

### DIFF
--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -24,7 +24,6 @@ import (
 
 var (
 	testAccProviders         map[string]*schema.Provider
-	testAccProviderFactories map[string]func() (*schema.Provider, error)
 	testAccProvider          *schema.Provider
 	testExternalProviders    map[string]resource.ExternalProvider
 	testAccFrameworkProvider *provider.FrameworkProvider
@@ -128,11 +127,6 @@ func init() {
 	testAccProvider = Provider()
 	testAccProviders = map[string]*schema.Provider{
 		"equinix": testAccProvider,
-	}
-	testAccProviderFactories = map[string]func() (*schema.Provider, error){
-		"equinix": func() (*schema.Provider, error) {
-			return testAccProvider, nil
-		},
 	}
 	testExternalProviders = map[string]resource.ExternalProvider{
 		"random": {

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -1117,10 +1117,10 @@ func TestAccMetalDeviceCreate_timeout(t *testing.T) {
 	project := "equinix_metal_project.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalDeviceCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccMetalDeviceConfig_timeout(rs, "10s", "", ""),
@@ -1149,10 +1149,10 @@ func TestAccMetalDeviceUpdate_timeout(t *testing.T) {
 	r := "equinix_metal_device.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalDeviceCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalDeviceConfig_timeout(rs, "", "", ""),
@@ -1174,10 +1174,10 @@ func TestAccMetalDevice_LockingAndUnlocking(t *testing.T) {
 	r := "equinix_metal_device.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalDeviceCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalDeviceConfig_lockable(rs, true),

--- a/equinix/resource_metal_port_acc_test.go
+++ b/equinix/resource_metal_port_acc_test.go
@@ -237,10 +237,10 @@ resource "equinix_metal_vlan" "test" {
 func TestAccMetalPort_hybridBondedVxlan(t *testing.T) {
 	rs := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalPortDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalPortDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: confAccMetalPort_HybridBondedVxlan(rs),
@@ -266,10 +266,10 @@ func TestAccMetalPort_hybridBondedVxlan(t *testing.T) {
 func TestAccMetalPort_L2IndividualNativeVlan(t *testing.T) {
 	rs := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalPortDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalPortDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: confAccMetalPort_L2IndividualNativeVlan(rs),
@@ -299,10 +299,10 @@ func TestAccMetalPort_L2IndividualNativeVlan(t *testing.T) {
 func testAccMetalPortTemplate(t *testing.T, conf func(string) string, expectedType string) {
 	rs := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalPortDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalPortDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: conf(rs),
@@ -422,10 +422,10 @@ func TestAccMetalPortCreate_hybridBonded_timeout(t *testing.T) {
 	deviceName := "equinix_metal_device.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalPortDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalPortDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config:      confAccMetalPort_HybridBonded_timeout(rInt, rs, "5s", ""),
@@ -463,10 +463,10 @@ func TestAccMetalPortUpdate_hybridBonded_timeout(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalPortDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalPortDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: confAccMetalPort_HybridBonded_timeout(rInt, rs, "", "5s"),

--- a/equinix/resource_metal_reserved_ip_block_acc_test.go
+++ b/equinix/resource_metal_reserved_ip_block_acc_test.go
@@ -85,10 +85,10 @@ func TestAccMetalReservedIPBlock_global(t *testing.T) {
 	rs := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalReservedIPBlockCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalReservedIPBlockCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalReservedIPBlockConfig_global(rs),
@@ -117,10 +117,10 @@ func TestAccMetalReservedIPBlock_public(t *testing.T) {
 	rs := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalReservedIPBlockCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalReservedIPBlockCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalReservedIPBlockConfig_public(rs, ""),
@@ -152,10 +152,10 @@ func TestAccMetalReservedIPBlock_metro(t *testing.T) {
 	tag := "tag"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalReservedIPBlockCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalReservedIPBlockCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalReservedIPBlockConfig_metro(rs, tag),
@@ -191,10 +191,10 @@ func TestAccMetalReservedIPBlock_importBasic(t *testing.T) {
 	rs := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalReservedIPBlockCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalReservedIPBlockCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalReservedIPBlockConfig_public(rs, ""),
@@ -241,10 +241,10 @@ resource "equinix_metal_reserved_ip_block" "test" {
 
 func TestAccMetalReservedIPBlock_facilityToMetro(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalReservedIPBlockCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalReservedIPBlockCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalReservedIPBlockConfig_facilityToMetro(`   facility = "ny5"`),
@@ -306,10 +306,10 @@ func TestAccMetalReservedIPBlock_device(t *testing.T) {
 	rs := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalReservedIPBlockCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalReservedIPBlockCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalReservedIP_device(rs),
@@ -328,10 +328,10 @@ func TestAccMetalReservedIPBlockCreate_public_timeout(t *testing.T) {
 	rs := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalReservedIPBlockCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalReservedIPBlockCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccMetalReservedIPBlockConfig_public(rs, "2s"),

--- a/equinix/resource_metal_spot_market_request_acc_test.go
+++ b/equinix/resource_metal_spot_market_request_acc_test.go
@@ -22,11 +22,11 @@ func TestAccMetalSpotMarketRequest_basic(t *testing.T) {
 	projSuffix := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalSpotMarketRequestCheckDestroyed,
-		ErrorCheck:        skipIfOverbidOrTimedOut(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalSpotMarketRequestCheckDestroyed,
+		ErrorCheck:               skipIfOverbidOrTimedOut(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalSpotMarketRequestConfig_basic(projSuffix),
@@ -150,11 +150,11 @@ func TestAccMetalSpotMarketRequest_Import(t *testing.T) {
 	projSuffix := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalSpotMarketRequestCheckDestroyed,
-		ErrorCheck:        skipIfOverbidOrTimedOut(t),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalSpotMarketRequestCheckDestroyed,
+		ErrorCheck:               skipIfOverbidOrTimedOut(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckMetalSpotMarketRequestConfig_import(projSuffix),
@@ -243,10 +243,10 @@ func TestAccMetalSpotMarketRequestCreate_WithTimeout(t *testing.T) {
 	projSuffix := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ExternalProviders: testExternalProviders,
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccMetalSpotMarketRequestCheckDestroyed,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ExternalProviders:        testExternalProviders,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalSpotMarketRequestCheckDestroyed,
 		ErrorCheck: func(err error) error {
 			if matchErrOverbid.MatchString(err.Error()) {
 				t.Skipf("price was higher than max allowed bid; skipping")

--- a/internal/acceptance/acceptance.go
+++ b/internal/acceptance/acceptance.go
@@ -25,7 +25,6 @@ const (
 var (
 	TestAccProvider          *schema.Provider
 	TestAccProviders         map[string]*schema.Provider
-	TestAccProviderFactories map[string]func() (*schema.Provider, error)
 	TestExternalProviders    map[string]resource.ExternalProvider
 	TestAccFrameworkProvider *provider.FrameworkProvider
 )
@@ -34,11 +33,6 @@ func init() {
 	TestAccProvider = equinix.Provider()
 	TestAccProviders = map[string]*schema.Provider{
 		"equinix": TestAccProvider,
-	}
-	TestAccProviderFactories = map[string]func() (*schema.Provider, error){
-		"equinix": func() (*schema.Provider, error) {
-			return TestAccProvider, nil
-		},
 	}
 	TestExternalProviders = map[string]resource.ExternalProvider{
 		"random": {

--- a/internal/resources/metal/project/datasource_test.go
+++ b/internal/resources/metal/project/datasource_test.go
@@ -15,10 +15,10 @@ func TestAccDataSourceMetalProject_byId(t *testing.T) {
 	rn := acctest.RandStringFromCharSet(12, "abcdef0123456789")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalProjectCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalProjectCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalProject_byId(rn),
@@ -69,10 +69,10 @@ func TestAccDataSourceMetalProject_byName(t *testing.T) {
 	rn := acctest.RandStringFromCharSet(12, "abcdef0123456789")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalProjectCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalProjectCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalProject_byName(rn),

--- a/internal/resources/metal/project/resource_test.go
+++ b/internal/resources/metal/project/resource_test.go
@@ -61,10 +61,10 @@ func TestAccMetalProject_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalProjectCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalProjectCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalProjectConfig_basic(rInt),
@@ -151,10 +151,10 @@ func TestAccMetalProject_BGPBasic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalProjectCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalProjectCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalProjectConfig_BGP(rInt, "2SFsdfsg43"),
@@ -179,10 +179,10 @@ func TestAccMetalProject_backendTransferUpdate(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalProjectCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalProjectCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalProjectConfig_basic(rInt),
@@ -222,10 +222,10 @@ func TestAccMetalProject_update(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalProjectCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalProjectCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalProjectConfig_basic(rInt),
@@ -262,10 +262,10 @@ func TestAccMetalProject_BGPUpdate(t *testing.T) {
 	res := "equinix_metal_project.foobar"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalProjectCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalProjectCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalProjectConfig_basic(rInt),
@@ -395,10 +395,10 @@ func TestAccMetalProject_organization(t *testing.T) {
 	rn := acctest.RandStringFromCharSet(12, "abcdef0123456789")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalProjectCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalProjectCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalProjectConfig_organization(rn),
@@ -421,10 +421,10 @@ func TestAccMetalProject_importBasic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalProjectCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalProjectCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalProjectConfig_basic(rInt),

--- a/internal/resources/metal/vrf/resource_test.go
+++ b/internal/resources/metal/vrf/resource_test.go
@@ -79,10 +79,10 @@ func TestAccMetalVRF_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheckMetal(t) },
-		ExternalProviders: acceptance.TestExternalProviders,
-		Providers:         acceptance.TestAccProviders,
-		CheckDestroy:      testAccMetalVRFCheckDestroyed,
+		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetalVRFConfig_basic(rInt),


### PR DESCRIPTION
A previous PR (#586) updated "all" Metal resource & datasource acceptance tests to use ProtoV5ProviderFactories instead of Provider so that we don't need to update unrelated tests whenever we migrate a resource from the SDK provider to the framework provider.

That PR missed a couple resources that are already in the `internal/` directory but aren't migrated to framework yet; this one updates the tests that were missed.