### PR TITLE
feat!: upgrade to tfprotov6

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository is [Maintained](https://github.com/equinix-labs/equinix-labs/blo
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) 0.12+
+- [Terraform](https://www.terraform.io/downloads.html) 1.0.0+
 
 ## Using the provider
 

--- a/equinix/data_source_metal_device_acc_test.go
+++ b/equinix/data_source_metal_device_acc_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceMetalDevice_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -68,7 +68,7 @@ func TestAccDataSourceMetalDevice_byID(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/data_source_metal_device_bgp_neighbors_acc_test.go
+++ b/equinix/data_source_metal_device_bgp_neighbors_acc_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceMetalDeviceBgpNeighbors(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalDeviceBgpNeighborsConfig(projectName),

--- a/equinix/data_source_metal_devices_acc_test.go
+++ b/equinix/data_source_metal_devices_acc_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceMetalDevices(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/data_source_metal_facility_acc_test.go
+++ b/equinix/data_source_metal_facility_acc_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceMetalFacility_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalFacilityConfig_basic(testFac),
@@ -51,7 +51,7 @@ func TestAccDataSourceMetalFacility_Features(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceMetalFacilityConfig_missingFeatures(),

--- a/equinix/data_source_metal_ip_block_ranges_acc_test.go
+++ b/equinix/data_source_metal_ip_block_ranges_acc_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceMetalIPBlockRanges_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalIPBlockRangesConfig_basic(rs),

--- a/equinix/data_source_metal_metro_acc_test.go
+++ b/equinix/data_source_metal_metro_acc_test.go
@@ -12,7 +12,7 @@ func TestAccDataSourceMetalMetro_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{ // Step 3/4, expected an error with pattern, no match on: Error running pre-apply refresh: exit status 1
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalMetroConfig_basic(testMetro),

--- a/equinix/data_source_metal_operating_system_acc_test.go
+++ b/equinix/data_source_metal_operating_system_acc_test.go
@@ -11,7 +11,7 @@ func TestAccDataSourceMetalOperatingSystem_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalOperatingSystemConfig_basic,
@@ -35,7 +35,7 @@ func TestAccDataSourceMetalOperatingSystem_notFound(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceMetalOperatingSystemConfig_notFound,
@@ -57,7 +57,7 @@ func TestAccDataSourceMetalOperatingSystem_ambiguous(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceMetalOperatingSystemConfig_ambiguous,

--- a/equinix/data_source_metal_organization_acc_test.go
+++ b/equinix/data_source_metal_organization_acc_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceMetalOrganization_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalOrganizationCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/data_source_metal_plans_acc_test.go
+++ b/equinix/data_source_metal_plans_acc_test.go
@@ -12,7 +12,7 @@ func TestAccDataSourcePlans_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourcePlansConfigBasic(testSlug),

--- a/equinix/data_source_metal_port_acc_test.go
+++ b/equinix/data_source_metal_port_acc_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceMetalPort_byName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalPortConfig_byName(rs),
@@ -59,7 +59,7 @@ func TestAccDataSourceMetalPort_byId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalPortConfig_byId(rs),

--- a/equinix/data_source_metal_precreated_ip_block_acc_test.go
+++ b/equinix/data_source_metal_precreated_ip_block_acc_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceMetalPreCreatedIPBlock_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMetalPreCreatedIPBlockConfig_basic(rs),

--- a/equinix/data_source_metal_reserved_ip_block_acc_test.go
+++ b/equinix/data_source_metal_reserved_ip_block_acc_test.go
@@ -38,7 +38,7 @@ func TestAccDataSourceMetalReservedIPBlock_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalReservedIPBlockCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/data_source_metal_spot_market_price_acc_test.go
+++ b/equinix/data_source_metal_spot_market_price_acc_test.go
@@ -11,7 +11,7 @@ func TestAccDataSourceMetalSpotMarketPrice_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalSpotMarketRequestCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/data_source_metal_spot_market_request_acc_test.go
+++ b/equinix/data_source_metal_spot_market_request_acc_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceMetalSpotMarketRequest_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalSpotMarketRequestCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/data_source_metal_vlan_acc_test.go
+++ b/equinix/data_source_metal_vlan_acc_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceMetalVlan_byVxlanFacility(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -67,7 +67,7 @@ func TestAccDataSourceMetalVlan_byVxlanMetro(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -138,7 +138,7 @@ func TestAccDataSourceMetalVlan_byVlanId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -184,7 +184,7 @@ func TestAccDataSourceMetalVlan_byProjectId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDatasourceVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -13,13 +13,14 @@ import (
 	"github.com/equinix/terraform-provider-equinix/version"
 
 	"github.com/equinix/ecx-go/v2"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 )
 
 var (
@@ -29,16 +30,20 @@ var (
 	testExternalProviders    map[string]resource.ExternalProvider
 	testAccFrameworkProvider *provider.FrameworkProvider
 
-	testAccProtoV5ProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
-		"equinix": func() (tfprotov5.ProviderServer, error) {
+	testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+		"equinix": func() (tfprotov6.ProviderServer, error) {
 			ctx := context.Background()
-			providers := []func() tfprotov5.ProviderServer{
-				testAccProviders["equinix"].GRPCProvider,
-				providerserver.NewProtocol5(
+			sdkAsProtoV6, err := tf5to6server.UpgradeServer(context.Background(), testAccProviders["equinix"].GRPCProvider)
+			if err != nil {
+				return nil, err
+			}
+			providers := []func() tfprotov6.ProviderServer{
+				func() tfprotov6.ProviderServer { return sdkAsProtoV6 },
+				providerserver.NewProtocol6(
 					testAccFrameworkProvider,
 				),
 			}
-			muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+			muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
 			if err != nil {
 				return nil, err
 			}

--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/equinix/terraform-provider-equinix/version"
 
 	"github.com/equinix/ecx-go/v2"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-mux/tf6to5server"
 )
 
 var (
@@ -30,20 +30,25 @@ var (
 	testExternalProviders    map[string]resource.ExternalProvider
 	testAccFrameworkProvider *provider.FrameworkProvider
 
-	testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-		"equinix": func() (tfprotov6.ProviderServer, error) {
+	testAccProtoV5ProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
+		"equinix": func() (tfprotov5.ProviderServer, error) {
 			ctx := context.Background()
-			sdkAsProtoV6, err := tf5to6server.UpgradeServer(context.Background(), testAccProviders["equinix"].GRPCProvider)
-			if err != nil {
-				return nil, err
+
+			frameworkServer := providerserver.NewProtocol6(testAccFrameworkProvider)
+
+			providers := []func() tfprotov5.ProviderServer{
+				func() tfprotov5.ProviderServer {
+					downgradedServer, err := tf6to5server.DowngradeServer(ctx, frameworkServer)
+
+					if err != nil {
+						panic(err)
+					}
+					return downgradedServer
+				},
+				testAccProviders["equinix"].GRPCProvider,
 			}
-			providers := []func() tfprotov6.ProviderServer{
-				func() tfprotov6.ProviderServer { return sdkAsProtoV6 },
-				providerserver.NewProtocol6(
-					testAccFrameworkProvider,
-				),
-			}
-			muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+
+			muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
 			if err != nil {
 				return nil, err
 			}

--- a/equinix/provider_test.go
+++ b/equinix/provider_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/equinix/terraform-provider-equinix/version"
 
 	"github.com/equinix/ecx-go/v2"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
-	"github.com/hashicorp/terraform-plugin-mux/tf6to5server"
 )
 
 var (
@@ -30,25 +30,20 @@ var (
 	testExternalProviders    map[string]resource.ExternalProvider
 	testAccFrameworkProvider *provider.FrameworkProvider
 
-	testAccProtoV5ProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
-		"equinix": func() (tfprotov5.ProviderServer, error) {
+	testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+		"equinix": func() (tfprotov6.ProviderServer, error) {
 			ctx := context.Background()
-
-			frameworkServer := providerserver.NewProtocol6(testAccFrameworkProvider)
-
-			providers := []func() tfprotov5.ProviderServer{
-				func() tfprotov5.ProviderServer {
-					downgradedServer, err := tf6to5server.DowngradeServer(ctx, frameworkServer)
-
-					if err != nil {
-						panic(err)
-					}
-					return downgradedServer
-				},
-				testAccProviders["equinix"].GRPCProvider,
+			sdkAsProtoV6, err := tf5to6server.UpgradeServer(context.Background(), testAccProviders["equinix"].GRPCProvider)
+			if err != nil {
+				return nil, err
 			}
-
-			muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+			providers := []func() tfprotov6.ProviderServer{
+				func() tfprotov6.ProviderServer { return sdkAsProtoV6 },
+				providerserver.NewProtocol6(
+					testAccFrameworkProvider,
+				),
+			}
+			muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
 			if err != nil {
 				return nil, err
 			}

--- a/equinix/resource_metal_bgp_setup_acc_test.go
+++ b/equinix/resource_metal_bgp_setup_acc_test.go
@@ -17,7 +17,7 @@ func TestAccMetalBGPSetup_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalBGPSetupCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -224,7 +224,7 @@ func TestAccMetalDevice_sshConfig(t *testing.T) {
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -198,7 +198,7 @@ func TestAccMetalDevice_facilityList(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -257,7 +257,7 @@ func TestAccMetalDevice_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -303,7 +303,7 @@ func TestAccMetalDevice_update(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -359,7 +359,7 @@ func TestAccMetalDevice_IPXEScriptUrl(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -397,7 +397,7 @@ func TestAccMetalDevice_IPXEConflictingFields(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -419,7 +419,7 @@ func TestAccMetalDevice_IPXEConfigMissing(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -445,7 +445,7 @@ func TestAccMetalDevice_allowUserdataChanges(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -479,7 +479,7 @@ func TestAccMetalDevice_allowCustomdataChanges(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -507,7 +507,7 @@ func TestAccMetalDevice_allowChangesErrorOnUnsupportedAttribute(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccMetalDeviceConfig_allowAttributeChanges(rInt, rs, "", "", "project_id"),
@@ -647,7 +647,7 @@ func TestAccMetalDevice_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/resource_metal_device_acc_test.go
+++ b/equinix/resource_metal_device_acc_test.go
@@ -224,7 +224,7 @@ func TestAccMetalDevice_sshConfig(t *testing.T) {
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
 		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{

--- a/equinix/resource_metal_ip_attachment_acc_test.go
+++ b/equinix/resource_metal_ip_attachment_acc_test.go
@@ -17,7 +17,7 @@ func TestAccMetalIPAttachment_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalIPAttachmentCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -75,7 +75,7 @@ func TestAccMetalIPAttachment_metro(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalIPAttachmentCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/resource_metal_organization_acc_test.go
+++ b/equinix/resource_metal_organization_acc_test.go
@@ -56,7 +56,7 @@ func TestAccMetalOrganization_create(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalOrganizationCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -119,7 +119,7 @@ func TestAccMetalOrganization_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalOrganizationCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/resource_metal_organization_member_acc_test.go
+++ b/equinix/resource_metal_organization_member_acc_test.go
@@ -16,7 +16,7 @@ func TestAccResourceMetalOrganizationMember_owner(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		// TODO: CheckDestroy: testAccMetalOrganizationMemberCheckDestroyed,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -54,7 +54,7 @@ func TestAccResourceMetalOrganizationMember_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		// TODO: CheckDestroy: testAccMetalOrganizationMemberCheckDestroyed,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{

--- a/equinix/resource_metal_port_vlan_attachment_acc_test.go
+++ b/equinix/resource_metal_port_vlan_attachment_acc_test.go
@@ -75,7 +75,7 @@ func TestAccMetalPortVlanAttachment_L2Bonded(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalPortVlanAttachmentCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -163,7 +163,7 @@ func TestAccMetalPortVlanAttachment_L2Individual(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalPortVlanAttachmentCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -239,7 +239,7 @@ func TestAccMetalPortVlanAttachment_hybridBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalPortVlanAttachmentCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -314,7 +314,7 @@ func TestAccMetalPortVlanAttachment_hybridMultipleVlans(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalPortVlanAttachmentCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -445,7 +445,7 @@ func TestAccMetalPortVlanAttachment_L2Native(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalPortVlanAttachmentCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/resource_metal_project_api_key_acc_test.go
+++ b/equinix/resource_metal_project_api_key_acc_test.go
@@ -14,7 +14,7 @@ func TestAccMetalProjectAPIKey_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalProjectAPIKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/resource_metal_virtual_circuit_acc_test.go
+++ b/equinix/resource_metal_virtual_circuit_acc_test.go
@@ -131,7 +131,7 @@ func TestAccMetalVirtualCircuit_dedicated(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{ // Error: Error waiting for virtual circuit 863d4df5-b3ea-46ee-8497-858cb0cbfcb9 to be created: GET https://api.equinix.com/metal/v1/virtual-circuits/863d4df5-b3ea-46ee-8497-858cb0cbfcb9?include=project%2Cport%2Cvirtual_network%2Cvrf: 500 Oh snap, something went wrong! We've logged the error and will take a look - please reach out to us if you continue having trouble.
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalVirtualCircuitCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/resource_metal_virtual_circuit_acc_test.go
+++ b/equinix/resource_metal_virtual_circuit_acc_test.go
@@ -131,7 +131,7 @@ func TestAccMetalVirtualCircuit_dedicated(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{ // Error: Error waiting for virtual circuit 863d4df5-b3ea-46ee-8497-858cb0cbfcb9 to be created: GET https://api.equinix.com/metal/v1/virtual-circuits/863d4df5-b3ea-46ee-8497-858cb0cbfcb9?include=project%2Cport%2Cvirtual_network%2Cvrf: 500 Oh snap, something went wrong! We've logged the error and will take a look - please reach out to us if you continue having trouble.
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalVirtualCircuitCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/equinix/resource_metal_vlan_acc_test.go
+++ b/equinix/resource_metal_vlan_acc_test.go
@@ -84,7 +84,7 @@ func TestAccMetalVlan_metro(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -108,7 +108,7 @@ func TestAccMetalVlan_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -187,7 +187,7 @@ func TestAccMetalVlan_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/internal/acceptance/provider_factories.go
+++ b/internal/acceptance/provider_factories.go
@@ -4,30 +4,28 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
-	"github.com/hashicorp/terraform-plugin-mux/tf6to5server"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 )
 
-var ProtoV5ProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
-	"equinix": func() (tfprotov5.ProviderServer, error) {
+var ProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"equinix": func() (tfprotov6.ProviderServer, error) {
 		ctx := context.Background()
-
-		frameworkServer := providerserver.NewProtocol6(TestAccFrameworkProvider)
-
-		providers := []func() tfprotov5.ProviderServer{
-			func() tfprotov5.ProviderServer {
-				downgradedServer, err := tf6to5server.DowngradeServer(ctx, frameworkServer)
-
+		providers := []func() tfprotov6.ProviderServer{
+			func() tfprotov6.ProviderServer {
+				upgradedSdkProvider, err := tf5to6server.UpgradeServer(context.Background(), TestAccProviders["equinix"].GRPCProvider)
 				if err != nil {
 					panic(err)
 				}
-				return downgradedServer
+				return upgradedSdkProvider
 			},
-			TestAccProviders["equinix"].GRPCProvider,
+			providerserver.NewProtocol6(
+				TestAccFrameworkProvider,
+			),
 		}
 
-		muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+		muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/acceptance/provider_factories.go
+++ b/internal/acceptance/provider_factories.go
@@ -4,21 +4,28 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 )
 
-var ProtoV5ProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
-	"equinix": func() (tfprotov5.ProviderServer, error) {
+var ProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"equinix": func() (tfprotov6.ProviderServer, error) {
 		ctx := context.Background()
-		providers := []func() tfprotov5.ProviderServer{
-			TestAccProviders["equinix"].GRPCProvider,
-			providerserver.NewProtocol5(
+		providers := []func() tfprotov6.ProviderServer{
+			func() tfprotov6.ProviderServer {
+				upgradedSdkProvider, err := tf5to6server.UpgradeServer(context.Background(), TestAccProviders["equinix"].GRPCProvider)
+				if err != nil {
+					panic(err)
+				}
+				return upgradedSdkProvider
+			},
+			providerserver.NewProtocol6(
 				TestAccFrameworkProvider,
 			),
 		}
 
-		muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+		muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/resources/metal/connection/datasource_test.go
+++ b/internal/resources/metal/connection/datasource_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceMetalConnection_withoutVlans(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceMetalConnectionConfig_withoutVlans(rInt),
@@ -63,7 +63,7 @@ func TestAccDataSourceMetalConnection_withVlans(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceMetalConnectionConfig_withVlans(rInt),
@@ -151,7 +151,7 @@ func TestAccDataSourceMetalConnection_withoutVlans_upgradeFromVersion(t *testing
 				),
 			},
 			{
-				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 				Config:                   testDataSourceMetalConnectionConfig_withoutVlans(rInt),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/connection/datasource_test.go
+++ b/internal/resources/metal/connection/datasource_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceMetalConnection_withoutVlans(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceMetalConnectionConfig_withoutVlans(rInt),
@@ -63,7 +63,7 @@ func TestAccDataSourceMetalConnection_withVlans(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceMetalConnectionConfig_withVlans(rInt),
@@ -151,7 +151,7 @@ func TestAccDataSourceMetalConnection_withoutVlans_upgradeFromVersion(t *testing
 				),
 			},
 			{
-				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 				Config:                   testDataSourceMetalConnectionConfig_withoutVlans(rInt),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/connection/models.go
+++ b/internal/resources/metal/connection/models.go
@@ -76,7 +76,6 @@ type ServiceTokenModel struct {
 	Role            types.String `tfsdk:"role"`
 	State           types.String `tfsdk:"state"`
 	Type            types.String `tfsdk:"type"`
-	ExpiresAt       types.String `tfsdk:"expires_at"`
 }
 
 func (m *DataSourceModel) parse(ctx context.Context, conn *packngo.Connection) diag.Diagnostics {

--- a/internal/resources/metal/connection/models.go
+++ b/internal/resources/metal/connection/models.go
@@ -76,6 +76,7 @@ type ServiceTokenModel struct {
 	Role            types.String `tfsdk:"role"`
 	State           types.String `tfsdk:"state"`
 	Type            types.String `tfsdk:"type"`
+	ExpiresAt       types.String `tfsdk:"expires_at"`
 }
 
 func (m *DataSourceModel) parse(ctx context.Context, conn *packngo.Connection) diag.Diagnostics {

--- a/internal/resources/metal/connection/resource_test.go
+++ b/internal/resources/metal/connection/resource_test.go
@@ -70,7 +70,7 @@ func TestAccMetalConnection_shared_zside(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -96,7 +96,7 @@ func TestAccMetalConnection_shared(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -171,7 +171,7 @@ func TestAccMetalConnection_dedicated(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -228,7 +228,7 @@ func TestAccMetalConnection_tunnel(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -304,7 +304,7 @@ func TestAccMetalConnection_sharedVlans(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -390,7 +390,7 @@ func TestAccMetalConnection_shared_zside_upgradeFromVersion(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 				Config:                   cfg,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/connection/resource_test.go
+++ b/internal/resources/metal/connection/resource_test.go
@@ -70,7 +70,7 @@ func TestAccMetalConnection_shared_zside(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -96,7 +96,7 @@ func TestAccMetalConnection_shared(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -171,7 +171,7 @@ func TestAccMetalConnection_dedicated(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -228,7 +228,7 @@ func TestAccMetalConnection_tunnel(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -304,7 +304,7 @@ func TestAccMetalConnection_sharedVlans(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -390,7 +390,7 @@ func TestAccMetalConnection_shared_zside_upgradeFromVersion(t *testing.T) {
 				),
 			},
 			{
-				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 				Config:                   cfg,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/gateway/datasource_test.go
+++ b/internal/resources/metal/gateway/datasource_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceMetalGateway_privateIPv4(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalGatewayCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -78,7 +78,7 @@ func TestAccDataSourceMetalProjectSSHKey_upgradeFromVersion(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 				Config:                   testAccDataSourceMetalGatewayConfig_privateIPv4(),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/gateway/datasource_test.go
+++ b/internal/resources/metal/gateway/datasource_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceMetalGateway_privateIPv4(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalGatewayCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -78,7 +78,7 @@ func TestAccDataSourceMetalProjectSSHKey_upgradeFromVersion(t *testing.T) {
 				),
 			},
 			{
-				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 				Config:                   testAccDataSourceMetalGatewayConfig_privateIPv4(),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/gateway/resource_test.go
+++ b/internal/resources/metal/gateway/resource_test.go
@@ -15,7 +15,7 @@ func TestAccMetalGateway_privateIPv4(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalGatewayCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -56,7 +56,7 @@ func TestAccMetalGateway_existingReservation(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalGatewayCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -119,7 +119,7 @@ func TestAccMetalGateway_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalGatewayCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -158,7 +158,7 @@ func TestAccMetalGateway_upgradeFromVersion(t *testing.T) {
 				),
 			},
 			{
-				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 				Config:                   testAccMetalGatewayConfig_privateIPv4(),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/gateway/resource_test.go
+++ b/internal/resources/metal/gateway/resource_test.go
@@ -15,7 +15,7 @@ func TestAccMetalGateway_privateIPv4(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalGatewayCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -56,7 +56,7 @@ func TestAccMetalGateway_existingReservation(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalGatewayCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -119,7 +119,7 @@ func TestAccMetalGateway_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalGatewayCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -158,7 +158,7 @@ func TestAccMetalGateway_upgradeFromVersion(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 				Config:                   testAccMetalGatewayConfig_privateIPv4(),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/project_ssh_key/datasource_test.go
+++ b/internal/resources/metal/project_ssh_key/datasource_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceMetalProjectSSHKey_bySearch(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV5ProviderFactories:  acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories:  acceptance.ProtoV6ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		CheckDestroy:              testAccMetalProjectSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
@@ -61,7 +61,7 @@ func TestAccDataSourceMetalProjectSSHKeyDataSource_byID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV5ProviderFactories:  acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories:  acceptance.ProtoV6ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		CheckDestroy:              testAccMetalProjectSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
@@ -178,7 +178,7 @@ func TestAccDataSourceMetalProjectSSHKey_upgradeFromVersion(t *testing.T) {
 				),
 			},
 			{
-				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 				Config:                   testAccDataSourceMetalProjectSSHKeyConfig_bySearch(keyName, publicKeyMaterial),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/project_ssh_key/datasource_test.go
+++ b/internal/resources/metal/project_ssh_key/datasource_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceMetalProjectSSHKey_bySearch(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV6ProviderFactories:  acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories:  acceptance.ProtoV5ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		CheckDestroy:              testAccMetalProjectSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
@@ -61,7 +61,7 @@ func TestAccDataSourceMetalProjectSSHKeyDataSource_byID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV6ProviderFactories:  acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories:  acceptance.ProtoV5ProviderFactories,
 		PreventPostDestroyRefresh: true,
 		CheckDestroy:              testAccMetalProjectSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
@@ -178,7 +178,7 @@ func TestAccDataSourceMetalProjectSSHKey_upgradeFromVersion(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 				Config:                   testAccDataSourceMetalProjectSSHKeyConfig_bySearch(keyName, publicKeyMaterial),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/project_ssh_key/resource_test.go
+++ b/internal/resources/metal/project_ssh_key/resource_test.go
@@ -60,7 +60,7 @@ func TestAccMetalProjectSSHKey_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalProjectSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -144,7 +144,7 @@ func TestAccMetalProjectSSHKey_upgradeFromVersion(t *testing.T) {
 						Source: "hashicorp/random",
 					},
 				},
-				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 				Config:                   cfg,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/project_ssh_key/resource_test.go
+++ b/internal/resources/metal/project_ssh_key/resource_test.go
@@ -60,7 +60,7 @@ func TestAccMetalProjectSSHKey_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalProjectSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -144,7 +144,7 @@ func TestAccMetalProjectSSHKey_upgradeFromVersion(t *testing.T) {
 						Source: "hashicorp/random",
 					},
 				},
-				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 				Config:                   cfg,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/ssh_key/resource_test.go
+++ b/internal/resources/metal/ssh_key/resource_test.go
@@ -60,7 +60,7 @@ func TestAccMetalSSHKey_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -88,7 +88,7 @@ func TestAccMetalSSHKey_projectBasic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -114,7 +114,7 @@ func TestAccMetalSSHKey_update(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -148,7 +148,7 @@ func TestAccMetalSSHKey_projectImportBasic(t *testing.T) {
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -170,7 +170,7 @@ func TestAccMetalSSHKey_importBasic(t *testing.T) {
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -257,7 +257,7 @@ func TestAccMetalSSHKey_upgradeFromVersion(t *testing.T) {
 				),
 			},
 			{
-				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 				Config:                   cfg,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/ssh_key/resource_test.go
+++ b/internal/resources/metal/ssh_key/resource_test.go
@@ -60,7 +60,7 @@ func TestAccMetalSSHKey_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -88,7 +88,7 @@ func TestAccMetalSSHKey_projectBasic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -114,7 +114,7 @@ func TestAccMetalSSHKey_update(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -148,7 +148,7 @@ func TestAccMetalSSHKey_projectImportBasic(t *testing.T) {
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -170,7 +170,7 @@ func TestAccMetalSSHKey_importBasic(t *testing.T) {
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -257,7 +257,7 @@ func TestAccMetalSSHKey_upgradeFromVersion(t *testing.T) {
 				),
 			},
 			{
-				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+				ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 				Config:                   cfg,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/resources/metal/vrf/datasource_test.go
+++ b/internal/resources/metal/vrf/datasource_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceMetalVrfDataSource_byID(t *testing.T) {
 		PreCheck:                  func() { acceptance.TestAccPreCheckMetal(t) },
 		PreventPostDestroyRefresh: true,
 		ExternalProviders:         acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories:  acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories:  acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:              testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/metal/vrf/datasource_test.go
+++ b/internal/resources/metal/vrf/datasource_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceMetalVrfDataSource_byID(t *testing.T) {
 		PreCheck:                  func() { acceptance.TestAccPreCheckMetal(t) },
 		PreventPostDestroyRefresh: true,
 		ExternalProviders:         acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories:  acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories:  acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:              testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/metal/vrf/resource_test.go
+++ b/internal/resources/metal/vrf/resource_test.go
@@ -110,7 +110,7 @@ func TestAccMetalVRF_withIPRanges(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -153,7 +153,7 @@ func TestAccMetalVRF_withIPReservations(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -195,7 +195,7 @@ func TestAccMetalVRF_withGateway(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -237,7 +237,7 @@ func TestAccMetalVRFConfig_withConnection(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/metal/vrf/resource_test.go
+++ b/internal/resources/metal/vrf/resource_test.go
@@ -110,7 +110,7 @@ func TestAccMetalVRF_withIPRanges(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -153,7 +153,7 @@ func TestAccMetalVRF_withIPReservations(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -195,7 +195,7 @@ func TestAccMetalVRF_withGateway(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -237,7 +237,7 @@ func TestAccMetalVRFConfig_withConnection(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
 		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalVRFCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/main.go
+++ b/main.go
@@ -5,15 +5,15 @@ import (
 	"flag"
 	"log"
 
-	sdkprovider "github.com/equinix/terraform-provider-equinix/equinix"
-	frameworkprovider "github.com/equinix/terraform-provider-equinix/internal/provider"
+	"github.com/equinix/terraform-provider-equinix/equinix"
+	"github.com/equinix/terraform-provider-equinix/internal/provider"
 	"github.com/equinix/terraform-provider-equinix/version"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-mux/tf6to5server"
 )
 
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
@@ -26,32 +26,32 @@ func main() {
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	upgradedSdkProvider, err := tf5to6server.UpgradeServer(
-		context.Background(),
-		sdkprovider.Provider().GRPCProvider,
-	)
+	frameworkServer := providerserver.NewProtocol6(provider.CreateFrameworkProvider(version.ProviderVersion))
 
-	providers := []func() tfprotov6.ProviderServer{
-		func() tfprotov6.ProviderServer {
-			return upgradedSdkProvider
+	providers := []func() tfprotov5.ProviderServer{
+		func() tfprotov5.ProviderServer {
+			downgradedServer, err := tf6to5server.DowngradeServer(ctx, frameworkServer)
+
+			if err != nil {
+				log.Fatal(err)
+			}
+			return downgradedServer
 		},
-
-		// Example terraform-plugin-framework provider
-		providerserver.NewProtocol6(frameworkprovider.CreateFrameworkProvider(version.ProviderVersion)),
+		equinix.Provider().GRPCProvider,
 	}
 
-	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+	muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	var serveOpts []tf6server.ServeOpt
+	var serveOpts []tf5server.ServeOpt
 
 	if debugMode {
-		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
+		serveOpts = append(serveOpts, tf5server.WithManagedDebug())
 	}
 
-	err = tf6server.Serve(
+	err = tf5server.Serve(
 		"registry.terraform.io/equinix/equinix",
 		muxServer.ProviderServer,
 		serveOpts...,

--- a/main.go
+++ b/main.go
@@ -5,15 +5,15 @@ import (
 	"flag"
 	"log"
 
-	"github.com/equinix/terraform-provider-equinix/equinix"
-	"github.com/equinix/terraform-provider-equinix/internal/provider"
+	sdkprovider "github.com/equinix/terraform-provider-equinix/equinix"
+	frameworkprovider "github.com/equinix/terraform-provider-equinix/internal/provider"
 	"github.com/equinix/terraform-provider-equinix/version"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
-	"github.com/hashicorp/terraform-plugin-mux/tf6to5server"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 )
 
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
@@ -26,32 +26,32 @@ func main() {
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	frameworkServer := providerserver.NewProtocol6(provider.CreateFrameworkProvider(version.ProviderVersion))
+	upgradedSdkProvider, err := tf5to6server.UpgradeServer(
+		context.Background(),
+		sdkprovider.Provider().GRPCProvider,
+	)
 
-	providers := []func() tfprotov5.ProviderServer{
-		func() tfprotov5.ProviderServer {
-			downgradedServer, err := tf6to5server.DowngradeServer(ctx, frameworkServer)
-
-			if err != nil {
-				log.Fatal(err)
-			}
-			return downgradedServer
+	providers := []func() tfprotov6.ProviderServer{
+		func() tfprotov6.ProviderServer {
+			return upgradedSdkProvider
 		},
-		equinix.Provider().GRPCProvider,
+
+		// Example terraform-plugin-framework provider
+		providerserver.NewProtocol6(frameworkprovider.CreateFrameworkProvider(version.ProviderVersion)),
 	}
 
-	muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	var serveOpts []tf5server.ServeOpt
+	var serveOpts []tf6server.ServeOpt
 
 	if debugMode {
-		serveOpts = append(serveOpts, tf5server.WithManagedDebug())
+		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
 	}
 
-	err = tf5server.Serve(
+	err = tf6server.Serve(
 		"registry.terraform.io/equinix/equinix",
 		muxServer.ProviderServer,
 		serveOpts...,


### PR DESCRIPTION
During the migration from SDKv2 to framework we've run into cases where code changes that are suggested in the documentation do not work because we are using Terraform Plugin Protocol v5. 

Adopting Terraform Plugin Protocol v6 gives us access to nicer ways of defining nested attributes, but it means dropping support for terraform < 1.0, which is technically a breaking change regardless of whether anyone is actually using this provider with older versions of terraform.  As a result, this PR uses the `!` Conventional Commits modifier to mark this change as a breaking change.

**TODO**: actually adopt the nested attribute changes so we can see if it's a meaningful improvement