### PR TITLE
test: configure provider for upgradefromversion tests

### DIFF
--- a/internal/acceptance/context.go
+++ b/internal/acceptance/context.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package acceptance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+	helperlogging "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+)
+
+func Context(t *testing.T) context.Context {
+	t.Helper()
+
+	helperlogging.SetOutput(t)
+
+	ctx := context.Background()
+	ctx = tfsdklog.RegisterTestSink(ctx, t)
+	ctx = logger(ctx, t, "acctest")
+
+	return ctx
+}
+
+func logger(ctx context.Context, t *testing.T, name string) context.Context {
+	t.Helper()
+
+	ctx = tfsdklog.NewRootProviderLogger(ctx,
+		tfsdklog.WithLevelFromEnv("TF_LOG"),
+		tfsdklog.WithLogName(name),
+		tfsdklog.WithoutLocation(),
+	)
+	ctx = testNameContext(ctx, t.Name())
+
+	return ctx
+}
+
+// testNameContext adds the current test name to loggers.
+func testNameContext(ctx context.Context, testName string) context.Context {
+	ctx = tflog.SetField(ctx, "test_name", testName)
+
+	return ctx
+}

--- a/internal/resources/metal/connection/datasource_test.go
+++ b/internal/resources/metal/connection/datasource_test.go
@@ -128,7 +128,7 @@ func testDataSourceMetalConnectionConfig_withVlans(r int) string {
 func TestAccDataSourceMetalConnection_withoutVlans_upgradeFromVersion(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t) },
+		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t); acceptance.TestAccPreCheckProviderConfigured(t) },
 		CheckDestroy: testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/metal/connection/resource_test.go
+++ b/internal/resources/metal/connection/resource_test.go
@@ -367,7 +367,7 @@ func TestAccMetalConnection_shared_zside_upgradeFromVersion(t *testing.T) {
 	rs := acctest.RandString(10)
 	cfg := testAccMetalConnectionConfig_Shared_zside(rs)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t) },
+		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t); acceptance.TestAccPreCheckProviderConfigured(t) },
 		CheckDestroy: testAccMetalConnectionCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/metal/gateway/resource_test.go
+++ b/internal/resources/metal/gateway/resource_test.go
@@ -138,7 +138,7 @@ func TestAccMetalGateway_importBasic(t *testing.T) {
 // TODO (ocobles): once migrated, this test may be removed
 func TestAccMetalGateway_upgradeFromVersion(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t) },
+		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t); acceptance.TestAccPreCheckProviderConfigured(t) },
 		CheckDestroy: testAccMetalGatewayCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/metal/project_ssh_key/datasource_test.go
+++ b/internal/resources/metal/project_ssh_key/datasource_test.go
@@ -158,7 +158,7 @@ func TestAccDataSourceMetalProjectSSHKey_upgradeFromVersion(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                  func() { acceptance.TestAccPreCheckMetal(t) },
+		PreCheck:                  func() { acceptance.TestAccPreCheckMetal(t); acceptance.TestAccPreCheckProviderConfigured(t) },
 		PreventPostDestroyRefresh: true,
 		CheckDestroy:              testAccMetalProjectSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{

--- a/internal/resources/metal/project_ssh_key/resource_test.go
+++ b/internal/resources/metal/project_ssh_key/resource_test.go
@@ -110,7 +110,7 @@ func TestAccMetalProjectSSHKey_upgradeFromVersion(t *testing.T) {
 	cfg := testAccMetalProjectSSHKeyConfig_basic(rs, publicKeyMaterial)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t) },
+		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t); acceptance.TestAccPreCheckProviderConfigured(t) },
 		CheckDestroy: testAccMetalProjectSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/metal/ssh_key/resource_test.go
+++ b/internal/resources/metal/ssh_key/resource_test.go
@@ -199,7 +199,7 @@ func TestAccMetalSSHKey_upgradeFromVersion(t *testing.T) {
 	cfg := testAccMetalSSHKeyConfig_basic(rInt, publicKeyMaterial)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t) },
+		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t); acceptance.TestAccPreCheckProviderConfigured(t) },
 		CheckDestroy: testAccMetalSSHKeyCheckDestroyed,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
when we define the ProviderFactories at TestStep level instead of TestCase and we run that single test it fails in CheckDestroy function because the client Meta() interface is nil. This PR adds a precheck to make sure the provider is always configured.