### PR TITLE
refactor: delay Fabric v4 token exchange until resources are used

### DIFF
--- a/equinix/resource_fabric_cloud_router.go
+++ b/equinix/resource_fabric_cloud_router.go
@@ -248,7 +248,6 @@ func projectCloudRouterTerraToGo(projectRequest []interface{}) v4.Project {
 }
 func resourceFabricCloudRouterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	schemaNotifications := d.Get("notifications").([]interface{})
 	notifications := equinix_fabric_schema.NotificationsToFabric(schemaNotifications)
 	schemaAccount := d.Get("account").(*schema.Set).List()
@@ -293,7 +292,6 @@ func resourceFabricCloudRouterCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceFabricCloudRouterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	CloudRouter, _, err := client.CloudRoutersApi.GetCloudRouterByUuid(ctx, d.Id())
 	if err != nil {
 		log.Printf("[WARN] Fabric Cloud Router %s not found , error %s", d.Id(), err)
@@ -386,7 +384,6 @@ func getCloudRouterUpdateRequest(conn v4.CloudRouter, d *schema.ResourceData) (v
 
 func resourceFabricCloudRouterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	dbConn, err := waitUntilCloudRouterIsProvisioned(d.Id(), meta, ctx)
 	if err != nil {
 		if !strings.Contains(err.Error(), "500") {
@@ -478,7 +475,6 @@ func waitUntilCloudRouterIsProvisioned(uuid string, meta interface{}, ctx contex
 func resourceFabricCloudRouterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	_, err := client.CloudRoutersApi.DeleteCloudRouterByUuid(ctx, d.Id())
 	if err != nil {
 		errors, ok := err.(v4.GenericSwaggerError).Model().([]v4.ModelError)

--- a/equinix/resource_fabric_cloud_router_acc_test.go
+++ b/equinix/resource_fabric_cloud_router_acc_test.go
@@ -5,11 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
-
 	"github.com/equinix/terraform-provider-equinix/equinix"
 	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
-	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -171,7 +168,6 @@ func testAccCloudRouterCreateMixedParameterConfig_PFCR() string {
 
 func checkCloudRouterDelete(s *terraform.State) error {
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, acceptance.TestAccProvider.Meta().(*config.Config).FabricAuthToken)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_fabric_cloud_router" {
 			continue

--- a/equinix/resource_fabric_connection.go
+++ b/equinix/resource_fabric_connection.go
@@ -3,10 +3,11 @@ package equinix
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_fabric_schema "github.com/equinix/terraform-provider-equinix/internal/fabric/schema"
@@ -612,7 +613,6 @@ func resourceFabricConnection() *schema.Resource {
 
 func resourceFabricConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	conType := v4.ConnectionType(d.Get("type").(string))
 	schemaNotifications := d.Get("notifications").([]interface{})
 	notifications := equinix_fabric_schema.NotificationsToFabric(schemaNotifications)
@@ -737,7 +737,6 @@ func additionalInfoContainsAWSSecrets(info []interface{}) ([]interface{}, bool) 
 
 func resourceFabricConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	conn, _, err := client.ConnectionsApi.GetConnectionByUuid(ctx, d.Id(), nil)
 	if err != nil {
 		log.Printf("[WARN] Connection %s not found , error %s", d.Id(), err)
@@ -799,7 +798,6 @@ func setFabricMap(d *schema.ResourceData, conn v4.Connection) diag.Diagnostics {
 
 func resourceFabricConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	dbConn, err := verifyConnectionCreated(d.Id(), meta, ctx)
 	if err != nil {
 		if !strings.Contains(err.Error(), "500") {
@@ -969,7 +967,6 @@ func verifyConnectionCreated(uuid string, meta interface{}, ctx context.Context)
 func resourceFabricConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	_, _, err := client.ConnectionsApi.DeleteConnectionByUuid(ctx, d.Id())
 	if err != nil {
 		errors, ok := err.(v4.GenericSwaggerError).Model().([]v4.ModelError)

--- a/equinix/resource_fabric_connection_acc_test.go
+++ b/equinix/resource_fabric_connection_acc_test.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/equinix/terraform-provider-equinix/equinix"
-	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 	"os"
 	"testing"
 
-	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/equinix"
+	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 
-	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -460,7 +458,6 @@ func testAccFabricCreateVirtualDevice2NetworkConnectionConfig(name, virtualDevic
 
 func CheckConnectionDelete(s *terraform.State) error {
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, acceptance.TestAccProvider.Meta().(*config.Config).FabricAuthToken)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_fabric_connection" {
 			continue

--- a/equinix/resource_fabric_network.go
+++ b/equinix/resource_fabric_network.go
@@ -3,6 +3,7 @@ package equinix
 import (
 	"context"
 	"fmt"
+
 	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
@@ -11,10 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func fabricNetworkChangeSch() map[string]*schema.Schema {
@@ -168,7 +170,6 @@ func resourceFabricNetwork() *schema.Resource {
 
 func resourceFabricNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	schemaNotifications := d.Get("notifications").([]interface{})
 	notifications := equinix_fabric_schema.NotificationsToFabric(schemaNotifications)
 	schemaLocation := d.Get("location").(*schema.Set).List()
@@ -202,7 +203,6 @@ func resourceFabricNetworkCreate(ctx context.Context, d *schema.ResourceData, me
 
 func resourceFabricNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	fabricNetwork, _, err := client.NetworksApi.GetNetworkByUuid(ctx, d.Id())
 	if err != nil {
 		return diag.FromErr(equinix_errors.FormatFabricError(err))
@@ -284,7 +284,6 @@ func getFabricNetworkUpdateRequest(network v4.Network, d *schema.ResourceData) (
 }
 func resourceFabricNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	dbConn, err := waitUntilFabricNetworkIsProvisioned(d.Id(), meta, ctx)
 	if err != nil {
 		return diag.Errorf("either timed out or errored out while fetching Fabric Network for uuid %s and error %v", d.Id(), err)
@@ -369,7 +368,6 @@ func waitUntilFabricNetworkIsProvisioned(uuid string, meta interface{}, ctx cont
 func resourceFabricNetworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	_, _, err := client.NetworksApi.DeleteNetworkByUuid(ctx, d.Id())
 	if err != nil {
 		errors, ok := err.(v4.GenericSwaggerError).Model().([]v4.ModelError)

--- a/equinix/resource_fabric_network_acc_test.go
+++ b/equinix/resource_fabric_network_acc_test.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/equinix/terraform-provider-equinix/equinix"
 	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
-	"github.com/equinix/terraform-provider-equinix/internal/config"
 
-	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -82,7 +80,6 @@ func testAccNetworkCreateOnlyRequiredParameterConfig_PFCR(name string) string {
 }
 func checkNetworkDelete(s *terraform.State) error {
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, acceptance.TestAccProvider.Meta().(*config.Config).FabricAuthToken)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_fabric_network" {
 			continue

--- a/equinix/resource_fabric_port.go
+++ b/equinix/resource_fabric_port.go
@@ -411,7 +411,6 @@ func fabricPortsListToTerra(ports v4.AllPortsResponse) []map[string]interface{} 
 
 func resourceFabricPortRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	port, _, err := client.PortsApi.GetPortByUuid(ctx, d.Id())
 	if err != nil {
 		log.Printf("[WARN] Port %s not found , error %s", d.Id(), err)
@@ -479,7 +478,6 @@ func resourceFabricPortGetByPortName(ctx context.Context, d *schema.ResourceData
 	}()
 
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	portNameParam := d.Get("filters").(*schema.Set).List()
 	portName := portNameQueryParamToFabric(portNameParam)
 	ports, _, err := client.PortsApi.GetPorts(ctx, &portName)

--- a/equinix/resource_fabric_routing_protocol.go
+++ b/equinix/resource_fabric_routing_protocol.go
@@ -3,11 +3,12 @@ package equinix
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_fabric_schema "github.com/equinix/terraform-provider-equinix/internal/fabric/schema"
@@ -287,7 +288,6 @@ func resourceFabricRoutingProtocol() *schema.Resource {
 
 func resourceFabricRoutingProtocolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	log.Printf("[WARN] Routing Protocol Connection uuid: %s", d.Get("connection_uuid").(string))
 	fabricRoutingProtocol, _, err := client.RoutingProtocolsApi.GetConnectionRoutingProtocolByUuid(ctx, d.Id(), d.Get("connection_uuid").(string))
 	if err != nil {
@@ -309,7 +309,6 @@ func resourceFabricRoutingProtocolRead(ctx context.Context, d *schema.ResourceDa
 
 func resourceFabricRoutingProtocolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	schemaBgpIpv4 := d.Get("bgp_ipv4").(*schema.Set).List()
 	bgpIpv4 := routingProtocolBgpIpv4ToFabric(schemaBgpIpv4)
 	schemaBgpIpv6 := d.Get("bgp_ipv6").(*schema.Set).List()
@@ -392,7 +391,6 @@ func resourceFabricRoutingProtocolCreate(ctx context.Context, d *schema.Resource
 
 func resourceFabricRoutingProtocolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 
 	schemaBgpIpv4 := d.Get("bgp_ipv4").(*schema.Set).List()
 	bgpIpv4 := routingProtocolBgpIpv4ToFabric(schemaBgpIpv4)
@@ -485,7 +483,6 @@ func resourceFabricRoutingProtocolUpdate(ctx context.Context, d *schema.Resource
 func resourceFabricRoutingProtocolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	_, _, err := client.RoutingProtocolsApi.DeleteConnectionRoutingProtocolByUuid(ctx, d.Id(), d.Get("connection_uuid").(string))
 	if err != nil {
 		errors, ok := err.(v4.GenericSwaggerError).Model().([]v4.ModelError)

--- a/equinix/resource_fabric_routing_protocol_acc_test.go
+++ b/equinix/resource_fabric_routing_protocol_acc_test.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/equinix/terraform-provider-equinix/equinix"
 	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
-	"github.com/equinix/terraform-provider-equinix/internal/config"
 
-	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -197,7 +195,6 @@ data "equinix_fabric_routing_protocol" "bgp" {
 
 func checkRoutingProtocolDelete(s *terraform.State) error {
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, acceptance.TestAccProvider.Meta().(*config.Config).FabricAuthToken)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_fabric_routing_protocol" {
 			continue

--- a/equinix/resource_fabric_service_profile.go
+++ b/equinix/resource_fabric_service_profile.go
@@ -544,7 +544,6 @@ func resourceFabricServiceProfile() *schema.Resource {
 
 func resourceFabricServiceProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	serviceProfile, _, err := client.ServiceProfilesApi.GetServiceProfileByUuid(ctx, d.Id(), nil)
 	if err != nil {
 		if !strings.Contains(err.Error(), "500") {
@@ -558,7 +557,6 @@ func resourceFabricServiceProfileRead(ctx context.Context, d *schema.ResourceDat
 
 func resourceFabricServiceProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 
 	createRequest := getServiceProfileRequestPayload(d)
 	sp, _, err := client.ServiceProfilesApi.CreateServiceProfile(ctx, createRequest)
@@ -628,7 +626,6 @@ func getServiceProfileRequestPayload(d *schema.ResourceData) v4.ServiceProfileRe
 
 func resourceFabricServiceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	uuid := d.Id()
 	updateRequest := getServiceProfileRequestPayload(d)
 
@@ -724,7 +721,6 @@ func waitForActiveServiceProfileAndPopulateETag(uuid string, meta interface{}, c
 func resourceFabricServiceProfileDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	uuid := d.Id()
 	if uuid == "" {
 		return diag.Errorf("No uuid found for Service Profile Deletion %v ", uuid)
@@ -822,7 +818,6 @@ func fabricServiceProfileMap(serviceProfile *v4.ServiceProfile) map[string]inter
 
 func resourceServiceProfilesSearchRequest(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).FabricClient
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, meta.(*config.Config).FabricAuthToken)
 	schemaFilter := d.Get("filter").(*schema.Set).List()
 	filter := serviceProfilesSearchFilterRequestToFabric(schemaFilter)
 	var serviceProfileFlt v4.ServiceProfileFilter // Cast ServiceProfile search expression struct type to interface

--- a/equinix/resource_fabric_service_profile_acc_test.go
+++ b/equinix/resource_fabric_service_profile_acc_test.go
@@ -3,15 +3,14 @@ package equinix_test
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/equinix/terraform-provider-equinix/equinix"
 	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
-	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-	v4 "github.com/equinix-labs/fabric-go/fabric/v4"
 )
 
 func TestAccFabricCreateServiceProfile_PFCR(t *testing.T) {
@@ -155,7 +154,6 @@ func testAccFabricCreateServiceProfileConfig(portUUID string, portType string, p
 func checkServiceProfileDelete(s *terraform.State) error {
 	client := acceptance.TestAccProvider.Meta().(*config.Config).FabricClient
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, v4.ContextAccessToken, acceptance.TestAccProvider.Meta().(*config.Config).FabricAuthToken)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_fabric_service_profile" {
 			continue

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -72,13 +72,15 @@ func FormatFabricError(err error) error {
 	// errors = append(errors, string(err.(fabric.GenericSwaggerError).Body()))
 	var errors Errors
 	errors = append(errors, err.Error())
-	if fabricErrs, ok := err.(fabric.GenericSwaggerError).Model().([]fabric.ModelError); ok {
-		for _, e := range fabricErrs {
-			errors = append(errors, fmt.Sprintf("Code: %s", e.ErrorCode))
-			errors = append(errors, fmt.Sprintf("Message: %s", e.ErrorMessage))
-			errors = append(errors, fmt.Sprintf("Details: %s", e.Details))
-			if additionalInfo := FormatFabricAdditionalInfo(e.AdditionalInfo); additionalInfo != "" {
-				errors = append(errors, fmt.Sprintf("AdditionalInfo: [%s]", additionalInfo))
+	if genericError, ok := err.(fabric.GenericSwaggerError); ok {
+		if fabricErrs, ok := genericError.Model().([]fabric.ModelError); ok {
+			for _, e := range fabricErrs {
+				errors = append(errors, fmt.Sprintf("Code: %s", e.ErrorCode))
+				errors = append(errors, fmt.Sprintf("Message: %s", e.ErrorMessage))
+				errors = append(errors, fmt.Sprintf("Details: %s", e.Details))
+				if additionalInfo := FormatFabricAdditionalInfo(e.AdditionalInfo); additionalInfo != "" {
+					errors = append(errors, fmt.Sprintf("AdditionalInfo: [%s]", additionalInfo))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This updates Fabric v4 client creation to allow the client to get an OAuth token when it is needed rather than running a token exchange at provider startup.  This reduces the risk of tokens expiring for long-running configurations and brings Fabric client initialization in line with how other Equinix API clients are initialized.