### PR TITLE
fix: vlans is now required in the Metal API for shared connections

### DIFF
--- a/docs/resources/equinix_metal_connection.md
+++ b/docs/resources/equinix_metal_connection.md
@@ -57,6 +57,11 @@ resource "equinix_ecx_l2_connection" "example" {
 ### Shared Connection with z_side token - Non-redundant Connection from your own Equinix Fabric Port to Equinix Metal
 
 ```hcl
+resource "equinix_metal_vlan" "example" {
+    project_id      = local.my_project_id
+    metro           = "FR"
+}
+
 resource "equinix_metal_connection" "example" {
     name               = "tf-port-to-metal"
     project_id         = local.project_id
@@ -66,6 +71,9 @@ resource "equinix_metal_connection" "example" {
     speed              = "200Mbps"
     service_token_type = "z_side"
     contact_email      = "username@example.com"
+    vlans              = [
+      equinix_metal_vlan.example.vxlan
+    ]
 }
 
 data "equinix_ecx_port" "example" {
@@ -88,6 +96,16 @@ resource "equinix_ecx_l2_connection" "example" {
 ### Shared Connection for organizations without Connection Services Token feature enabled
 
 ```hcl
+resource "equinix_metal_vlan" "example1" {
+    project_id      = local.my_project_id
+    metro           = "SV"
+}
+
+resource "equinix_metal_vlan" "example2" {
+    project_id      = local.my_project_id
+    metro           = "SV"
+}
+
 resource "equinix_metal_connection" "example" {
     name            = "tf-port-to-metal-legacy"
     project_id      = local.my_project_id
@@ -95,6 +113,10 @@ resource "equinix_metal_connection" "example" {
     redundancy      = "redundant"
     type            = "shared"
     contact_email   = "username@example.com"
+    vlans              = [
+      equinix_metal_vlan.example1.vxlan,
+      equinix_metal_vlan.example2.vxlan
+    ]
 }
 
 data "equinix_ecx_port" "example" {

--- a/internal/resources/metal/connection/datasource_test.go
+++ b/internal/resources/metal/connection/datasource_test.go
@@ -10,53 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
-func TestAccDataSourceMetalConnection_withoutVlans(t *testing.T) {
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
-		ExternalProviders:        acceptance.TestExternalProviders,
-		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testDataSourceMetalConnectionConfig_withoutVlans(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(
-						"equinix_metal_connection.test", "id",
-						"data.equinix_metal_connection.test", "id"),
-					resource.TestCheckResourceAttrPair(
-						"equinix_metal_connection.test", "vlans.#",
-						"data.equinix_metal_connection.test", "vlans.#"),
-					resource.TestCheckResourceAttr(
-						"data.equinix_metal_connection.test", "vlans.#", "0"),
-				),
-			},
-		},
-	})
-}
-
-func testDataSourceMetalConnectionConfig_withoutVlans(r int) string {
-	return fmt.Sprintf(`
-		resource "equinix_metal_project" "test" {
-			name = "tfacc-conn-project-%d"
-		}
-
-		resource "equinix_metal_connection" "test" {
-			name               = "tfacc-conn-%d"
-			project_id         = equinix_metal_project.test.id
-			type               = "shared"
-			redundancy         = "redundant"
-			metro              = "sv"
-			speed              = "50Mbps"
-			service_token_type = "a_side"
-		}
-
-		data "equinix_metal_connection" "test" {
-			connection_id = equinix_metal_connection.test.id
-		}`,
-		r, r)
-}
-
 func TestAccDataSourceMetalConnection_withVlans(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -125,7 +78,7 @@ func testDataSourceMetalConnectionConfig_withVlans(r int) string {
 
 // Test to verify that switching from SDKv2 to the Framework has not affected provider's behavior
 // TODO (ocobles): once migrated, this test may be removed
-func TestAccDataSourceMetalConnection_withoutVlans_upgradeFromVersion(t *testing.T) {
+func TestAccDataSourceMetalConnection_withVlans_upgradeFromVersion(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.TestAccPreCheckMetal(t); acceptance.TestAccPreCheckProviderConfigured(t) },
@@ -138,7 +91,7 @@ func TestAccDataSourceMetalConnection_withoutVlans_upgradeFromVersion(t *testing
 						Source:            "equinix/equinix",
 					},
 				},
-				Config: testDataSourceMetalConnectionConfig_withoutVlans(rInt),
+				Config: testDataSourceMetalConnectionConfig_withVlans(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"equinix_metal_connection.test", "id",
@@ -152,7 +105,7 @@ func TestAccDataSourceMetalConnection_withoutVlans_upgradeFromVersion(t *testing
 			},
 			{
 				ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
-				Config:                   testDataSourceMetalConnectionConfig_withoutVlans(rInt),
+				Config:                   testDataSourceMetalConnectionConfig_withVlans(rInt),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),

--- a/internal/resources/metal/connection/resource.go
+++ b/internal/resources/metal/connection/resource.go
@@ -9,6 +9,7 @@ import (
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	"github.com/equinix/terraform-provider-equinix/internal/framework"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -74,6 +75,22 @@ func (r *Resource) Create(
 				"project_id is required for 'shared' connection type",
 			)
 			return
+		}
+		if plan.Vlans.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("vlans"),
+				"Missing vlans",
+				"You must specify vlans for 'shared' connection type",
+			)
+			return
+		}
+
+		if plan.Redundancy.ValueString() == "redundant" && len(plan.Vlans.Elements()) < 2 {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("vlans"),
+				"Not enough vlans",
+				"You must specify 2 vlans when for 'shared' connection type with redundancy 'redundant'",
+			)
 		}
 
 		// Create the shared connection

--- a/internal/resources/metal/connection/resource_schema.go
+++ b/internal/resources/metal/connection/resource_schema.go
@@ -130,6 +130,9 @@ func resourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(2),
 				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
 			},
 			"service_token_type": schema.StringAttribute{
 				Description: "Only used with shared connection. Type of service token to use for the connection, a_side or z_side",

--- a/internal/resources/metal/connection/speed.go
+++ b/internal/resources/metal/connection/speed.go
@@ -19,6 +19,7 @@ var (
 		{2 * giga, "2Gbps"},
 		{5 * giga, "5Gbps"},
 		{10 * giga, "10Gbps"},
+		{100 * giga, "100Gbps"},
 	}
 )
 


### PR DESCRIPTION
The Metal API was recently updated to change the behavior of shared interconnections as follows:

- VLANs must be specified at creation for shared connections
- VLANs cannot be updated for shared connections

This updates the connection resource to align with the new API behavior so that users can catch configuration errors earlier.

Note this rolls back #273, which was written to address #222.

This also includes a fix for #595 