### PR TITLE
Feat: To Provide Capability to Add Secondary Device to existing Primary Device

### DIFF
--- a/docs/resources/equinix_network_device.md
+++ b/docs/resources/equinix_network_device.md
@@ -249,6 +249,53 @@ resource "equinix_network_device" "arista-ha" {
 }
 ```
 
+```hcl
+# Add a secondary device to an existing primary device.
+
+data "equinix_network_account" "sy" {
+    name = "account-name"
+    metro_code = "SY"
+    project_id = "92cbcfd9-347b-4da5-901d-2cea82575941"
+}
+
+resource "equinix_network_device" "C8KV-SV" {
+    name            = "tf-primary"
+    project_id      = "68ccfd49-39b1-478e-957a-67c72f719d7a"
+    primary_device_id = "8b028560-4a91-4b52-87ba-9fae0fcb538c"
+    metro_code      = data.equinix_network_account.sy.metro_code
+    type_code       = "C8000V"
+    self_managed    = true
+    byol            = true
+    package_code    = "network-essentials"
+    notifications   = ["test@eq.com"]
+    hostname        = "C8KV"
+    account_number  = data.equinix_network_account.sy.number
+    version         = "17.13.1a"
+    core_count      = 2
+    term_length     = 1
+    additional_bandwidth = 5
+    ssh_key {
+        username = "test-username"
+        key_name = "test"
+    }
+    acl_template_id = "fee5e2c0-6198-4ce6-9cbd-bbe6c1dbe138"
+    secondary_device {
+        name            = "tf-secondary"
+        metro_code      = data.equinix_network_account.sy.metro_code
+        notifications   = ["test@eq.com"]
+        hostname        = "C8KV"
+        account_number  = data.equinix_network_account.sy.number
+        vendor_configuration = {"hostNamePrefix" ="C8KV-secondary"}
+        additional_bandwidth = 5
+        ssh_key {
+            username = "test-username"
+            key_name = "test"
+        }
+        acl_template_id = "fee5e2c0-6198-4ce6-9cbd-bbe6c1dbe138"
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -302,6 +349,8 @@ leave it out, the device will be created under the default project id of your or
 * `diverse_device_id` - (Optional) Unique ID of an existing device.
 Use this field to let Equinix know if you want your new device to be in a different location from any existing virtual 
 device. This field is only meaningful for single devices.
+* `primary_device_id` - Unique ID of an existing primary device. This field is used when you are using Create Virtual 
+Device API to add a secondary device to an existing primary device. If not used it would create new HA/redundant devices
 
 ### Secondary Device
 

--- a/equinix/resource_network_device.go
+++ b/equinix/resource_network_device.go
@@ -69,6 +69,7 @@ var neDeviceSchemaNames = map[string]string{
 	"Connectivity":          "connectivity",
 	"DiverseFromDeviceUUID": "diverse_device_id",
 	"DiverseFromDeviceName": "diverse_device_name",
+	"PrimaryDeviceUUID":     "primary_device_id",
 }
 
 var neDeviceDescriptions = map[string]string{
@@ -118,6 +119,7 @@ var neDeviceDescriptions = map[string]string{
 	"ProjectID":             "The unique identifier of Project Resource to which device is scoped to",
 	"DiverseFromDeviceUUID": "Unique ID of an existing device",
 	"DiverseFromDeviceName": "Diverse Device Name of an existing device",
+	"PrimaryDeviceUUID":     "Primary Device UUID",
 }
 
 var neDeviceInterfaceSchemaNames = map[string]string{
@@ -227,6 +229,13 @@ func createNetworkDeviceSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: neDeviceDescriptions["UUID"],
+		},
+		neDeviceSchemaNames["PrimaryDeviceUUID"]: {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IsUUID,
+			Description:  neDeviceDescriptions["PrimaryDeviceUUID"],
 		},
 		neDeviceSchemaNames["Name"]: {
 			Type:     schema.TypeString,
@@ -1081,6 +1090,9 @@ func createNetworkDevices(d *schema.ResourceData) (*ne.Device, *ne.Device) {
 	}
 	if v, ok := d.GetOk(neDeviceSchemaNames["DiverseFromDeviceUUID"]); ok {
 		primary.DiverseFromDeviceUUID = ne.String(v.(string))
+	}
+	if v, ok := d.GetOk(neDeviceSchemaNames["PrimaryDeviceUUID"]); ok {
+		primary.PrimaryDeviceUUID = ne.String(v.(string))
 	}
 	if v, ok := d.GetOk(neDeviceSchemaNames["Throughput"]); ok {
 		primary.Throughput = ne.Int(v.(int))

--- a/equinix/resource_network_device_test.go
+++ b/equinix/resource_network_device_test.go
@@ -91,6 +91,151 @@ func TestNetworkDevice_createFromResourceData(t *testing.T) {
 	assert.Equal(t, expectedPrimary, primary, "Primary device matches expected result")
 }
 
+func TestNetworkDevice_AddSecFromResourceData(t *testing.T) {
+	expectedPrimaryUserKey := ne.DeviceUserPublicKey{
+		Username: ne.String("user"),
+		KeyName:  ne.String("key"),
+	}
+	expectedSecondaryUserKey := ne.DeviceUserPublicKey{
+		Username: ne.String("user"),
+		KeyName:  ne.String("key"),
+	}
+	expectedPrimaryVendorConfig := map[string]string{
+		"key": "value",
+	}
+	expectedSecondaryVendorConfig := map[string]string{
+		"key": "value",
+	}
+	expectedPrimary := &ne.Device{
+		Name:                ne.String("device"),
+		TypeCode:            ne.String("C8000V"),
+		MetroCode:           ne.String("SV"),
+		HostName:            ne.String("test"),
+		PackageCode:         ne.String("network-essentials"),
+		Version:             ne.String("17.13.1a"),
+		IsBYOL:              ne.Bool(true),
+		LicenseToken:        ne.String("sWf3df4gaAvbbexw45ga4f"),
+		ACLTemplateUUID:     ne.String("a624178c-6d59-4798-9a7f-2ddf2c7c5881"),
+		AccountNumber:       ne.String("123456"),
+		Notifications:       []string{"bla@bla.com"},
+		TermLength:          ne.Int(1),
+		AdditionalBandwidth: ne.Int(50),
+		OrderReference:      ne.String("12312121sddsf1231"),
+		InterfaceCount:      ne.Int(10),
+		WanInterfaceId:      ne.String("5"),
+		CoreCount:           ne.Int(2),
+		IsSelfManaged:       ne.Bool(false),
+		VendorConfiguration: expectedPrimaryVendorConfig,
+		UserPublicKey:       &expectedPrimaryUserKey,
+		Connectivity:        ne.String("INTERNET-ACCESS"),
+		ProjectID:           ne.String("68ccfd49-39b1-478e-957a-67c72f719d7a"),
+		PrimaryDeviceUUID:   ne.String("8b028560-4a91-4b52-87ba-9fae0fcb538c"),
+	}
+	expectedSecondary := &ne.Device{
+		Name: ne.String("device"),
+		//TypeCode:            ne.String("C8000V"),
+		MetroCode:           ne.String("SV"),
+		HostName:            ne.String("test"),
+		LicenseToken:        ne.String("sWf3df4gaAvbbexw45ga4f"),
+		ACLTemplateUUID:     ne.String("a624178c-6d59-4798-9a7f-2ddf2c7c5881"),
+		AccountNumber:       ne.String("123456"),
+		Notifications:       []string{"bla@bla.com"},
+		AdditionalBandwidth: ne.Int(50),
+		VendorConfiguration: expectedSecondaryVendorConfig,
+		UserPublicKey:       &expectedSecondaryUserKey,
+		ProjectID:           ne.String("68ccfd49-39b1-478e-957a-67c72f719d7a"),
+	}
+	rawData := map[string]interface{}{
+		neDeviceSchemaNames["Name"]:                ne.StringValue(expectedPrimary.Name),
+		neDeviceSchemaNames["TypeCode"]:            ne.StringValue(expectedPrimary.TypeCode),
+		neDeviceSchemaNames["MetroCode"]:           ne.StringValue(expectedPrimary.MetroCode),
+		neDeviceSchemaNames["HostName"]:            ne.StringValue(expectedPrimary.HostName),
+		neDeviceSchemaNames["PackageCode"]:         ne.StringValue(expectedPrimary.PackageCode),
+		neDeviceSchemaNames["Version"]:             ne.StringValue(expectedPrimary.Version),
+		neDeviceSchemaNames["IsBYOL"]:              ne.BoolValue(expectedPrimary.IsBYOL),
+		neDeviceSchemaNames["LicenseToken"]:        ne.StringValue(expectedPrimary.LicenseToken),
+		neDeviceSchemaNames["ACLTemplateUUID"]:     ne.StringValue(expectedPrimary.ACLTemplateUUID),
+		neDeviceSchemaNames["AccountNumber"]:       ne.StringValue(expectedPrimary.AccountNumber),
+		neDeviceSchemaNames["TermLength"]:          ne.IntValue(expectedPrimary.TermLength),
+		neDeviceSchemaNames["AdditionalBandwidth"]: ne.IntValue(expectedPrimary.AdditionalBandwidth),
+		neDeviceSchemaNames["OrderReference"]:      ne.StringValue(expectedPrimary.OrderReference),
+		neDeviceSchemaNames["InterfaceCount"]:      ne.IntValue(expectedPrimary.InterfaceCount),
+		neDeviceSchemaNames["WanInterfaceId"]:      ne.StringValue(expectedPrimary.WanInterfaceId),
+		neDeviceSchemaNames["CoreCount"]:           ne.IntValue(expectedPrimary.CoreCount),
+		neDeviceSchemaNames["IsSelfManaged"]:       ne.BoolValue(expectedPrimary.IsSelfManaged),
+		neDeviceSchemaNames["ProjectID"]:           ne.StringValue(expectedPrimary.ProjectID),
+		neDeviceSchemaNames["PrimaryDeviceUUID"]:   ne.StringValue(expectedPrimary.PrimaryDeviceUUID),
+	}
+
+	input := &ne.Device{
+		Name:                ne.String("device"),
+		MetroCode:           ne.String("SV"),
+		IBX:                 ne.String("SV5"),
+		Region:              ne.String("AMER"),
+		HostName:            ne.String("test"),
+		LicenseToken:        ne.String("sWf3df4gaAvbbexw45ga4f"),
+		ACLTemplateUUID:     ne.String("a624178c-6d59-4798-9a7f-2ddf2c7c5881"),
+		SSHIPAddress:        ne.String("1.1.1.1"),
+		SSHIPFqdn:           ne.String("test-1.1.1.1-SV.test.equinix.com"),
+		AccountNumber:       ne.String("123456"),
+		Notifications:       []string{"bla@bla.com"},
+		RedundancyType:      ne.String("SECONDARY"),
+		AdditionalBandwidth: ne.Int(50),
+		ProjectID:           ne.String("68ccfd49-39b1-478e-957a-67c72f719d7a"),
+		Interfaces: []ne.DeviceInterface{
+			{
+				ID:                ne.Int(1),
+				Name:              ne.String("GigabitEthernet1"),
+				Status:            ne.String("AVAILABLE"),
+				OperationalStatus: ne.String("UP"),
+				MACAddress:        ne.String("58-0A-C9-7A-DA-E9"),
+				IPAddress:         ne.String("2.2.2.2"),
+				AssignedType:      ne.String("test-connection(AWS Direct Connect)"),
+				Type:              ne.String("DATA"),
+			},
+		},
+		VendorConfiguration: map[string]string{
+			"key": "value",
+		},
+		UserPublicKey: &ne.DeviceUserPublicKey{
+			Username: ne.String("user"),
+			KeyName:  ne.String("key"),
+		},
+		ASN:      ne.Int(11222),
+		ZoneCode: ne.String("Zone2"),
+	}
+
+	d := schema.TestResourceDataRaw(t, createNetworkDeviceSchema(), rawData)
+	d.Set(neDeviceSchemaNames["Secondary"], flattenNetworkDeviceSecondary(input))
+	d.Set(neDeviceSchemaNames["Notifications"], expectedPrimary.Notifications)
+	d.Set(neDeviceSchemaNames["UserPublicKey"], flattenNetworkDeviceUserKeys([]*ne.DeviceUserPublicKey{&expectedPrimaryUserKey}))
+	d.Set(neDeviceSchemaNames["VendorConfiguration"], expectedPrimary.VendorConfiguration)
+	d.Set(neDeviceSchemaNames["PrimaryDeviceUUID"], expectedPrimary.PrimaryDeviceUUID)
+	d.Set(neDeviceSchemaNames["TypeCode"], expectedPrimary.TypeCode)
+	d.Set(neDeviceSchemaNames["Version"], expectedPrimary.Version)
+	d.Set(neDeviceSchemaNames["TermLength"], expectedPrimary.TermLength)
+	d.Set(neDeviceSchemaNames["OrderReference"], expectedPrimary.OrderReference)
+	d.Set(neDeviceSchemaNames["PackageCode"], expectedPrimary.PackageCode)
+	d.Set(neDeviceSchemaNames["CoreCount"], expectedPrimary.CoreCount)
+	d.Set(neDeviceSchemaNames["InterfaceCount"], expectedPrimary.InterfaceCount)
+	d.Set(neDeviceSchemaNames["Notifications"], expectedSecondary.Notifications)
+	d.Set(neDeviceSchemaNames["UserPublicKey"], flattenNetworkDeviceUserKeys([]*ne.DeviceUserPublicKey{&expectedSecondaryUserKey}))
+	d.Set(neDeviceSchemaNames["VendorConfiguration"], expectedSecondary.VendorConfiguration)
+	d.Set(neDeviceSchemaNames["Name"], expectedSecondary.Name)
+	d.Set(neDeviceSchemaNames["PurchaseOrderNumber"], nil)
+	d.Set(neDeviceSchemaNames["HostName"], expectedSecondary.HostName)
+	d.Set(neDeviceSchemaNames["ProjectID"], expectedSecondary.ProjectID)
+
+	// when
+	primary, secondary := createNetworkDevices(d)
+
+	// then
+	assert.NotNil(t, primary, "Primary device is not nil")
+	assert.NotNil(t, secondary, "Secondary device is not nil")
+	assert.Equal(t, expectedPrimary, primary, "Primary device matches expected result")
+	assert.Equal(t, expectedSecondary, secondary, "Secondary device matches expected result")
+}
+
 func TestNetworkDevice_updateResourceData(t *testing.T) {
 	// given
 	inputPrimary := &ne.Device{

--- a/go.mod
+++ b/go.mod
@@ -131,3 +131,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/equinix/ne-go => /Users/kdhulipala/workspace/projects/terraform-kpdhulipala/ne-go


### PR DESCRIPTION
Feat: To Provide Capability to Add Secondary Device to existing Primary Device by passing 
primaryDeviceUuid Attribute in Create Virtual Device.

closes: https://github.com/equinix/ne-go/pull/32

Doc Url: https://developer.equinix.com/catalog/network-edgev1#operation/createVirtualDeviceUsingPOST