### PR TITLE
chore(ci): sweep shared connections

### DIFF
--- a/internal/resources/metal/connection/sweeper.go
+++ b/internal/resources/metal/connection/sweeper.go
@@ -29,7 +29,7 @@ func testSweepMetalConnections(region string) error {
 		return fmt.Errorf("error getting configuration for sweeping Conections: %s", err)
 	}
 	metal := config.NewMetalClientForTesting()
-	orgList, err := metal.OrganizationsApi.FindOrganizations(ctx).ExecuteWithPagination()
+	orgList, err := metal.OrganizationsApi.FindOrganizations(ctx).Exclude([]string{"address", "billing_address"}).ExecuteWithPagination()
 	if err != nil {
 		return fmt.Errorf("error getting organization list for sweeping Connections: %s", err)
 	}

--- a/internal/resources/metal/connection/sweeper.go
+++ b/internal/resources/metal/connection/sweeper.go
@@ -1,0 +1,57 @@
+package connection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
+	"github.com/equinix/terraform-provider-equinix/internal/sweep"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/packethost/packngo"
+)
+
+func AddTestSweeper() {
+	resource.AddTestSweepers("equinix_metal_connection", &resource.Sweeper{
+		Name:         "equinix_metal_connection",
+		Dependencies: []string{},
+		F:            testSweepMetalConnections,
+	})
+}
+
+func testSweepMetalConnections(region string) error {
+	var errs []error
+	log.Printf("[DEBUG] Sweeping Connections")
+	ctx := context.Background()
+	config, err := sweep.GetConfigForMetal()
+	if err != nil {
+		return fmt.Errorf("error getting configuration for sweeping Conections: %s", err)
+	}
+	metal := config.NewMetalClientForTesting()
+	orgList, err := metal.OrganizationsApi.FindOrganizations(ctx).ExecuteWithPagination()
+	if err != nil {
+		return fmt.Errorf("error getting organization list for sweeping Connections: %s", err)
+	}
+
+	for _, org := range orgList.Organizations {
+		conns, _, err := metal.InterconnectionsApi.OrganizationListInterconnections(ctx, org.GetId()).Execute()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error getting connections list for sweeping Connections: %s", err))
+			continue
+		}
+		for _, conn := range conns.GetInterconnections() {
+			if sweep.IsSweepableTestResource(conn.GetName()) {
+				if packngo.ConnectionType(conn.GetType()) != packngo.ConnectionType(metalv1.INTERCONNECTIONTYPE_DEDICATED) {
+					log.Printf("[INFO][SWEEPER_LOG] Deleting Connection: %s", conn.GetId())
+					_, _, err := metal.InterconnectionsApi.DeleteInterconnection(ctx, conn.GetId()).Execute()
+					if err != nil {
+						errs = append(errs, fmt.Errorf("error deleting VirtualCircuit: %s", err))
+					}
+				}
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/internal/resources/metal/virtual_circuit/sweeper.go
+++ b/internal/resources/metal/virtual_circuit/sweeper.go
@@ -1,6 +1,7 @@
 package virtual_circuit
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
@@ -18,24 +19,25 @@ func AddTestSweeper() {
 }
 
 func testSweepVirtualCircuits(region string) error {
+	var errs []error
 	log.Printf("[DEBUG] Sweeping VirtualCircuits")
 	config, err := sweep.GetConfigForMetal()
 	if err != nil {
-		return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting configuration for sweeping VirtualCircuits: %s", err)
+		return fmt.Errorf("error getting configuration for sweeping VirtualCircuits: %s", err)
 	}
 	metal := config.NewMetalClient()
 	orgList, _, err := metal.Organizations.List(nil)
 	if err != nil {
-		return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting organization list for sweeping VirtualCircuits: %s", err)
+		return fmt.Errorf("error getting organization list for sweeping VirtualCircuits: %s", err)
 	}
 	vcs := map[string]*packngo.VirtualCircuit{}
 	for _, org := range orgList {
 		conns, _, err := metal.Connections.OrganizationList(org.ID, &packngo.GetOptions{Includes: []string{"ports"}})
 		if err != nil {
-			return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting connections list for sweeping VirtualCircuits: %s", err)
+			errs = append(errs, fmt.Errorf("error getting connections list for sweeping VirtualCircuits: %s", err))
 		}
 		for _, conn := range conns {
-			if conn.Type != packngo.ConnectionShared {
+			if conn.Type == packngo.ConnectionDedicated {
 				for _, port := range conn.Ports {
 					for _, vc := range port.VirtualCircuits {
 						if sweep.IsSweepableTestResource(vc.Name) {
@@ -50,9 +52,9 @@ func testSweepVirtualCircuits(region string) error {
 		log.Printf("[INFO][SWEEPER_LOG] Deleting VirtualCircuit: %s", vc.Name)
 		_, err := metal.VirtualCircuits.Delete(vc.ID)
 		if err != nil {
-			return fmt.Errorf("[INFO][SWEEPER_LOG] Error deleting VirtualCircuit: %s", err)
+			errs = append(errs, fmt.Errorf("error deleting VirtualCircuit: %s", err))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }

--- a/internal/resources/metal/vlan/sweeper.go
+++ b/internal/resources/metal/vlan/sweeper.go
@@ -11,7 +11,7 @@ import (
 func AddTestSweeper() {
 	resource.AddTestSweepers("equinix_metal_vlan", &resource.Sweeper{
 		Name:         "equinix_metal_vlan",
-		Dependencies: []string{"equinix_metal_virtual_circuit", "equinix_metal_vrf", "equinix_metal_device"},
+		Dependencies: []string{"equinix_metal_connection", "equinix_metal_virtual_circuit", "equinix_metal_vrf", "equinix_metal_device"},
 		F:            testSweepVlans,
 	})
 }

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -3,6 +3,7 @@ package sweep_test
 import (
 	"testing"
 
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/connection"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/device"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/organization"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/project"
@@ -22,6 +23,7 @@ func TestMain(m *testing.M) {
 }
 
 func addTestSweepers() {
+	connection.AddTestSweeper()
 	device.AddTestSweeper()
 	organization.AddTestSweeper()
 	project.AddTestSweeper()


### PR DESCRIPTION
The sweep task fails occasionally in CI because it attempts to delete VLANs that are attached to virtual circuits that belong to shared connections.  Virtual circuits on shared connections are API-managed and can only be deleted by deleting the shared connection, but we did not have a sweeper to clean up dangling shared connections after tests.

This adds a sweeper to clean up shared connections.  New shared connection types were recently added in the API, so the sweeper checks that a connection is not "dedicated" rather than checking that it is "shared."  A similar update was made to the virtual circuit sweeper.  The VLAN sweeper has been updated to declare the new connection sweeper as a dependency to ensure that shared connections have been cleaned up before we try to clean up VLANs.