### PR TITLE
fix: correctly handle null MD5 in project BGP settings

### DIFF
--- a/internal/resources/metal/project/models.go
+++ b/internal/resources/metal/project/models.go
@@ -105,9 +105,11 @@ func parseBGPConfig(ctx context.Context, bgpConfig *metalv1.BgpConfig) fwtypes.L
 		bgpConfigResourceModel[0] = BGPConfigModel{
 			DeploymentType: types.StringValue(string(bgpConfig.GetDeploymentType())),
 			ASN:            types.Int64Value(int64(bgpConfig.GetAsn())),
-			MD5:            types.StringValue(bgpConfig.GetMd5()),
 			Status:         types.StringValue(string(bgpConfig.GetStatus())),
 			MaxPrefix:      types.Int64Value(int64(bgpConfig.GetMaxPrefix())),
+		}
+		if bgpConfig.Md5.Get() != nil {
+			bgpConfigResourceModel[0].MD5 = types.StringValue(bgpConfig.GetMd5())
 		}
 		return fwtypes.NewListNestedObjectValueOfValueSlice[BGPConfigModel](ctx, bgpConfigResourceModel)
 	}

--- a/internal/resources/metal/project/resource_test.go
+++ b/internal/resources/metal/project/resource_test.go
@@ -132,12 +132,26 @@ func TestAccMetalProject_BGPBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"equinix_metal_project.foobar", "bgp_config.0.md5",
 						"2SFsdfsg43"),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_project.foobar", "bgp_config.0.asn",
+						"65000"),
 				),
 			},
 			{
 				ResourceName:      "equinix_metal_project.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccMetalProjectConfig_BGPWithoutMD5(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalProjectExists("equinix_metal_project.foobar", &project),
+					resource.TestCheckNoResourceAttr(
+						"equinix_metal_project.foobar", "bgp_config.0.md5"),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_project.foobar", "bgp_config.0.asn",
+						"65000"),
+				),
 			},
 		},
 	})
@@ -340,6 +354,17 @@ func testAccMetalProjectConfig_basic(r int) string {
 	return fmt.Sprintf(`
 resource "equinix_metal_project" "foobar" {
     name = "tfacc-project-%d"
+}`, r)
+}
+
+func testAccMetalProjectConfig_BGPWithoutMD5(r int) string {
+	return fmt.Sprintf(`
+resource "equinix_metal_project" "foobar" {
+    name = "tfacc-project-%d"
+	bgp_config {
+		deployment_type = "local"
+		asn = 65000
+	}
 }`, r)
 }
 


### PR DESCRIPTION
During the framework migration of the project resource, we missed that the framework-based resource doesn't correctly handle null values for the `md5` attribute in BGP config.

This updates the basic project BGP test to cover that aspect of the project resource and updates the project model to avoid setting the in-state md5 value to `""` when it should be `nil`.

Closes #630 