### PR TITLE
docs: remove disclaimers about VRF being beta

### DIFF
--- a/docs/data-sources/equinix_metal_gateway.md
+++ b/docs/data-sources/equinix_metal_gateway.md
@@ -6,7 +6,7 @@ subcategory: "Metal"
 
 Use this datasource to retrieve Metal Gateway resources in Equinix Metal.
 
-~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
 ## Example Usage
 

--- a/docs/data-sources/equinix_metal_reserved_ip_block.md
+++ b/docs/data-sources/equinix_metal_reserved_ip_block.md
@@ -9,7 +9,7 @@ ID for lookup.
 
 ~> For backward compatibility, this data source can be also used for precreated (management) IP blocks.
 
-~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
 ## Example Usage
 

--- a/docs/data-sources/equinix_metal_virtual_circuit.md
+++ b/docs/data-sources/equinix_metal_virtual_circuit.md
@@ -7,7 +7,7 @@ subcategory: "Metal"
 Use this data source to retrieve a virtual circuit resource from
 [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/)
 
-~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
 ## Example Usage
 

--- a/docs/data-sources/equinix_metal_vrf.md
+++ b/docs/data-sources/equinix_metal_vrf.md
@@ -6,7 +6,7 @@ subcategory: "Metal"
 
 Use this data source to retrieve a VRF resource.
 
-~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
 ## Example Usage
 

--- a/docs/resources/equinix_metal_gateway.md
+++ b/docs/resources/equinix_metal_gateway.md
@@ -6,7 +6,7 @@ subcategory: "Metal"
 
 Use this resource to create Metal Gateway resources in Equinix Metal.
 
-~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
 ## Example Usage
 

--- a/docs/resources/equinix_metal_reserved_ip_block.md
+++ b/docs/resources/equinix_metal_reserved_ip_block.md
@@ -17,7 +17,7 @@ Addresses from global blocks can be assigned in any metro. Global blocks can hav
 
 Once IP block is allocated or imported, an address from it can be assigned to device with the `equinix_metal_ip_attachment` resource.
 
-~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
 ## Example Usage
 

--- a/docs/resources/equinix_metal_virtual_circuit.md
+++ b/docs/resources/equinix_metal_virtual_circuit.md
@@ -7,7 +7,7 @@ subcategory: "Metal"
 Use this resource to associate VLAN with a Dedicated Port from
 [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/#associating-a-vlan-with-a-dedicated-port).
 
-~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
 ## Example Usage
 

--- a/docs/resources/equinix_metal_vrf.md
+++ b/docs/resources/equinix_metal_vrf.md
@@ -6,7 +6,7 @@ subcategory: "Metal"
 
 Use this resource to manage a VRF.
 
-~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
 ## Example Usage
 


### PR DESCRIPTION
Replace this text:

> ~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.

With this:
> See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
