### PR TITLE
fix: avoid inconsistent state errors for vlans

### DIFF
--- a/internal/resources/metal/vlan/resource.go
+++ b/internal/resources/metal/vlan/resource.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	"github.com/equinix/terraform-provider-equinix/internal/framework"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/internal/resources/metal/vlan/resource.go
+++ b/internal/resources/metal/vlan/resource.go
@@ -8,7 +8,6 @@ import (
 
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	"github.com/equinix/terraform-provider-equinix/internal/framework"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -147,7 +146,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	data.Metro = types.StringValue(strings.ToLower(data.Metro.ValueString()))
 	if diag := resp.State.Set(ctx, &data); diag.HasError() {
 		resp.Diagnostics.Append(diag...)
 		return

--- a/internal/resources/metal/vlan/resource_test.go
+++ b/internal/resources/metal/vlan/resource_test.go
@@ -80,7 +80,7 @@ func TestAccMetalVlan_metro(t *testing.T) {
 			{
 				Config: testAccCheckMetalVlanConfig_metro(rs, strings.ToUpper(metro), "tfacc-vlan"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMetalVlanExists("equinix_metal_vlan.foovlan", &vlan),
+					testAccCheckMetalSameVlan("equinix_metal_vlan.foovlan", &vlan),
 					resource.TestCheckResourceAttr(
 						"equinix_metal_vlan.foovlan", "description", "tfacc-vlan"),
 					resource.TestCheckResourceAttr(
@@ -100,7 +100,7 @@ func TestAccMetalVlan_metro(t *testing.T) {
 			{
 				Config: testAccCheckMetalVlanConfig_metro(rs, strings.ToLower(upperMetro), "tfacc-vlan"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMetalVlanExists("equinix_metal_vlan.foovlan", &vlan),
+					testAccCheckMetalSameVlan("equinix_metal_vlan.foovlan", &vlan),
 					resource.TestCheckResourceAttr(
 						"equinix_metal_vlan.foovlan", "description", "tfacc-vlan"),
 					resource.TestCheckResourceAttr(
@@ -192,6 +192,24 @@ func testAccCheckMetalVlanExists(n string, vlan *packngo.VirtualNetwork) resourc
 		}
 
 		*vlan = *foundVlan
+
+		return nil
+	}
+}
+
+func testAccCheckMetalSameVlan(n string, vlan *packngo.VirtualNetwork) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		if vlan.ID != rs.Primary.ID {
+			return fmt.Errorf("VLAN was recreated.  Expected ID: %v ID in state: %v", vlan.ID, rs.Primary.ID)
+		}
 
 		return nil
 	}

--- a/internal/resources/metal/vlan/resource_test.go
+++ b/internal/resources/metal/vlan/resource_test.go
@@ -135,6 +135,42 @@ func TestAccMetalVlan_NoDescription(t *testing.T) {
 		},
 	})
 }
+
+func TestAccMetalVlan_RemoveDescription(t *testing.T) {
+	var vlan packngo.VirtualNetwork
+	rs := acctest.RandString(10)
+	metro := "sv"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalVlanCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckMetalVlanConfig_metro(rs, metro, "tfacc-vlan"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMetalVlanExists("equinix_metal_vlan.foovlan", &vlan),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_vlan.foovlan", "description", "tfacc-vlan"),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_vlan.foovlan", "metro", metro),
+				),
+			},
+			{
+				Config: testAccCheckMetalVlanConfig_NoDescription(rs, metro),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMetalVlanExists("equinix_metal_vlan.foovlan", &vlan),
+					resource.TestCheckNoResourceAttr(
+						"equinix_metal_vlan.foovlan", "description"),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_vlan.foovlan", "metro", metro),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckMetalVlanExists(n string, vlan *packngo.VirtualNetwork) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/internal/resources/metal/vlan/resource_test.go
+++ b/internal/resources/metal/vlan/resource_test.go
@@ -78,17 +78,16 @@ func TestAccMetalVlan_metro(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckMetalVlanConfig_metro(rs, strings.ToUpper(metro), "tfacc-vlan"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMetalSameVlan("equinix_metal_vlan.foovlan", &vlan),
-					resource.TestCheckResourceAttr(
-						"equinix_metal_vlan.foovlan", "description", "tfacc-vlan"),
-					resource.TestCheckResourceAttr(
-						"equinix_metal_vlan.foovlan", "metro", metro),
-				),
+				Config:   testAccCheckMetalVlanConfig_metro(rs, strings.ToUpper(metro), "tfacc-vlan"),
+				PlanOnly: true,
 			},
 			{
 				Config: testAccCheckMetalVlanConfig_metro(rs, upperMetro, "tfacc-vlan"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("equinix_metal_vlan.foovlan", plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetalVlanExists("equinix_metal_vlan.foovlan", &vlan),
 					resource.TestCheckResourceAttr(
@@ -98,14 +97,8 @@ func TestAccMetalVlan_metro(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckMetalVlanConfig_metro(rs, strings.ToLower(upperMetro), "tfacc-vlan"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMetalSameVlan("equinix_metal_vlan.foovlan", &vlan),
-					resource.TestCheckResourceAttr(
-						"equinix_metal_vlan.foovlan", "description", "tfacc-vlan"),
-					resource.TestCheckResourceAttr(
-						"equinix_metal_vlan.foovlan", "metro", upperMetro),
-				),
+				Config:   testAccCheckMetalVlanConfig_metro(rs, strings.ToLower(upperMetro), "tfacc-vlan"),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -192,24 +185,6 @@ func testAccCheckMetalVlanExists(n string, vlan *packngo.VirtualNetwork) resourc
 		}
 
 		*vlan = *foundVlan
-
-		return nil
-	}
-}
-
-func testAccCheckMetalSameVlan(n string, vlan *packngo.VirtualNetwork) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Record ID is set")
-		}
-
-		if vlan.ID != rs.Primary.ID {
-			return fmt.Errorf("VLAN was recreated.  Expected ID: %v ID in state: %v", vlan.ID, rs.Primary.ID)
-		}
 
 		return nil
 	}

--- a/internal/resources/metal/vlan/resource_test.go
+++ b/internal/resources/metal/vlan/resource_test.go
@@ -58,8 +58,8 @@ resource "equinix_metal_vlan" "foovlan" {
 func TestAccMetalVlan_metro(t *testing.T) {
 	var vlan packngo.VirtualNetwork
 	rs := acctest.RandString(10)
-	metro := "sv"
-	upperMetro := "DA"
+	lowerSiliconValley := "sv"
+	upperDallas := "DA"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
@@ -68,21 +68,24 @@ func TestAccMetalVlan_metro(t *testing.T) {
 		CheckDestroy:             testAccMetalVlanCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalVlanConfig_metro(rs, metro, "tfacc-vlan"),
+				// Create VLAN with metro "sv" (lower-case)
+				Config: testAccCheckMetalVlanConfig_metro(rs, lowerSiliconValley, "tfacc-vlan"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetalVlanExists("equinix_metal_vlan.foovlan", &vlan),
 					resource.TestCheckResourceAttr(
 						"equinix_metal_vlan.foovlan", "description", "tfacc-vlan"),
 					resource.TestCheckResourceAttr(
-						"equinix_metal_vlan.foovlan", "metro", metro),
+						"equinix_metal_vlan.foovlan", "metro", lowerSiliconValley),
 				),
 			},
 			{
-				Config:   testAccCheckMetalVlanConfig_metro(rs, strings.ToUpper(metro), "tfacc-vlan"),
+				// Confirm no changes if metro is changed to "SV" (upper-case)
+				Config:   testAccCheckMetalVlanConfig_metro(rs, strings.ToUpper(lowerSiliconValley), "tfacc-vlan"),
 				PlanOnly: true,
 			},
 			{
-				Config: testAccCheckMetalVlanConfig_metro(rs, upperMetro, "tfacc-vlan"),
+				// Recreate VLAN with metro "DA" (upper-case)
+				Config: testAccCheckMetalVlanConfig_metro(rs, upperDallas, "tfacc-vlan"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("equinix_metal_vlan.foovlan", plancheck.ResourceActionDestroyBeforeCreate),
@@ -93,11 +96,12 @@ func TestAccMetalVlan_metro(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"equinix_metal_vlan.foovlan", "description", "tfacc-vlan"),
 					resource.TestCheckResourceAttr(
-						"equinix_metal_vlan.foovlan", "metro", upperMetro),
+						"equinix_metal_vlan.foovlan", "metro", upperDallas),
 				),
 			},
 			{
-				Config:   testAccCheckMetalVlanConfig_metro(rs, strings.ToLower(upperMetro), "tfacc-vlan"),
+				// Confirm no changes if metro is changed to "da" (lower-case)
+				Config:   testAccCheckMetalVlanConfig_metro(rs, strings.ToLower(upperDallas), "tfacc-vlan"),
 				PlanOnly: true,
 			},
 		},


### PR DESCRIPTION
When the equinix_metal_vlan resource was migrated (#578) from terraform-plugin-sdk/v2 (SDKv2) to terraform-plugin-framework (framework), some unintended behavior was introduced around the description and metro attributes.

For equinix_metal_vlan resources under SDKv2, description was an optional attribute and metro was case insensitive, but after migration from SDKv2 to framework, the description was set to `""` when the attribute was omitted, and metro was required to be lower-case to avoid terraform errors.

This updates the VLAN model parsing function so that:
- if there is already metro value configured in state and it is equal to the value received from the API or from the config, ignoring case, then the value that is already in state is used instead of the value from the API
- if there is no description in the API response, the description property is omitted entirely instead of being set to an empty string

`TestAccMetalVlan_NoDescription` has been added to validate the resource behavior when the description is omitted and `TestAccMetalVlan_metro` has been updated to validate behavior when metro is specified in uppercase.

Fixes #633 