### PR TITLE
fix: Datasource-Organization: Fix data type issues.

### DIFF
--- a/internal/resources/metal/organization/datasource.go
+++ b/internal/resources/metal/organization/datasource.go
@@ -96,7 +96,10 @@ func (r *DataSource) Read(
 	}
 
 	// Set state to fully populated data
-	data.parse(ctx, orgOk)
+	resp.Diagnostics.Append(data.parse(ctx, orgOk)...)
+        if resp.Diagnostics.HasError() {
+                return
+        }
 
 	// Update the Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
No matter what I tried, I always ran into errors when usind the org datasource. E.g.

```sh
data.equinix_metal_organization.org: Reading...
╷
│ Error: Value Conversion Error
│ 
│   with data.equinix_metal_organization.org,
│   on tmp.tf line 1, in data "equinix_metal_organization" "org":
│    1: data "equinix_metal_organization" "org" {
│ 
│ An unexpected error was encountered while verifying an attribute value
│ matched its expected type to prevent unexpected behavior or panics. This is
│ always an error in the provider. Please report the following to the
│ provider developer:
│ 
│ Expected framework type from provider logic: basetypes.StringType /
│ underlying type: tftypes.String
│ Received framework type from provider logic: types.ListType[!!! MISSING
│ TYPE !!!] / underlying type: tftypes.List[tftypes.DynamicPseudoType]
│ Path: project_ids[0]
```

I looked into "similar" code and noticed that there is something different when compared to the project data source. Therefore I have no idea, if this would fix things, but maybe someone of you can have a look and do a quick test if the org datasource is even working :)


Signed-off-by: Tim Beermann <tibeer@outlook.de>
