### PR TITLE
fix: Adding ACTIVE connection state to WaitUntilConnectionDeprovisioned method for pending stage

### DIFF
--- a/equinix/resource_fabric_connection.go
+++ b/equinix/resource_fabric_connection.go
@@ -993,6 +993,7 @@ func WaitUntilConnectionDeprovisioned(uuid string, meta interface{}, d *schema.R
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			string(fabricv4.CONNECTIONSTATE_DEPROVISIONING),
+			string(fabricv4.CONNECTIONSTATE_ACTIVE),
 		},
 		Target: []string{
 			string(fabricv4.CONNECTIONSTATE_DEPROVISIONED),

--- a/equinix/resource_fabric_connection.go
+++ b/equinix/resource_fabric_connection.go
@@ -994,6 +994,7 @@ func WaitUntilConnectionDeprovisioned(uuid string, meta interface{}, d *schema.R
 		Pending: []string{
 			string(fabricv4.CONNECTIONSTATE_DEPROVISIONING),
 			string(fabricv4.CONNECTIONSTATE_ACTIVE),
+			string(fabricv4.CONNECTIONSTATE_PENDING),
 		},
 		Target: []string{
 			string(fabricv4.CONNECTIONSTATE_DEPROVISIONED),


### PR DESCRIPTION
- Added CONNECTIONSTATE_ACTIVE, CONNECTIONSTATE_PENDING to pending stage in  WaitUntilConnectionDeprovisioned method to resolve issue for Oracle Connection deletion process.