### PR TITLE
fix: Updating connectionRedundancyTerraformToGo fucntion

### DIFF
--- a/equinix/resource_fabric_connection.go
+++ b/equinix/resource_fabric_connection.go
@@ -1026,7 +1026,9 @@ func connectionRedundancyTerraformToGo(redundancyTerraform []interface{}) fabric
 	connectionPriority := redundancyMap["priority"].(string)
 	redundancyGroup := redundancyMap["group"].(string)
 	redundancy.SetPriority(fabricv4.ConnectionPriority(connectionPriority))
-	redundancy.SetGroup(redundancyGroup)
+	if redundancyGroup != "" {
+		redundancy.SetGroup(redundancyGroup)
+	}
 
 	return redundancy
 }


### PR DESCRIPTION
- Setting Redundancy group only when it's not empty