### PR TITLE
feat: convert virtual circuit resource & datasource to equinix-sdk-go

### DIFF
--- a/docs/data-sources/equinix_metal_virtual_circuit.md
+++ b/docs/data-sources/equinix_metal_virtual_circuit.md
@@ -5,7 +5,7 @@ subcategory: "Metal"
 # equinix_metal_virtual_circuit (Data Source)
 
 Use this data source to retrieve a virtual circuit resource from
-[Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/)
+[Equinix Fabric - software-defined interconnections](https://deploy.equinix.com/developers/docs/metal/interconnections/introduction/)
 
 See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
@@ -38,7 +38,7 @@ In addition to all arguments above, the following attributes are exported:
 * `port_id` - UUID of the Connection Port where the VC is scoped to.
 * `project_id` - ID of project to which the VC belongs.
 * `vnid`, `nni_vlan`, `nni_nvid` - VLAN parameters, see the
-[documentation for Equinix Fabric](https://metal.equinix.com/developers/docs/networking/fabric/).
+[documentation for Equinix Fabric](https://deploy.equinix.com/developers/docs/metal/interconnections/introduction/).
 * `description` - Description for the Virtual Circuit resource.
 * `tags` - Tags for the Virtual Circuit resource.
 * `speed` - Speed of the Virtual Circuit resource.

--- a/docs/resources/equinix_metal_virtual_circuit.md
+++ b/docs/resources/equinix_metal_virtual_circuit.md
@@ -5,7 +5,7 @@ subcategory: "Metal"
 # equinix_metal_virtual_circuit (Resource)
 
 Use this resource to associate VLAN with a Dedicated Port from
-[Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/#associating-a-vlan-with-a-dedicated-port).
+[Equinix Fabric - software-defined interconnections](https://deploy.equinix.com/developers/docs/metal/interconnections/introduction/#associating-a-vlan-with-a-dedicated-port).
 
 See the [Virtual Routing and Forwarding documentation](https://deploy.equinix.com/developers/docs/metal/layer2-networking/vrf/) for product details and API reference material.
 
@@ -67,8 +67,8 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `status` - Status of the virtal circuit.
-* `vnid` - VNID VLAN parameter, see the [documentation for Equinix Fabric](https://metal.equinix.com/developers/docs/networking/fabric/).
-* `nni_vnid` - NNI VLAN parameters, see the [documentation for Equinix Fabric](https://metal.equinix.com/developers/docs/networking/fabric/).
+* `vnid` - VNID VLAN parameter, see the [documentation for Equinix Fabric](https://deploy.equinix.com/developers/docs/metal/interconnections/introduction/).
+* `nni_vnid` - NNI VLAN parameters, see the [documentation for Equinix Fabric](https://deploy.equinix.com/developers/docs/metal/interconnections/introduction/).
 
 ## Import
 

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 	fabric_connection "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/connection"
 	fabric_network "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/network"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/virtual_circuit"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vrf"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -112,7 +113,7 @@ func Provider() *schema.Provider {
 			"equinix_metal_port":                 dataSourceMetalPort(),
 			"equinix_metal_reserved_ip_block":    dataSourceMetalReservedIPBlock(),
 			"equinix_metal_spot_market_request":  dataSourceMetalSpotMarketRequest(),
-			"equinix_metal_virtual_circuit":      dataSourceMetalVirtualCircuit(),
+			"equinix_metal_virtual_circuit":      virtual_circuit.DataSource(),
 			"equinix_metal_vrf":                  vrf.DataSource(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -139,7 +140,7 @@ func Provider() *schema.Provider {
 			"equinix_metal_reserved_ip_block":    resourceMetalReservedIPBlock(),
 			"equinix_metal_ip_attachment":        resourceMetalIPAttachment(),
 			"equinix_metal_spot_market_request":  resourceMetalSpotMarketRequest(),
-			"equinix_metal_virtual_circuit":      resourceMetalVirtualCircuit(),
+			"equinix_metal_virtual_circuit":      virtual_circuit.Resource(),
 			"equinix_metal_vrf":                  vrf.Resource(),
 			"equinix_metal_bgp_session":          resourceMetalBGPSession(),
 			"equinix_metal_port_vlan_attachment": resourceMetalPortVlanAttachment(),

--- a/equinix/resource_metal_virtual_circuit.go
+++ b/equinix/resource_metal_virtual_circuit.go
@@ -3,22 +3,21 @@ package equinix
 import (
 	"context"
 	"log"
-	"reflect"
 	"regexp"
 	"strconv"
 	"time"
 
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/equinix/terraform-provider-equinix/internal/converters"
 
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
-	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/packethost/packngo"
 )
 
 func resourceMetalVirtualCircuit() *schema.Resource {
@@ -146,74 +145,105 @@ func resourceMetalVirtualCircuit() *schema.Resource {
 }
 
 func resourceMetalVirtualCircuitCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	meta.(*config.Config).AddModuleToMetalUserAgent(d)
-	client := meta.(*config.Config).Metal
-	vncr := packngo.VCCreateRequest{
-		VirtualNetworkID: d.Get("vlan_id").(string),
-		Name:             d.Get("name").(string),
-		Description:      d.Get("description").(string),
-		Speed:            d.Get("speed").(string),
-		VRFID:            d.Get("vrf_id").(string),
-		PeerASN:          d.Get("peer_asn").(int),
-		Subnet:           d.Get("subnet").(string),
-		MetalIP:          d.Get("metal_ip").(string),
-		CustomerIP:       d.Get("customer_ip").(string),
-		MD5:              d.Get("md5").(string),
-	}
+	client := meta.(*config.Config).NewMetalClientForSDK(d)
+	vncr := metalv1.VirtualCircuitCreateInput{}
 
 	connId := d.Get("connection_id").(string)
 	portId := d.Get("port_id").(string)
 	projectId := d.Get("project_id").(string)
+	name := d.Get("name").(string)
+
+	if _, ok := d.GetOk("vlan_id"); ok {
+		vncr.VlanVirtualCircuitCreateInput = &metalv1.VlanVirtualCircuitCreateInput{
+			ProjectId:   projectId,
+			Name:        &name,
+			Description: metalv1.PtrString(d.Get("description").(string)),
+			Speed:       metalv1.PtrString(d.Get("speed").(string)),
+			Vnid:        metalv1.PtrString(d.Get("vlan_id").(string)),
+		}
+	} else {
+		vncr.VrfVirtualCircuitCreateInput = &metalv1.VrfVirtualCircuitCreateInput{
+			ProjectId:   projectId,
+			Name:        &name,
+			Description: metalv1.PtrString(d.Get("description").(string)),
+			Speed:       metalv1.PtrString(d.Get("speed").(string)),
+			Vrf:         d.Get("vrf_id").(string),
+			// TODO: woof
+			Md5:        *metalv1.NewNullableString(metalv1.PtrString(d.Get("md5").(string))),
+			PeerAsn:    int64(d.Get("peer_asn").(int)),
+			Subnet:     d.Get("subnet").(string),
+			CustomerIp: metalv1.PtrString(d.Get("customer_ip").(string)),
+			MetalIp:    metalv1.PtrString(d.Get("metal_ip").(string)),
+		}
+	}
 
 	tags := d.Get("tags.#").(int)
 	if tags > 0 {
-		vncr.Tags = converters.IfArrToStringArr(d.Get("tags").([]interface{}))
+		if _, ok := d.GetOk("vlan_id"); ok {
+			vncr.VlanVirtualCircuitCreateInput.Tags = converters.IfArrToStringArr(d.Get("tags").([]interface{}))
+		} else {
+			vncr.VrfVirtualCircuitCreateInput.Tags = converters.IfArrToStringArr(d.Get("tags").([]interface{}))
+		}
 	}
 
 	if nniVlan, ok := d.GetOk("nni_vlan"); ok {
-		vncr.NniVLAN = nniVlan.(int)
+		if _, ok := d.GetOk("vlan_id"); ok {
+			vncr.VlanVirtualCircuitCreateInput.NniVlan = metalv1.PtrInt32(int32(nniVlan.(int)))
+		} else {
+			vncr.VrfVirtualCircuitCreateInput.NniVlan = int32(nniVlan.(int))
+		}
 	}
-	conn, _, err := client.Connections.Get(connId, nil)
+
+	conn, _, err := client.InterconnectionsApi.GetInterconnection(ctx, connId).Execute()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if conn.Status == string(packngo.VCStatusPending) {
-		return diag.Errorf("Connection request with name %s and ID %s wasn't approved yet", conn.Name, conn.ID)
+	if conn.GetStatus() == string(metalv1.VLANVIRTUALCIRCUITSTATUS_PENDING) {
+		return diag.Errorf("Connection request with name %s and ID %s wasn't approved yet", conn.GetName(), conn.GetId())
 	}
 
-	vc, _, err := client.VirtualCircuits.Create(projectId, connId, portId, &vncr, nil)
+	vc, _, err := client.InterconnectionsApi.CreateInterconnectionPortVirtualCircuit(ctx, connId, portId).VirtualCircuitCreateInput(vncr).Execute()
 	if err != nil {
 		log.Printf("[DEBUG] Error creating virtual circuit: %s", err)
 		return diag.FromErr(err)
 	}
+
+	var vcId string
+
+	if vc.VlanVirtualCircuit != nil {
+		vcId = vc.VlanVirtualCircuit.GetId()
+	} else {
+		vcId = vc.VrfVirtualCircuit.GetId()
+	}
+
 	// TODO: offer to wait while VCStatusPending
 	createWaiter := getVCStateWaiter(
+		ctx,
 		client,
-		vc.ID,
+		vcId,
 		d.Timeout(schema.TimeoutCreate)-30*time.Second,
-		[]string{string(packngo.VCStatusActivating)},
-		[]string{string(packngo.VCStatusActive)},
+		[]string{string(metalv1.VLANVIRTUALCIRCUITSTATUS_ACTIVATING)},
+		[]string{string(metalv1.VLANVIRTUALCIRCUITSTATUS_ACTIVE)},
 	)
 
 	_, err = createWaiter.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("Error waiting for virtual circuit %s to be created: %s", vc.ID, err.Error())
+		return diag.Errorf("Error waiting for virtual circuit %s to be created: %s", vcId, err.Error())
 	}
 
-	d.SetId(vc.ID)
+	d.SetId(vcId)
 
 	return resourceMetalVirtualCircuitRead(ctx, d, meta)
 }
 
 func resourceMetalVirtualCircuitRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	meta.(*config.Config).AddModuleToMetalUserAgent(d)
-	client := meta.(*config.Config).Metal
+	client := meta.(*config.Config).NewMetalClientForSDK(d)
 	vcId := d.Id()
 
-	vc, _, err := client.VirtualCircuits.Get(
-		vcId,
-		&packngo.GetOptions{Includes: []string{"project", "virtual_network", "vrf"}},
-	)
+	vc, _, err := client.InterconnectionsApi.GetVirtualCircuit(ctx, vcId).
+		Include([]string{"project", "virtual_network", "vrf"}).
+		Execute()
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -221,66 +251,83 @@ func resourceMetalVirtualCircuitRead(ctx context.Context, d *schema.ResourceData
 	// TODO: use API field from VC responses when available The regexp is
 	// optimistic, not guaranteed. This affects resource imports. "port" is not
 	// in the Includes above to assure the Href needed below.
+	var portHref string
+
+	if vc.VlanVirtualCircuit != nil {
+		portHref = vc.VlanVirtualCircuit.Port.GetHref()
+	} else {
+		portHref = vc.VrfVirtualCircuit.Port.GetHref()
+	}
 	connectionID := "" // vc.Connection.ID is not available yet
 	portID := ""       // vc.Port.ID would be available with ?include=port
 	connectionRe := regexp.MustCompile("/connections/([0-9a-z-]+)/ports/([0-9a-z-]+)")
-	matches := connectionRe.FindStringSubmatch(vc.Port.Href.Href)
+	matches := connectionRe.FindStringSubmatch(portHref)
 	if len(matches) == 3 {
 		connectionID = matches[1]
 		portID = matches[2]
 	} else {
-		log.Printf("[DEBUG] Could not parse connection and port ID from port href %s", vc.Port.Href.Href)
+		log.Printf("[DEBUG] Could not parse connection and port ID from port href %s", portHref)
+	}
+	errs := &multierror.Error{}
+
+	if connectionID != "" {
+		multierror.Append(errs, d.Set("connection_id", connectionID))
+	}
+	d.Set("port_id", portID)
+
+	if vc.VlanVirtualCircuit != nil {
+		multierror.Append(errs, d.Set("project_id", vc.VlanVirtualCircuit.Project.GetId()))
+		// TODO: blarg, spec has virtual network as Href, so these attrs arent directly available
+		multierror.Append(errs, d.Set("vlan_id", vc.VlanVirtualCircuit.VirtualNetwork.AdditionalProperties["id"]))
+		multierror.Append(errs, d.Set("status", vc.VlanVirtualCircuit.GetStatus()))
+		multierror.Append(errs, d.Set("nni_vlan", vc.VlanVirtualCircuit.GetNniVlan()))
+		multierror.Append(errs, d.Set("vnid", vc.VlanVirtualCircuit.GetVnid()))
+		// TODO: this attribute isn't mentioned in the spec
+		multierror.Append(errs, d.Set("nni_vnid", vc.VlanVirtualCircuit.AdditionalProperties["nni_vnid"]))
+		multierror.Append(errs, d.Set("name", vc.VlanVirtualCircuit.GetName()))
+		multierror.Append(errs, d.Set("speed", strconv.Itoa(int(vc.VlanVirtualCircuit.GetSpeed()))))
+		multierror.Append(errs, d.Set("description", vc.VlanVirtualCircuit.GetDescription()))
+		multierror.Append(errs, d.Set("tags", vc.VlanVirtualCircuit.GetTags()))
+	} else {
+		multierror.Append(errs, d.Set("project_id", vc.VrfVirtualCircuit.Project.GetId()))
+		multierror.Append(errs, d.Set("vrf_id", vc.VrfVirtualCircuit.Vrf.GetId()))
+		multierror.Append(errs, d.Set("status", vc.VrfVirtualCircuit.GetStatus()))
+		multierror.Append(errs, d.Set("nni_vlan", vc.VrfVirtualCircuit.GetNniVlan()))
+		// TODO: this attribute isn't mentioned in the spec
+		multierror.Append(errs, d.Set("nni_vnid", vc.VrfVirtualCircuit.AdditionalProperties["nni_vnid"]))
+		multierror.Append(errs, d.Set("name", vc.VrfVirtualCircuit.GetName()))
+		multierror.Append(errs, d.Set("speed", strconv.Itoa(int(vc.VrfVirtualCircuit.GetSpeed()))))
+		multierror.Append(errs, d.Set("description", vc.VrfVirtualCircuit.GetDescription()))
+		multierror.Append(errs, d.Set("tags", vc.VrfVirtualCircuit.GetTags()))
+		multierror.Append(errs, d.Set("peer_asn", vc.VrfVirtualCircuit.GetPeerAsn()))
+		multierror.Append(errs, d.Set("subnet", vc.VrfVirtualCircuit.GetSubnet()))
+		multierror.Append(errs, d.Set("metal_ip", vc.VrfVirtualCircuit.GetMetalIp()))
+		multierror.Append(errs, d.Set("customer_ip", vc.VrfVirtualCircuit.GetCustomerIp()))
+		multierror.Append(errs, d.Set("md5", vc.VrfVirtualCircuit.GetMd5()))
 	}
 
-	err = equinix_schema.SetMap(d, map[string]interface{}{
-		"project_id": vc.Project.ID,
-		"port_id":    portID,
-		"vlan_id": func(d *schema.ResourceData, k string) error {
-			if vc.VirtualNetwork != nil {
-				return d.Set(k, vc.VirtualNetwork.ID)
-			}
-			return nil
-		},
-		"vrf_id": func(d *schema.ResourceData, k string) error {
-			if vc.VRF != nil {
-				return d.Set(k, vc.VRF.ID)
-			}
-			return nil
-		},
-		"status":      vc.Status,
-		"nni_vlan":    vc.NniVLAN,
-		"vnid":        vc.VNID,
-		"nni_vnid":    vc.NniVNID,
-		"name":        vc.Name,
-		"speed":       strconv.Itoa(vc.Speed),
-		"description": vc.Description,
-		"tags":        vc.Tags,
-		"peer_asn":    vc.PeerASN,
-		"subnet":      vc.Subnet,
-		"metal_ip":    vc.MetalIP,
-		"customer_ip": vc.CustomerIP,
-		"md5":         vc.MD5,
-		"connection_id": func(d *schema.ResourceData, k string) error {
-			if connectionID != "" {
-				return d.Set(k, connectionID)
-			}
-			return nil
-		},
-	})
-
-	return diag.FromErr(err)
+	return diag.FromErr(errs.ErrorOrNil())
 }
 
-func getVCStateWaiter(client *packngo.Client, id string, timeout time.Duration, pending, target []string) *retry.StateChangeConf {
+func getVCStateWaiter(ctx context.Context, client *metalv1.APIClient, id string, timeout time.Duration, pending, target []string) *retry.StateChangeConf {
 	return &retry.StateChangeConf{
 		Pending: pending,
 		Target:  target,
 		Refresh: func() (interface{}, string, error) {
-			vc, _, err := client.VirtualCircuits.Get(id, nil)
+			vc, resp, err := client.InterconnectionsApi.GetVirtualCircuit(ctx, id).Execute()
 			if err != nil {
+				if resp != nil {
+					err = equinix_errors.FriendlyErrorForMetalGo(err, resp)
+				}
 				return 0, "", err
 			}
-			return vc, string(vc.Status), nil
+			vcStatus := ""
+			if vc.VlanVirtualCircuit != nil {
+				vcStatus = string(vc.VlanVirtualCircuit.GetStatus())
+			} else {
+				vcStatus = string(vc.VrfVirtualCircuit.GetStatus())
+			}
+			return vc, vcStatus, nil
 		},
 		Timeout:    timeout,
 		Delay:      10 * time.Second,
@@ -289,47 +336,92 @@ func getVCStateWaiter(client *packngo.Client, id string, timeout time.Duration, 
 }
 
 func resourceMetalVirtualCircuitUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	meta.(*config.Config).AddModuleToMetalUserAgent(d)
-	client := meta.(*config.Config).Metal
+	client := meta.(*config.Config).NewMetalClientForSDK(d)
+	needsUpdate := false
 
-	ur := packngo.VCUpdateRequest{}
-	if d.HasChange("vlan_id") {
-		vnid := d.Get("vlan_id").(string)
-		ur.VirtualNetworkID = &vnid
-	}
+	ur := metalv1.VirtualCircuitUpdateInput{}
 
-	if d.HasChange("name") {
-		name := d.Get("name").(string)
-		ur.Name = &name
-	}
+	if _, ok := d.GetOk("vlan_id"); ok {
+		ur.VlanVirtualCircuitUpdateInput = &metalv1.VlanVirtualCircuitUpdateInput{}
+		if d.HasChange("vlan_id") {
+			needsUpdate = true
+			vnid := d.Get("vlan_id").(string)
+			ur.VlanVirtualCircuitUpdateInput.Vnid = &vnid
+		}
 
-	if d.HasChange("description") {
-		desc := d.Get("description").(string)
-		ur.Description = &desc
-	}
+		if d.HasChange("name") {
+			needsUpdate = true
+			name := d.Get("name").(string)
+			ur.VlanVirtualCircuitUpdateInput.Name = &name
+		}
 
-	if d.HasChange("speed") {
-		speed := d.Get("speed").(string)
-		ur.Speed = speed
-	}
+		if d.HasChange("description") {
+			needsUpdate = true
+			desc := d.Get("description").(string)
+			ur.VlanVirtualCircuitUpdateInput.Description = &desc
+		}
 
-	if d.HasChange("tags") {
-		ts := d.Get("tags")
-		sts := []string{}
+		if d.HasChange("speed") {
+			needsUpdate = true
+			speed := d.Get("speed").(string)
+			ur.VlanVirtualCircuitUpdateInput.Speed = &speed
+		}
 
-		switch ts.(type) {
-		case []interface{}:
-			for _, v := range ts.([]interface{}) {
-				sts = append(sts, v.(string))
+		if d.HasChange("tags") {
+			needsUpdate = true
+			ts := d.Get("tags")
+			sts := []string{}
+
+			switch ts.(type) {
+			case []interface{}:
+				for _, v := range ts.([]interface{}) {
+					sts = append(sts, v.(string))
+				}
+				ur.VlanVirtualCircuitUpdateInput.Tags = sts
+			default:
+				return diag.Errorf("garbage in tags: %s", ts)
 			}
-			ur.Tags = &sts
-		default:
-			return diag.Errorf("garbage in tags: %s", ts)
+		}
+	} else {
+		ur.VrfVirtualCircuitUpdateInput = &metalv1.VrfVirtualCircuitUpdateInput{}
+
+		if d.HasChange("name") {
+			needsUpdate = true
+			name := d.Get("name").(string)
+			ur.VrfVirtualCircuitUpdateInput.Name = &name
+		}
+
+		if d.HasChange("description") {
+			needsUpdate = true
+			desc := d.Get("description").(string)
+			ur.VrfVirtualCircuitUpdateInput.Description = &desc
+		}
+
+		if d.HasChange("speed") {
+			needsUpdate = true
+			speed := d.Get("speed").(string)
+			ur.VrfVirtualCircuitUpdateInput.Speed = &speed
+		}
+
+		if d.HasChange("tags") {
+			needsUpdate = true
+			ts := d.Get("tags")
+			sts := []string{}
+
+			switch ts.(type) {
+			case []interface{}:
+				for _, v := range ts.([]interface{}) {
+					sts = append(sts, v.(string))
+				}
+				ur.VrfVirtualCircuitUpdateInput.Tags = sts
+			default:
+				return diag.Errorf("garbage in tags: %s", ts)
+			}
 		}
 	}
 
-	if !reflect.DeepEqual(ur, packngo.VCUpdateRequest{}) {
-		if _, _, err := client.VirtualCircuits.Update(d.Id(), &ur, nil); err != nil {
+	if needsUpdate {
+		if _, _, err := client.InterconnectionsApi.UpdateVirtualCircuit(ctx, d.Id()).VirtualCircuitUpdateInput(ur).Execute(); err != nil {
 			return diag.FromErr(equinix_errors.FriendlyError(err))
 		}
 	}
@@ -337,24 +429,29 @@ func resourceMetalVirtualCircuitUpdate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceMetalVirtualCircuitDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	meta.(*config.Config).AddModuleToMetalUserAgent(d)
-	client := meta.(*config.Config).Metal
+	client := meta.(*config.Config).NewMetalClientForSDK(d)
 
-	resp, err := client.VirtualCircuits.Delete(d.Id())
-	if equinix_errors.IgnoreResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
-		return diag.FromErr(equinix_errors.FriendlyError(err))
+	_, resp, err := client.InterconnectionsApi.DeleteVirtualCircuit(ctx, d.Id()).Execute()
+	if err != nil {
+		if resp != nil {
+			err = equinix_errors.FriendlyErrorForMetalGo(err, resp)
+		}
+		if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+			return diag.FromErr(equinix_errors.FriendlyError(err))
+		}
 	}
 
 	deleteWaiter := getVCStateWaiter(
+		ctx,
 		client,
 		d.Id(),
 		d.Timeout(schema.TimeoutDelete)-30*time.Second,
-		[]string{string(packngo.VCStatusDeleting)},
+		[]string{string(metalv1.VLANVIRTUALCIRCUITSTATUS_DELETING)},
 		[]string{},
 	)
 
 	_, err = deleteWaiter.WaitForStateContext(ctx)
-	if equinix_errors.IgnoreResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(nil, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(nil, err) != nil {
 		return diag.Errorf("Error deleting virtual circuit %s: %s", d.Id(), err)
 	}
 	d.SetId("")

--- a/equinix/resource_metal_virtual_circuit_acc_test.go
+++ b/equinix/resource_metal_virtual_circuit_acc_test.go
@@ -1,6 +1,7 @@
 package equinix
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -17,13 +18,13 @@ const (
 )
 
 func testAccMetalVirtualCircuitCheckDestroyed(s *terraform.State) error {
-	client := testAccProvider.Meta().(*config.Config).Metal
+	client := testAccProvider.Meta().(*config.Config).NewMetalClientForTesting()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_metal_virtual_circuit" {
 			continue
 		}
-		if _, _, err := client.VirtualCircuits.Get(rs.Primary.ID, nil); err == nil {
+		if _, _, err := client.InterconnectionsApi.GetVirtualCircuit(context.Background(), rs.Primary.ID).Execute(); err == nil {
 			return fmt.Errorf("Metal VirtualCircuit still exists")
 		}
 	}

--- a/internal/resources/metal/virtual_circuit/datasource.go
+++ b/internal/resources/metal/virtual_circuit/datasource.go
@@ -46,17 +46,17 @@ func DataSource() *schema.Resource {
 			"vnid": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "VNID VLAN parameter, see https://metal.equinix.com/developers/docs/networking/fabric/",
+				Description: "VNID VLAN parameter, see https://deploy.equinix.com/developers/docs/metal/interconnections/introduction/",
 			},
 			"nni_vnid": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "Nni VLAN ID parameter, see https://metal.equinix.com/developers/docs/networking/fabric/",
+				Description: "Nni VLAN ID parameter, see https://deploy.equinix.com/developers/docs/metal/interconnections/introduction/",
 			},
 			"nni_vlan": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "Nni VLAN parameter, see https://metal.equinix.com/developers/docs/networking/fabric/",
+				Description: "Nni VLAN parameter, see https://deploy.equinix.com/developers/docs/metal/interconnections/introduction/",
 			},
 			"project_id": {
 				Type:        schema.TypeString,

--- a/internal/resources/metal/virtual_circuit/datasource.go
+++ b/internal/resources/metal/virtual_circuit/datasource.go
@@ -1,4 +1,4 @@
-package equinix
+package virtual_circuit
 
 import (
 	"context"
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceMetalVirtualCircuit() *schema.Resource {
+func DataSource() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceMetalVirtualCircuitRead,
 

--- a/internal/resources/metal/virtual_circuit/resource.go
+++ b/internal/resources/metal/virtual_circuit/resource.go
@@ -1,4 +1,4 @@
-package equinix
+package virtual_circuit
 
 import (
 	"context"
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func resourceMetalVirtualCircuit() *schema.Resource {
+func Resource() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout:   resourceMetalVirtualCircuitRead,
 		CreateContext:        resourceMetalVirtualCircuitCreate,

--- a/internal/resources/metal/virtual_circuit/resource.go
+++ b/internal/resources/metal/virtual_circuit/resource.go
@@ -128,12 +128,12 @@ func Resource() *schema.Resource {
 			"vnid": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "VNID VLAN parameter, see https://metal.equinix.com/developers/docs/networking/fabric/",
+				Description: "VNID VLAN parameter, see https://deploy.equinix.com/developers/docs/metal/interconnections/introduction/",
 			},
 			"nni_vnid": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "Nni VLAN ID parameter, see https://metal.equinix.com/developers/docs/networking/fabric/",
+				Description: "Nni VLAN ID parameter, see https://deploy.equinix.com/developers/docs/metal/interconnections/introduction/",
 			},
 			"status": {
 				Type:        schema.TypeString,

--- a/internal/resources/metal/virtual_circuit/resource_test.go
+++ b/internal/resources/metal/virtual_circuit/resource_test.go
@@ -1,4 +1,4 @@
-package equinix
+package virtual_circuit_test
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -18,7 +19,7 @@ const (
 )
 
 func testAccMetalVirtualCircuitCheckDestroyed(s *terraform.State) error {
-	client := testAccProvider.Meta().(*config.Config).NewMetalClientForTesting()
+	client := acceptance.TestAccProvider.Meta().(*config.Config).NewMetalClientForTesting()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "equinix_metal_virtual_circuit" {
@@ -80,9 +81,9 @@ func TestAccMetalVirtualCircuit_dedicated(t *testing.T) {
 	ri := acctest.RandIntRange(1024, 1093)
 
 	resource.ParallelTest(t, resource.TestCase{ // Error: Error waiting for virtual circuit 863d4df5-b3ea-46ee-8497-858cb0cbfcb9 to be created: GET https://api.equinix.com/metal/v1/virtual-circuits/863d4df5-b3ea-46ee-8497-858cb0cbfcb9?include=project%2Cport%2Cvirtual_network%2Cvrf: 500 Oh snap, something went wrong! We've logged the error and will take a look - please reach out to us if you continue having trouble.
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalVirtualCircuitCheckDestroyed,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/metal/virtual_circuit/sweeper.go
+++ b/internal/resources/metal/virtual_circuit/sweeper.go
@@ -51,7 +51,7 @@ func testSweepVirtualCircuits(region string) error {
 							vcId = vc.VrfVirtualCircuit.GetId()
 							vcName = vc.VlanVirtualCircuit.GetName()
 						}
-						if sweep.IsSweepableTestResource(vc.VlanVirtualCircuit.GetName()) {
+						if sweep.IsSweepableTestResource(vcName) {
 							log.Printf("[INFO][SWEEPER_LOG] Deleting VirtualCircuit: %s", vcName)
 							_, resp, err := metal.InterconnectionsApi.DeleteVirtualCircuit(context.Background(), vcId).Execute()
 							if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {

--- a/internal/resources/metal/virtual_circuit/sweeper.go
+++ b/internal/resources/metal/virtual_circuit/sweeper.go
@@ -29,7 +29,7 @@ func testSweepVirtualCircuits(region string) error {
 		return fmt.Errorf("error getting configuration for sweeping VirtualCircuits: %s", err)
 	}
 	metal := config.NewMetalClientForTesting()
-	orgList, err := metal.OrganizationsApi.FindOrganizations(context.Background()).ExecuteWithPagination()
+	orgList, err := metal.OrganizationsApi.FindOrganizations(context.Background()).Exclude([]string{"address", "billing_address"}).ExecuteWithPagination()
 	if err != nil {
 		return fmt.Errorf("error getting organization list for sweeping VirtualCircuits: %s", err)
 	}

--- a/internal/resources/metal/virtual_circuit/sweeper.go
+++ b/internal/resources/metal/virtual_circuit/sweeper.go
@@ -1,13 +1,16 @@
 package virtual_circuit
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
+
+	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	"github.com/equinix/terraform-provider-equinix/internal/sweep"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/packethost/packngo"
 )
 
 func AddTestSweeper() {
@@ -25,34 +28,39 @@ func testSweepVirtualCircuits(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting configuration for sweeping VirtualCircuits: %s", err)
 	}
-	metal := config.NewMetalClient()
-	orgList, _, err := metal.Organizations.List(nil)
+	metal := config.NewMetalClientForTesting()
+	orgList, err := metal.OrganizationsApi.FindOrganizations(context.Background()).ExecuteWithPagination()
 	if err != nil {
 		return fmt.Errorf("error getting organization list for sweeping VirtualCircuits: %s", err)
 	}
-	vcs := map[string]*packngo.VirtualCircuit{}
-	for _, org := range orgList {
-		conns, _, err := metal.Connections.OrganizationList(org.ID, &packngo.GetOptions{Includes: []string{"ports"}})
+	for _, org := range orgList.Organizations {
+		conns, _, err := metal.InterconnectionsApi.OrganizationListInterconnections(context.Background(), org.GetId()).Include([]string{"ports"}).Execute()
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error getting connections list for sweeping VirtualCircuits: %s", err))
 		}
-		for _, conn := range conns {
-			if conn.Type == packngo.ConnectionDedicated {
+		for _, conn := range conns.GetInterconnections() {
+			if conn.GetType() == metalv1.INTERCONNECTIONTYPE_DEDICATED {
 				for _, port := range conn.Ports {
 					for _, vc := range port.VirtualCircuits {
-						if sweep.IsSweepableTestResource(vc.Name) {
-							vcs[vc.ID] = &vc
+						vcId := ""
+						vcName := ""
+						if vc.VlanVirtualCircuit != nil {
+							vcId = vc.VlanVirtualCircuit.GetId()
+							vcName = vc.VlanVirtualCircuit.GetName()
+						} else {
+							vcId = vc.VrfVirtualCircuit.GetId()
+							vcName = vc.VlanVirtualCircuit.GetName()
+						}
+						if sweep.IsSweepableTestResource(vc.VlanVirtualCircuit.GetName()) {
+							log.Printf("[INFO][SWEEPER_LOG] Deleting VirtualCircuit: %s", vcName)
+							_, resp, err := metal.InterconnectionsApi.DeleteVirtualCircuit(context.Background(), vcId).Execute()
+							if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+								errs = append(errs, fmt.Errorf("error deleting VirtualCircuit: %s", err))
+							}
 						}
 					}
 				}
 			}
-		}
-	}
-	for _, vc := range vcs {
-		log.Printf("[INFO][SWEEPER_LOG] Deleting VirtualCircuit: %s", vc.Name)
-		_, err := metal.VirtualCircuits.Delete(vc.ID)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting VirtualCircuit: %s", err))
 		}
 	}
 


### PR DESCRIPTION
This updates the `metal_virtual_circuit` resource and data source to use `equinix-sdk-go` instead of `packngo`.  As mentioned in #402, the `packngo` SDK has been deprecated, and moving to `equinix-sdk-go` makes it possible for these resources to gain new features in the future.

As an added bonus, the affected code has also been moved to `internal/resources/metal` to align with #106.