### PR TITLE
fix: ignore HTTP errors based only on status

### DIFF
--- a/equinix/resource_metal_device.go
+++ b/equinix/resource_metal_device.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"path"
 	"reflect"
 	"regexp"
@@ -789,7 +790,7 @@ func resourceMetalDeviceDelete(ctx context.Context, d *schema.ResourceData, meta
 	start := time.Now()
 
 	resp, err := client.DevicesApi.DeleteDevice(ctx, d.Id()).ForceDelete(fdv).Execute()
-	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
 		return diag.FromErr(equinix_errors.FriendlyError(err))
 	}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -2,9 +2,11 @@ package errors
 
 import (
 	"fmt"
-	"github.com/equinix/equinix-sdk-go/services/fabricv4"
 	"net/http"
+	"slices"
 	"strings"
+
+	"github.com/equinix/equinix-sdk-go/services/fabricv4"
 
 	"github.com/equinix/rest-go"
 	"github.com/packethost/packngo"
@@ -191,19 +193,11 @@ func HasErrorCode(errors []fabricv4.Error, code string) bool {
 	return false
 }
 
-// ignoreHttpResponseErrors ignores http response errors when matched by one of the
-// provided checks
-func IgnoreHttpResponseErrors(ignore ...func(resp *http.Response, err error) bool) func(resp *http.Response, err error) error {
+// ignoreHttpResponseErrors ignores errors if the response matches
+// one of the specified status codes
+func IgnoreHttpResponseErrors(ignore ...int) func(resp *http.Response, err error) error {
 	return func(resp *http.Response, err error) error {
-		mute := false
-		for _, ignored := range ignore {
-			if ignored(resp, err) {
-				mute = true
-				break
-			}
-		}
-
-		if mute {
+		if resp != nil && slices.Contains(ignore, resp.StatusCode) {
 			return nil
 		}
 		return err

--- a/internal/resources/metal/project/resource.go
+++ b/internal/resources/metal/project/resource.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
@@ -292,7 +293,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 
 	// API call to delete the project
 	deleteResp, err := client.ProjectsApi.DeleteProject(ctx, id).Execute()
-	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(deleteResp, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(deleteResp, err) != nil {
 		err = equinix_errors.FriendlyErrorForMetalGo(err, deleteResp)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete Project %s", id),

--- a/internal/resources/metal/project_ssh_key/resource.go
+++ b/internal/resources/metal/project_ssh_key/resource.go
@@ -3,6 +3,7 @@ package project_ssh_key
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
@@ -182,7 +183,7 @@ func (r *Resource) Delete(
 
 	// Use API client to delete the resource
 	deleteResp, err := client.SSHKeysApi.DeleteSSHKey(ctx, id).Execute()
-	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(deleteResp, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(deleteResp, err) != nil {
 		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete Project SSHKey %s", id),

--- a/internal/resources/metal/ssh_key/resource.go
+++ b/internal/resources/metal/ssh_key/resource.go
@@ -3,6 +3,7 @@ package ssh_key
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
@@ -180,7 +181,7 @@ func (r *Resource) Delete(
 
 	// Use API client to delete the resource
 	deleteResp, err := client.SSHKeysApi.DeleteSSHKey(ctx, id).Execute()
-	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(deleteResp, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(deleteResp, err) != nil {
 		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete SSHKey %s", id),


### PR DESCRIPTION
The `equinix_errors.IgnoreHttpResponseErrors` function was introduced to support migration of Metal resources from `packngo` to `equinix-sdk-go`.  However, the check functions that were passed in to it (such as `equinix_errors.IsNotFound`) only work correctly for errors from `equinix-sdk-go` if the error is first converted to an `ErrorResponse` by calling `equinix_errors.FriendlyErrorForMetalGo(resp, err)`.

This updates `equinix_errors.IgnoreHttpResponseErrors` to only check the response status code.