### PR TITLE
refactor: move device resource and datasource to separate package

### DIFF
--- a/equinix/common_test.go
+++ b/equinix/common_test.go
@@ -1,0 +1,120 @@
+package equinix
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// list of plans and metros and os used as filter criteria to find available hardware to run tests
+var (
+	preferable_plans  = []string{"x1.small.x86", "t1.small.x86", "c2.medium.x86", "c3.small.x86", "c3.medium.x86", "m3.small.x86"}
+	preferable_metros = []string{"ch", "ny", "sv", "ty", "am"}
+	preferable_os     = []string{"ubuntu_20_04"}
+)
+
+// Deprecated: use the identical TestDeviceTerminationTime from internal/acceptance instead
+func testDeviceTerminationTime() string {
+	return time.Now().UTC().Add(60 * time.Minute).Format(time.RFC3339)
+}
+
+// This function should be used to find available plans in all test where a metal_device resource is needed.
+//
+// TODO consider adding a datasource for equinix_metal_operating_system and making the local.os conditional
+//
+//	https://github.com/equinix/terraform-provider-equinix/pull/220#discussion_r915418418equinix_metal_operating_system
+//	https://github.com/equinix/terraform-provider-equinix/discussions/221
+func confAccMetalDevice_base(plans, metros, os []string) string {
+	return fmt.Sprintf(`
+data "equinix_metal_plans" "test" {
+    sort {
+        attribute = "id"
+        direction = "asc"
+    }
+
+    filter {
+        attribute = "name"
+        values    = [%s]
+    }
+    filter {
+        attribute = "available_in_metros"
+        values    = [%s]
+    }
+    filter {
+        attribute = "deployment_types"
+        values    = ["on_demand", "spot_market"]
+    }
+}
+
+// Select a metal plan randomly and lock it in
+// so that we don't pick a different one for
+// every subsequent terraform plan
+resource "random_integer" "plan_idx" {
+  min = 0
+  max = length(data.equinix_metal_plans.test.plans) - 1
+}
+
+resource "terraform_data" "plan" {
+  input = data.equinix_metal_plans.test.plans[random_integer.plan_idx.result]
+
+  lifecycle {
+	ignore_changes = ["input"]
+  }
+}
+
+resource "terraform_data" "facilities" {
+  input = sort(tolist(setsubtract(terraform_data.plan.output.available_in, ["nrt1", "dfw2", "ewr1", "ams1", "sjc1", "ld7", "sy4", "ny6"])))
+
+  lifecycle {
+    ignore_changes = ["input"]
+  }
+}
+
+// Select a metal facility randomly and lock it in
+// so that we don't pick a different one for
+// every subsequent terraform plan
+resource "random_integer" "facility_idx" {
+  min = 0
+  max = length(local.facilities) - 1
+}
+
+resource "terraform_data" "facility" {
+  input = local.facilities[random_integer.facility_idx.result]
+
+  lifecycle {
+	ignore_changes = ["input"]
+  }
+}
+
+// Select a metal metro randomly and lock it in
+// so that we don't pick a different one for
+// every subsequent terraform plan
+resource "random_integer" "metro_idx" {
+  min = 0
+  max = length(local.metros) - 1
+}
+
+resource "terraform_data" "metro" {
+  input = local.metros[random_integer.metro_idx.result]
+
+  lifecycle {
+	ignore_changes = ["input"]
+  }
+}
+
+locals {
+    // Select a random plan
+    plan              = terraform_data.plan.output.slug
+
+    // Select a random facility from the facilities in which the selected plan is available, excluding decommed facilities
+    facilities             = terraform_data.facilities.output
+    facility               = terraform_data.facility.output
+
+    // Select a random metro from the metros in which the selected plan is available
+    metros             = sort(tolist(terraform_data.plan.output.available_in_metros))
+    metro              = terraform_data.metro.output
+
+    os = [%s][0]
+}
+`, fmt.Sprintf("\"%s\"", strings.Join(plans[:], `","`)), fmt.Sprintf("\"%s\"", strings.Join(metros[:], `","`)), fmt.Sprintf("\"%s\"", strings.Join(os[:], `","`)))
+}

--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -10,6 +10,7 @@ import (
 	fabric_connection "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/connection"
 	fabric_market_place_subscription "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/marketplace"
 	fabric_network "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/network"
+	metal_device "github.com/equinix/terraform-provider-equinix/internal/resources/metal/device"
 	metal_port "github.com/equinix/terraform-provider-equinix/internal/resources/metal/port"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/virtual_circuit"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vrf"
@@ -104,8 +105,8 @@ func Provider() *schema.Provider {
 			"equinix_metal_precreated_ip_block":        dataSourceMetalPreCreatedIPBlock(),
 			"equinix_metal_operating_system":           dataSourceOperatingSystem(),
 			"equinix_metal_spot_market_price":          dataSourceSpotMarketPrice(),
-			"equinix_metal_device":                     dataSourceMetalDevice(),
-			"equinix_metal_devices":                    dataSourceMetalDevices(),
+			"equinix_metal_device":                     metal_device.DataSource(),
+			"equinix_metal_devices":                    metal_device.ListDataSource(),
 			"equinix_metal_device_bgp_neighbors":       dataSourceMetalDeviceBGPNeighbors(),
 			"equinix_metal_plans":                      dataSourceMetalPlans(),
 			"equinix_metal_port":                       metal_port.DataSource(),
@@ -129,7 +130,7 @@ func Provider() *schema.Provider {
 			"equinix_network_file":               resourceNetworkFile(),
 			"equinix_metal_user_api_key":         resourceMetalUserAPIKey(),
 			"equinix_metal_project_api_key":      resourceMetalProjectAPIKey(),
-			"equinix_metal_device":               resourceMetalDevice(),
+			"equinix_metal_device":               metal_device.Resource(),
 			"equinix_metal_device_network_type":  resourceMetalDeviceNetworkType(),
 			"equinix_metal_port":                 metal_port.Resource(),
 			"equinix_metal_reserved_ip_block":    resourceMetalReservedIPBlock(),

--- a/equinix/resource_metal_spot_market_request.go
+++ b/equinix/resource_metal_spot_market_request.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"time"
@@ -20,6 +21,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/packethost/packngo"
+)
+
+var (
+	matchIPXEScript = regexp.MustCompile(`(?i)^#![i]?pxe`)
 )
 
 func resourceMetalSpotMarketRequest() *schema.Resource {
@@ -62,10 +67,7 @@ func resourceMetalSpotMarketRequest() *schema.Resource {
 					diffThreshold := .02
 					priceDiff := oldF / newF
 
-					if diffThreshold < priceDiff {
-						return true
-					}
-					return false
+					return diffThreshold < priceDiff
 				},
 			},
 			"facilities": {

--- a/internal/resources/metal/device/datasource_test.go
+++ b/internal/resources/metal/device/datasource_test.go
@@ -1,24 +1,25 @@
-package equinix
+package device_test
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDataSourceMetalDevice_basic(t *testing.T) {
-	projectName := fmt.Sprintf("ds-device-%s", acctest.RandString(10))
+	projSuffix := fmt.Sprintf("ds-device-%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceMetalDeviceConfig_basic(projectName),
+				Config: testDataSourceMetalDeviceConfig_basic(projSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.equinix_metal_device.test", "hostname", "tfacc-test-device"),
@@ -59,20 +60,20 @@ resource "equinix_metal_device" "test" {
 data "equinix_metal_device" "test" {
   project_id       = equinix_metal_project.test.id
   hostname         = equinix_metal_device.test.hostname
-}`, confAccMetalDevice_base(preferable_plans, preferable_metros, preferable_os), projSuffix, testDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, acceptance.TestDeviceTerminationTime())
 }
 
 func TestAccDataSourceMetalDevice_byID(t *testing.T) {
-	projectName := fmt.Sprintf("ds-device-by-id-%s", acctest.RandString(10))
+	projSuffix := fmt.Sprintf("ds-device-by-id-%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceMetalDeviceConfig_byID(projectName),
+				Config: testDataSourceMetalDeviceConfig_byID(projSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.equinix_metal_device.test", "hostname", "tfacc-test-device"),
@@ -112,5 +113,5 @@ resource "equinix_metal_device" "test" {
 
 data "equinix_metal_device" "test" {
   device_id       = equinix_metal_device.test.id
-}`, confAccMetalDevice_base(preferable_plans, preferable_metros, preferable_os), projSuffix, testDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, acceptance.TestDeviceTerminationTime())
 }

--- a/internal/resources/metal/device/helpers.go
+++ b/internal/resources/metal/device/helpers.go
@@ -1,4 +1,4 @@
-package equinix
+package device
 
 import (
 	"context"
@@ -71,6 +71,10 @@ func getNetworkInfo(ips []metalv1.IPAssignment) NetworkInfo {
 	return ni
 }
 
+// Deprecated: this exists for backwards compatibility with
+// packngo-based resources.  It relies on the deprecated packngo
+// SDK and either the logic from packngo should be pulled in to
+// the provider or this functionality should be removed entirely
 func getNetworkType(device *metalv1.Device) (*string, error) {
 	pgDevice := packngo.Device{}
 	res, err := device.MarshalJSON()
@@ -131,7 +135,7 @@ func hwReservationStateRefreshFunc(ctx context.Context, client *metalv1.APIClien
 	}
 }
 
-func waitUntilReservationProvisionable(ctx context.Context, client *metalv1.APIClient, reservationId, instanceId string, delay, timeout, minTimeout time.Duration) error {
+func WaitUntilReservationProvisionable(ctx context.Context, client *metalv1.APIClient, reservationId, instanceId string, delay, timeout, minTimeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{deprovisioning},
 		Target:     []string{provisionable, reprovisioned},

--- a/internal/resources/metal/device/helpers_test.go
+++ b/internal/resources/metal/device/helpers_test.go
@@ -1,7 +1,8 @@
-package equinix
+package device_test
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,9 +11,10 @@ import (
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/device"
 )
 
-func Test_waitUntilReservationProvisionable(t *testing.T) {
+func Test_WaitUntilReservationProvisionable(t *testing.T) {
 	type args struct {
 		reservationId string
 		instanceId    string
@@ -75,7 +77,11 @@ func Test_waitUntilReservationProvisionable(t *testing.T) {
 						w.Header().Add("Content-Type", "application/json")
 						w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 						w.WriteHeader(http.StatusOK)
-						w.Write(body)
+						_, err = w.Write(body)
+						if err != nil {
+							// This should never be reached and indicates a failure in the test itself
+							panic(err)
+						}
 					}
 				})(),
 			},
@@ -118,7 +124,11 @@ func Test_waitUntilReservationProvisionable(t *testing.T) {
 						w.Header().Add("Content-Type", "application/json")
 						w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 						w.WriteHeader(http.StatusOK)
-						w.Write(body)
+						_, err = w.Write(body)
+						if err != nil {
+							// This should never be reached and indicates a failure in the test itself
+							panic(err)
+						}
 					}
 				})(),
 			},
@@ -143,7 +153,11 @@ func Test_waitUntilReservationProvisionable(t *testing.T) {
 					w.Header().Add("Content-Type", "application/json")
 					w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 					w.WriteHeader(http.StatusOK)
-					w.Write(body)
+					_, err = w.Write(body)
+					if err != nil {
+						// This should never be reached and indicates a failure in the test itself
+						panic(err)
+					}
 				},
 			},
 			wantErr: true,
@@ -159,10 +173,13 @@ func Test_waitUntilReservationProvisionable(t *testing.T) {
 				BaseURL: mockAPI.URL,
 				Token:   "fakeTokenForMock",
 			}
-			meta.Load(ctx)
+			err := meta.Load(ctx)
+			if err != nil {
+				log.Printf("failed to load provider config during test: %v", err)
+			}
 
 			client := meta.NewMetalClientForTesting()
-			if err := waitUntilReservationProvisionable(ctx, client, tt.args.reservationId, tt.args.instanceId, 50*time.Millisecond, 1*time.Second, 50*time.Millisecond); (err != nil) != tt.wantErr {
+			if err := device.WaitUntilReservationProvisionable(ctx, client, tt.args.reservationId, tt.args.instanceId, 50*time.Millisecond, 1*time.Second, 50*time.Millisecond); (err != nil) != tt.wantErr {
 				t.Errorf("waitUntilReservationProvisionable() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/internal/resources/metal/device/list_datasource.go
+++ b/internal/resources/metal/device/list_datasource.go
@@ -1,4 +1,4 @@
-package equinix
+package device
 
 import (
 	"context"
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceMetalDevices() *schema.Resource {
-	dsmd := dataSourceMetalDevice()
+func ListDataSource() *schema.Resource {
+	dsmd := DataSource()
 	sch := dsmd.Schema
 	for _, v := range sch {
 		if v.Optional {

--- a/internal/resources/metal/device/list_datasource_test.go
+++ b/internal/resources/metal/device/list_datasource_test.go
@@ -1,9 +1,10 @@
-package equinix
+package device_test
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -12,9 +13,9 @@ func TestAccDataSourceMetalDevices(t *testing.T) {
 	projectName := fmt.Sprintf("ds-device-%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ExternalProviders:        testExternalProviders,
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
@@ -78,5 +79,5 @@ data "equinix_metal_devices" "test_search" {
   project_id = equinix_metal_project.test.id
   search     = "unlikelystring"
   depends_on = [equinix_metal_device.dev_search]
-}`, confAccMetalDevice_base(preferable_plans, preferable_metros, preferable_os), projSuffix, testDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, acceptance.TestDeviceTerminationTime())
 }

--- a/internal/resources/metal/device/resource.go
+++ b/internal/resources/metal/device/resource.go
@@ -1,4 +1,4 @@
-package equinix
+package device
 
 import (
 	"context"
@@ -40,7 +40,7 @@ var (
 	deviceCommonIncludes = []string{"project", "metro", "facility", "hardware_reservation"}
 )
 
-func resourceMetalDevice() *schema.Resource {
+func Resource() *schema.Resource {
 	return &schema.Resource{
 		Description: `Provides an Equinix Metal device resource. This can be used to create, modify, and delete devices.
 
@@ -51,7 +51,7 @@ func resourceMetalDevice() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 		CreateContext:      resourceMetalDeviceCreate,
-		ReadWithoutTimeout: resourceMetalDeviceRead,
+		ReadWithoutTimeout: Read,
 		UpdateContext:      resourceMetalDeviceUpdate,
 		DeleteContext:      resourceMetalDeviceDelete,
 		Importer: &schema.ResourceImporter{
@@ -563,14 +563,14 @@ func resourceMetalDeviceCreate(ctx context.Context, d *schema.ResourceData, meta
 	d.SetId(newDevice.GetId())
 
 	createTimeout := d.Timeout(schema.TimeoutCreate) - 30*time.Second - time.Since(start)
-	if err = waitForActiveDevice(ctx, d, meta, createTimeout); err != nil {
+	if err = WaitForActiveDevice(ctx, d, meta, createTimeout); err != nil {
 		return diag.FromErr(err)
 	}
 
-	return resourceMetalDeviceRead(ctx, d, meta)
+	return Read(ctx, d, meta)
 }
 
-func resourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).NewMetalClientForSDK(d)
 
 	device, resp, err := client.DevicesApi.FindDeviceById(ctx, d.Id()).Include(deviceCommonIncludes).Execute()
@@ -589,24 +589,25 @@ func resourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	d.Set("hostname", device.GetHostname())
-	d.Set("plan", device.Plan.GetSlug())
-	d.Set("deployed_facility", device.Facility.GetCode())
-	d.Set("facilities", []string{device.Facility.GetCode()})
+	var errs []error
+	errs = append(errs, d.Set("hostname", device.GetHostname()))
+	errs = append(errs, d.Set("plan", device.Plan.GetSlug()))
+	errs = append(errs, d.Set("deployed_facility", device.Facility.GetCode()))
+	errs = append(errs, d.Set("facilities", []string{device.Facility.GetCode()}))
 	if device.Metro != nil {
-		d.Set("metro", device.Metro.GetCode())
+		errs = append(errs, d.Set("metro", device.Metro.GetCode()))
 	}
-	d.Set("operating_system", device.OperatingSystem.GetSlug())
-	d.Set("state", device.GetState())
-	d.Set("billing_cycle", device.GetBillingCycle())
-	d.Set("locked", device.GetLocked())
-	d.Set("created", device.GetCreatedAt().Format(time.RFC3339))
-	d.Set("updated", device.GetUpdatedAt().Format(time.RFC3339))
-	d.Set("ipxe_script_url", device.GetIpxeScriptUrl())
-	d.Set("always_pxe", device.GetAlwaysPxe())
-	d.Set("root_password", device.GetRootPassword())
-	d.Set("project_id", device.Project.GetId())
-	d.Set("sos_hostname", device.GetSos())
+	errs = append(errs, d.Set("operating_system", device.OperatingSystem.GetSlug()))
+	errs = append(errs, d.Set("state", device.GetState()))
+	errs = append(errs, d.Set("billing_cycle", device.GetBillingCycle()))
+	errs = append(errs, d.Set("locked", device.GetLocked()))
+	errs = append(errs, d.Set("created", device.GetCreatedAt().Format(time.RFC3339)))
+	errs = append(errs, d.Set("updated", device.GetUpdatedAt().Format(time.RFC3339)))
+	errs = append(errs, d.Set("ipxe_script_url", device.GetIpxeScriptUrl()))
+	errs = append(errs, d.Set("always_pxe", device.GetAlwaysPxe()))
+	errs = append(errs, d.Set("root_password", device.GetRootPassword()))
+	errs = append(errs, d.Set("project_id", device.Project.GetId()))
+	errs = append(errs, d.Set("sos_hostname", device.GetSos()))
 	if device.Storage != nil {
 		rawStorageBytes, err := json.Marshal(device.Storage)
 		if err != nil {
@@ -617,37 +618,37 @@ func resourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.Errorf("[ERR] Error normalizing storage JSON string for device (%s): %s", d.Id(), err)
 		}
-		d.Set("storage", storageString)
+		errs = append(errs, d.Set("storage", storageString))
 	}
 	if device.HardwareReservation != nil {
-		d.Set("deployed_hardware_reservation_id", device.HardwareReservation.GetId())
+		errs = append(errs, d.Set("deployed_hardware_reservation_id", device.HardwareReservation.GetId()))
 	}
 
 	networkType, err := getNetworkType(device)
 	if err != nil {
 		return diag.Errorf("[ERR] Error computing network type for device (%s): %s", d.Id(), err)
 	}
-	d.Set("network_type", networkType)
+	errs = append(errs, d.Set("network_type", networkType))
 
 	wfrd := "wait_for_reservation_deprovision"
 	if _, ok := d.GetOk(wfrd); !ok {
-		d.Set(wfrd, nil)
+		errs = append(errs, d.Set(wfrd, nil))
 	}
 	fdv := "force_detach_volumes"
 	if _, ok := d.GetOk(fdv); !ok {
-		d.Set(fdv, nil)
+		errs = append(errs, d.Set(fdv, nil))
 	}
 	tt := "termination_time"
 	if _, ok := d.GetOk(tt); !ok {
-		d.Set(tt, nil)
+		errs = append(errs, d.Set(tt, nil))
 	}
 
-	d.Set("tags", device.Tags)
+	errs = append(errs, d.Set("tags", device.Tags))
 	keyIDs := []string{}
 	for _, k := range device.SshKeys {
 		keyIDs = append(keyIDs, path.Base(k.Href))
 	}
-	d.Set("ssh_key_ids", keyIDs)
+	errs = append(errs, d.Set("ssh_key_ids", keyIDs))
 	networkInfo := getNetworkInfo(device.IpAddresses)
 
 	sort.SliceStable(networkInfo.Networks, func(i, j int) bool {
@@ -658,19 +659,24 @@ func resourceMetalDeviceRead(ctx context.Context, d *schema.ResourceData, meta i
 		return getNetworkRank(int(famI), pubI) < getNetworkRank(int(famJ), pubJ)
 	})
 
-	d.Set("network", networkInfo.Networks)
-	d.Set("access_public_ipv4", networkInfo.PublicIPv4)
-	d.Set("access_private_ipv4", networkInfo.PrivateIPv4)
-	d.Set("access_public_ipv6", networkInfo.PublicIPv6)
+	errs = append(errs, d.Set("network", networkInfo.Networks))
+	errs = append(errs, d.Set("access_public_ipv4", networkInfo.PublicIPv4))
+	errs = append(errs, d.Set("access_private_ipv4", networkInfo.PrivateIPv4))
+	errs = append(errs, d.Set("access_public_ipv6", networkInfo.PublicIPv6))
 
 	ports := getPorts(device.NetworkPorts)
-	d.Set("ports", ports)
+	errs = append(errs, d.Set("ports", ports))
 
 	if networkInfo.Host != "" {
 		d.SetConnInfo(map[string]string{
 			"type": "ssh",
 			"host": networkInfo.Host,
 		})
+	}
+
+	err = errors.Join(errs...)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil
@@ -739,7 +745,7 @@ func resourceMetalDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	return resourceMetalDeviceRead(ctx, d, meta)
+	return Read(ctx, d, meta)
 }
 
 func doReinstall(ctx context.Context, client *metalv1.APIClient, d *schema.ResourceData, meta interface{}, start time.Time) error {
@@ -772,7 +778,7 @@ func doReinstall(ctx context.Context, client *metalv1.APIClient, d *schema.Resou
 		}
 
 		updateTimeout := d.Timeout(schema.TimeoutUpdate) - 30*time.Second - time.Since(start)
-		if err := waitForActiveDevice(ctx, d, meta, updateTimeout); err != nil {
+		if err := WaitForActiveDevice(ctx, d, meta, updateTimeout); err != nil {
 			return err
 		}
 	}
@@ -803,7 +809,7 @@ func resourceMetalDeviceDelete(ctx context.Context, d *schema.ResourceData, meta
 			// avoid "context: deadline exceeded"
 			timeout := d.Timeout(schema.TimeoutDelete) - 30*time.Second - time.Since(start)
 
-			err := waitUntilReservationProvisionable(ctx, client, resId.(string), d.Id(), 10*time.Second, timeout, 3*time.Second)
+			err := WaitUntilReservationProvisionable(ctx, client, resId.(string), d.Id(), 10*time.Second, timeout, 3*time.Second)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -812,7 +818,7 @@ func resourceMetalDeviceDelete(ctx context.Context, d *schema.ResourceData, meta
 	return nil
 }
 
-func waitForActiveDevice(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) error {
+func WaitForActiveDevice(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) error {
 	targets := []string{"active", "failed"}
 	pending := []string{"queued", "provisioning", "reinstalling"}
 
@@ -849,7 +855,7 @@ func waitForActiveDevice(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if state != "active" {
 		d.SetId("")
-		return fmt.Errorf("Device in non-active state \"%s\"", state)
+		return fmt.Errorf("device in non-active state \"%s\"", state)
 	}
 
 	return nil

--- a/internal/resources/metal/device/sweeper.go
+++ b/internal/resources/metal/device/sweeper.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -9,7 +10,6 @@ import (
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/equinix/terraform-provider-equinix/internal/sweep"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -21,7 +21,7 @@ func AddTestSweeper() {
 }
 
 func testSweepDevices(region string) error {
-	var errs error
+	var errs []error
 	log.Printf("[DEBUG] Sweeping devices")
 	ctx := context.Background()
 	config, err := sweep.GetConfigForMetal()
@@ -49,12 +49,12 @@ func testSweepDevices(region string) error {
 		for _, d := range ds.Devices {
 			err := sweepDevice(ctx, metal, d)
 			if err != nil {
-				errs = multierror.Append(errs, fmt.Errorf("Error deleting device %s", err))
+				errs = append(errs, fmt.Errorf("error deleting device %s", err))
 			}
 		}
 	}
 
-	return errs
+	return errors.Join(errs...)
 }
 
 func sweepDevice(ctx context.Context, metal *metalv1.APIClient, d metalv1.Device) error {


### PR DESCRIPTION
This moves the device resource and data sources out of the `equinix` package and into an isolated directory & package to align with #106.