### PR TITLE
fix: zSide.serviceToken.type. Unexpected value '' error message

### DIFF
--- a/internal/resources/fabric/connection/models.go
+++ b/internal/resources/fabric/connection/models.go
@@ -130,7 +130,10 @@ func serviceTokenTerraformToGo(serviceTokenList []interface{}) fabricv4.ServiceT
 	serviceTokenMap := serviceTokenList[0].(map[string]interface{})
 	serviceTokenType := serviceTokenMap["type"].(string)
 	uuid := serviceTokenMap["uuid"].(string)
-	serviceToken.SetType(fabricv4.ServiceTokenType(serviceTokenType))
+	if serviceTokenType != "" {
+		serviceToken.SetType(fabricv4.ServiceTokenType(serviceTokenType))
+	}
+
 	serviceToken.SetUuid(uuid)
 
 	return serviceToken


### PR DESCRIPTION
This checks that the serviceTokenType is only set when it is not an empty String value. 