### PR TITLE
chore: clean up debug code that is no longer needed

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"path"
@@ -40,19 +39,6 @@ const (
 
 type ProviderMeta struct {
 	ModuleName string `cty:"module_name"`
-}
-
-type DumpTransport struct {
-	r http.RoundTripper
-}
-
-func (d *DumpTransport) RoundTrip(h *http.Request) (*http.Response, error) {
-	dump, _ := httputil.DumpRequestOut(h, true)
-	fmt.Printf("****REQUEST****\n%q\n", dump)
-	resp, err := d.r.RoundTrip(h)
-	dump, _ = httputil.DumpResponse(resp, true)
-	fmt.Printf("****RESPONSE****\n%q\n****************\n\n", dump)
-	return resp, err
 }
 
 const (
@@ -207,7 +193,6 @@ func (c *Config) newFabricClient() *fabricv4.APIClient {
 // Deprecated: migrate to NewMetalClientForSdk or NewMetalClientForFramework instead
 func (c *Config) NewMetalClient() *packngo.Client {
 	transport := http.DefaultTransport
-	// transport = &DumpTransport{http.DefaultTransport} // Debug only
 	transport = logging.NewTransport("Equinix Metal (packngo)", transport)
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient.Transport = transport

--- a/internal/resources/metal/organization/resource.go
+++ b/internal/resources/metal/organization/resource.go
@@ -155,9 +155,6 @@ func (r *Resource) Update(
 		return
 	}
 
-	fmt.Printf("state: %v\n", state)
-	fmt.Printf("plan: %v\n", plan)
-
 	// Extract the ID of the resource from the state
 	id := plan.ID.ValueString()
 


### PR DESCRIPTION
This removes some unnecessary print statements for debugging the organization resource as well as the unused `DumpTransport` type.  The functionality of the `DumpTransport` type is already available by setting `TF_LOG=debug` and doesn't require a custom implementation.