### PR TITLE
fix: Fix provider crash when creating a metal gateway tied to an ipv6 reservation

### DIFF
--- a/internal/resources/metal/gateway/models.go
+++ b/internal/resources/metal/gateway/models.go
@@ -33,7 +33,9 @@ func (m *ResourceModel) parse(gw *metalv1.FindMetalGatewayById200Response) diag.
 			m.IPReservationID = types.StringNull()
 		}
 
-		m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.MetalGateway.IpReservation)
+		if shouldCalculateSubnetSize(gw.MetalGateway.IpReservation) {
+			m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.MetalGateway.IpReservation)
+		}
 		m.State = types.StringValue(string(gw.MetalGateway.GetState()))
 	} else {
 		m.ID = types.StringValue(gw.VrfMetalGateway.GetId())
@@ -47,7 +49,9 @@ func (m *ResourceModel) parse(gw *metalv1.FindMetalGatewayById200Response) diag.
 			m.IPReservationID = types.StringNull()
 		}
 
-		m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.VrfMetalGateway.IpReservation)
+		if shouldCalculateSubnetSize(gw.VrfMetalGateway.IpReservation) {
+			m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.VrfMetalGateway.IpReservation)
+		}
 		m.State = types.StringValue(string(gw.VrfMetalGateway.GetState()))
 	}
 	return nil
@@ -78,7 +82,7 @@ func (m *DataSourceModel) parse(gw *metalv1.FindMetalGatewayById200Response) dia
 			m.IPReservationID = types.StringNull()
 		}
 
-		if *gw.MetalGateway.IpReservation.AddressFamily == 4 && *gw.MetalGateway.IpReservation.Public {
+		if shouldCalculateSubnetSize(gw.MetalGateway.IpReservation) {
 			m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.MetalGateway.IpReservation)
 		}
 		m.State = types.StringValue(string(gw.MetalGateway.GetState()))
@@ -95,7 +99,9 @@ func (m *DataSourceModel) parse(gw *metalv1.FindMetalGatewayById200Response) dia
 			m.IPReservationID = types.StringNull()
 		}
 
-		m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.VrfMetalGateway.IpReservation)
+		if shouldCalculateSubnetSize(gw.MetalGateway.IpReservation) {
+			m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.VrfMetalGateway.IpReservation)
+		}
 		m.State = types.StringValue(string(gw.VrfMetalGateway.GetState()))
 	}
 	return nil
@@ -104,6 +110,11 @@ func (m *DataSourceModel) parse(gw *metalv1.FindMetalGatewayById200Response) dia
 type ipReservationCommon interface {
 	GetCidr() int32
 	GetPublic() bool
+	GetAddressFamily() int32
+}
+
+func shouldCalculateSubnetSize(ip ipReservationCommon) bool {
+	return ip.GetAddressFamily() == 4 && ip.GetPublic()
 }
 
 func calculateSubnetSize(ip ipReservationCommon) basetypes.Int64Value {

--- a/internal/resources/metal/gateway/models.go
+++ b/internal/resources/metal/gateway/models.go
@@ -33,9 +33,7 @@ func (m *ResourceModel) parse(gw *metalv1.FindMetalGatewayById200Response) diag.
 			m.IPReservationID = types.StringNull()
 		}
 
-		if shouldCalculateSubnetSize(gw.MetalGateway.IpReservation) {
-			m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.MetalGateway.IpReservation)
-		}
+		m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.MetalGateway.IpReservation)
 		m.State = types.StringValue(string(gw.MetalGateway.GetState()))
 	} else {
 		m.ID = types.StringValue(gw.VrfMetalGateway.GetId())
@@ -49,9 +47,7 @@ func (m *ResourceModel) parse(gw *metalv1.FindMetalGatewayById200Response) diag.
 			m.IPReservationID = types.StringNull()
 		}
 
-		if shouldCalculateSubnetSize(gw.VrfMetalGateway.IpReservation) {
-			m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.VrfMetalGateway.IpReservation)
-		}
+		m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.VrfMetalGateway.IpReservation)
 		m.State = types.StringValue(string(gw.VrfMetalGateway.GetState()))
 	}
 	return nil
@@ -82,9 +78,7 @@ func (m *DataSourceModel) parse(gw *metalv1.FindMetalGatewayById200Response) dia
 			m.IPReservationID = types.StringNull()
 		}
 
-		if shouldCalculateSubnetSize(gw.MetalGateway.IpReservation) {
-			m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.MetalGateway.IpReservation)
-		}
+		m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.MetalGateway.IpReservation)
 		m.State = types.StringValue(string(gw.MetalGateway.GetState()))
 	} else {
 		// Convert Metal Gateway data to the Terraform state
@@ -99,9 +93,7 @@ func (m *DataSourceModel) parse(gw *metalv1.FindMetalGatewayById200Response) dia
 			m.IPReservationID = types.StringNull()
 		}
 
-		if shouldCalculateSubnetSize(gw.MetalGateway.IpReservation) {
-			m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.VrfMetalGateway.IpReservation)
-		}
+		m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.VrfMetalGateway.IpReservation)
 		m.State = types.StringValue(string(gw.VrfMetalGateway.GetState()))
 	}
 	return nil
@@ -113,13 +105,9 @@ type ipReservationCommon interface {
 	GetAddressFamily() int32
 }
 
-func shouldCalculateSubnetSize(ip ipReservationCommon) bool {
-	return ip.GetAddressFamily() == 4 && ip.GetPublic()
-}
-
 func calculateSubnetSize(ip ipReservationCommon) basetypes.Int64Value {
 	privateIPv4SubnetSize := uint64(0)
-	if !ip.GetPublic() {
+	if !ip.GetPublic() && ip.GetAddressFamily() == 4 {
 		privateIPv4SubnetSize = 1 << (32 - ip.GetCidr())
 		return types.Int64Value(int64(privateIPv4SubnetSize))
 	}

--- a/internal/resources/metal/gateway/models.go
+++ b/internal/resources/metal/gateway/models.go
@@ -78,7 +78,9 @@ func (m *DataSourceModel) parse(gw *metalv1.FindMetalGatewayById200Response) dia
 			m.IPReservationID = types.StringNull()
 		}
 
-		m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.MetalGateway.IpReservation)
+		if *gw.MetalGateway.IpReservation.AddressFamily == 4 && *gw.MetalGateway.IpReservation.Public {
+			m.PrivateIPv4SubnetSize = calculateSubnetSize(gw.MetalGateway.IpReservation)
+		}
 		m.State = types.StringValue(string(gw.MetalGateway.GetState()))
 	} else {
 		// Convert Metal Gateway data to the Terraform state

--- a/internal/resources/metal/gateway/resource_test.go
+++ b/internal/resources/metal/gateway/resource_test.go
@@ -169,3 +169,61 @@ func TestAccMetalGateway_upgradeFromVersion(t *testing.T) {
 		},
 	})
 }
+
+func TestAccMetalGateway_IPv6Vrf(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMetalGatewayCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalGatewayConfig_IPv6Vrf(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_gateway.test", "project_id",
+						"equinix_metal_project.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMetalGatewayConfig_IPv6Vrf() string {
+	return `
+resource "equinix_metal_project" "test" {
+    name = "tfacc-gateway-test"
+}
+
+resource "equinix_metal_vlan" "test" {
+    description = "tfacc-vlan VLAN in SV"
+    metro       = "sv"
+    project_id  = equinix_metal_project.test.id
+}
+
+resource "equinix_metal_vrf" "test" {
+  description = "tfacc-vrf VRF in SV"
+  name = "tfacc-vrf"
+  metro       = "sv"
+  local_asn   = "65000"
+  ip_ranges   = ["2001:d78::/59"]
+
+  project_id  = equinix_metal_project.test.id
+}
+
+resource "equinix_metal_reserved_ip_block" "test" {
+  project_id = equinix_metal_project.test.id
+  type       = "vrf"
+  vrf_id     = equinix_metal_vrf.test.id
+  network    = "2001:d78::"
+  metro      = "sv"
+  cidr       = 64
+}
+
+resource "equinix_metal_gateway" "test" {
+    project_id               = equinix_metal_project.test.id
+    vlan_id                  = equinix_metal_vlan.test.id
+    ip_reservation_id        = equinix_metal_reserved_ip_block.test.id
+}
+`
+}

--- a/internal/resources/metal/gateway/resource_test.go
+++ b/internal/resources/metal/gateway/resource_test.go
@@ -183,6 +183,9 @@ func TestAccMetalGateway_IPv6Vrf(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						"equinix_metal_gateway.test", "project_id",
 						"equinix_metal_project.test", "id"),
+					resource.TestCheckResourceAttrPair(
+						"equinix_metal_gateway.test", "ip_reservation_id",
+						"equinix_metal_reserved_ip_block.test", "id"),
 				),
 			},
 		},


### PR DESCRIPTION
This PR fixes a bug when creating metal gateways associated with IPv6 reservations. Previously the provider would assume the gateway was tied to an IPv4 reservation, which would result in an error when the `calculateSubnetSize` function was called. 

To fix this, an additional check was added to the `calculateSubnetSize` function which ensures the address is actually `IPv4` before executing the private ipv4 subnet logic.

Additionally an acceptance test was added which creates a metal gateway associated with an IPv6 reservation and VRF.