### PR TITLE
chore(ci): convert to a push-button release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,5 @@
-# This GitHub action can publish assets for release when a tag is created.
-# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
-#
-# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your
-# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
-# secret. If you would rather own your own GPG handling, please fork this action
-# or use an alternative one for key handling.
-#
-# You will need to pass the `--batch` flag to `gpg` in your signing step
-# in `goreleaser` to indicate this is being used in a non-interactive mode.
-#
-name: release
+name: Generate Next Release
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -41,6 +27,17 @@ jobs:
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         passphrase: ${{ secrets.PASSPHRASE }}
+
+    - name: Release
+      uses: cycjimmy/semantic-release-action@v3
+      with:
+        semantic_version: 19.0.5
+        extra_plugins: |
+          @semantic-release/exec@6.0.3
+          @semantic-release/git@10.0.0
+          conventional-changelog-conventionalcommits@4.6.3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,7 +87,6 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-  # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
+  mode: "keep-existing"
 changelog:
   disable: true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,37 @@
+{
+  "branches": [
+    "main"
+  ],
+  "ci": false,
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
+        "labels": false,
+        "releasedLabels": false
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "message": "ci: regenerate code for version ${nextRelease.version}",
+        "assets": [
+          "."
+        ]
+      }
+    ]
+  ]
+}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+# Release Instructions
+
+These build and release instructions are intended for the maintainers and future maintainers of this project.
+
+## Preparing a new version
+
+There are no preparation steps.
+
+* the version is computed from [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) tags
+* There is no changelog; the GitHub release notes are generated based on [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) tags 
+
+## Releasing
+
+Run the GitHub Actions [Release Workflow](.github/workflows/release.yml) on the `main` branch.
+
+The release workflow:
+- Uses [Semantic Release](.releaserc.json) to determine the next version number and create the GitHub release
+- Uses [GoReleaser](.goreleaser.yml) to build the terraform provider plugins and attach them to the GitHub release
+
+This will build and release plugins for several different OS and Architecture combinations.
+
+Any special instructions or notes should be added by editing the release notes that the workflow publishes. These notes can be found at https://github.com/equinix/terraform-provider-equinix/releases


### PR DESCRIPTION
Currently, the release workflow requires someone to manually inspect the changes since the last release, decide on a good version number to use, create that tag locally, and push it to GitHub to trigger a release.

Instead, this follows the pattern established with our generated SDKs, which use Conventional Commits tags to automatically determine the next release version and construct the release notes for the GitHub release.

The updated push-button workflow creates the correct release automatically and then runs the pre-existing goreleaser action to attach the terraform provider builds to the existing GitHub release.