### PR TITLE
chore(ci): lint with golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,6 +25,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          args: --whole-files # Remove alogn with only-new-issues by 2025
+          args: --whole-files # Remove along with only-new-issues by 2025
           version: ${{ steps.golangcilint.outputs.version }}
           only-new-issues: true # Remove along with pull-requests: read permission by 2025

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Determine golangci-lint version
         id: golangcilint
         run: |
-          line=$(grep GOLANGCI_LINT_VERSION= Makefile)
+          line=$(grep GOLANGCI_LINT_VERSION= GNUmakefile)
           version=$(echo ${line} | cut -d = -f2)
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: golangci-lint

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,27 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Determine golangci-lint version
+        id: golangcilint
+        run: |
+          line=$(grep GOLANGCI_LINT_VERSION= Makefile)
+          version=$(echo ${line} | cut -d = -f2)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: ${{ steps.golangcilint.outputs.version }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 permissions:
   contents: read
+  pull-requests: read # Remove along with only-new-issues by 2025
 jobs:
   golangci:
     name: lint
@@ -24,4 +25,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
+          args: --whole-files # Remove alogn with only-new-issues by 2025
           version: ${{ steps.golangcilint.outputs.version }}
+          only-new-issues: true # Remove along with pull-requests: read permission by 2025

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,11 @@
+run:
+  modules-download-mode: readonly
+linters:
+  enable:
+    - errcheck
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,7 @@
 run:
   modules-download-mode: readonly
+  skip-dirs:
+    - cmd/migration-tool
 linters:
   enable:
     - errcheck

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,6 +11,12 @@ ACCTEST_COUNT       ?= 1
 GOFMT_FILES         ?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME            =equinix
 
+CRI=docker
+CRI_COMMAND_BASE=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} $(DOCKER_EXTRA_ARGS)
+GOLANGCI_LINT_VERSION=v1.56
+GOLANGCI_LINT_IMAGE=golangci/golangci-lint:${GOLANGCI_LINT_VERSION}
+GOLANGCI_LINT=${CRI_COMMAND_BASE} -v $(CURDIR):/app -w /app -e GOLANGCI_LINT_CACHE=/tmp/.cache -e GOCACHE=/tmp/.cache ${GOLANGCI_LINT_IMAGE} golangci-lint
+
 ifneq ($(origin TESTS_REGEXP), undefined)
 	TESTARGS = -run='$(TESTS_REGEXP)'
 endif
@@ -45,6 +51,8 @@ clean:
 	${GOCMD} clean
 	rm -f ${BINARY}
 
+lint:
+	${GOLANGCI_LINT} run -v
 
 vet:
 	@echo "go vet ."
@@ -117,4 +125,4 @@ tfproviderdocs-check:
 		echo "Unexpected issues found in code with bflad/tfproviderdocs."; \
 		exit 1)
 
-.PHONY: test testacc build install clean  fmt fmtcheck errcheck test-compile docs-lint docs-lint-fix tfproviderlint tfproviderlint-fix tfproviderdocs-check
+.PHONY: test testacc build install clean lint fmt fmtcheck errcheck test-compile docs-lint docs-lint-fix tfproviderlint tfproviderlint-fix tfproviderdocs-check

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,11 +11,8 @@ ACCTEST_COUNT       ?= 1
 GOFMT_FILES         ?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME            =equinix
 
-CRI=docker
-CRI_COMMAND_BASE=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} $(DOCKER_EXTRA_ARGS)
 GOLANGCI_LINT_VERSION=v1.56
-GOLANGCI_LINT_IMAGE=golangci/golangci-lint:${GOLANGCI_LINT_VERSION}
-GOLANGCI_LINT=${CRI_COMMAND_BASE} -v $(CURDIR):/app -w /app -e GOLANGCI_LINT_CACHE=/tmp/.cache -e GOCACHE=/tmp/.cache ${GOLANGCI_LINT_IMAGE} golangci-lint
+GOLANGCI_LINT=go run github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 
 ifneq ($(origin TESTS_REGEXP), undefined)
 	TESTARGS = -run='$(TESTS_REGEXP)'


### PR DESCRIPTION
This introduces linting in CI to help maintain code quality and identify issues that may not be caught by tests.  To avoid a big PR that resolves all existing linting issues, the CI workflow is configured to only look at files that are changed in a particular PR or commit; we'll need to keep an eye on this to make sure it's working as expected.  This will allow us to chip away at existing issues over time.  Eventually (ideally within a few months), the CI workflow should be updated to always lint the entire codebase.

This PR also introduces a `make lint` task for local execution, but this task lints the entire codebase and, for the time being, will catch some issues that are not flagged for a particular PR or commit in CI.