### PR TITLE
chore: allow continued use of stop context for now

### DIFF
--- a/equinix/provider.go
+++ b/equinix/provider.go
@@ -183,6 +183,11 @@ func configureProvider(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 		config.TerraformVersion = "0.11+compatible"
 	}
 
+	// We need to keep using a global stop context until
+	// all resources and data sources are updated to use
+	// context-aware CRUD functions, which should happen
+	// gradually due to linting on those files
+	// nolint:staticcheck
 	stopCtx, ok := schema.StopContext(ctx)
 	if !ok {
 		stopCtx = ctx


### PR DESCRIPTION
The linter will complain if any changes are made in `equinix/provider.go` because we are using a deprecated stop context for coordinated shutdown across resources.  We have to continue using a stop context until all resources and data sources are updated to use context-aware CRUD functions.  This disables staticcheck for the relevant line of code and adds a comment explaining why linting was disabled in this case.