### PR TITLE
refactor: switch to subsystem loggers for HTTP logging

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,10 +16,11 @@ import (
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/equinix/ne-go"
 	"github.com/equinix/oauth2-go"
+	"github.com/equinix/terraform-provider-equinix/internal/logging"
 	"github.com/equinix/terraform-provider-equinix/version"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/packethost/packngo"
 	xoauth2 "golang.org/x/oauth2"
@@ -32,6 +33,17 @@ const (
 	ClientTokenEnvVar    = "EQUINIX_API_TOKEN"
 	ClientTimeoutEnvVar  = "EQUINIX_API_TIMEOUT"
 	MetalAuthTokenEnvVar = "METAL_AUTH_TOKEN"
+
+	// This is the initial env var for HTTP logging for backwards
+	// compatibility.  We could now introduce service-specific
+	// variables, if desired, for more granular control of logging
+	HTTPLoggingEnvVar = "TF_LOG"
+
+	// Subsystems for API client logging
+	packetClientSubsystem  = "Equinix Metal (packngo)"
+	equinixClientSubsystem = "Equinix"
+	metalClientSubsystem   = "Equinix Metal (metal-go)"
+	fabricClientSubsystem  = "Equinix Fabric (fabricv4)"
 )
 
 type ProviderMeta struct {
@@ -39,14 +51,18 @@ type ProviderMeta struct {
 }
 
 const (
-	consumerToken = "aZ9GmqHTPtxevvFq9SK3Pi2yr9YCbRzduCSXF2SNem5sjB91mDq7Th3ZwTtRqMWZ"
-	metalBasePath = "/metal/v1/"
-	uaEnvVar      = "TF_APPEND_USER_AGENT"
+	consumerToken        = "aZ9GmqHTPtxevvFq9SK3Pi2yr9YCbRzduCSXF2SNem5sjB91mDq7Th3ZwTtRqMWZ"
+	metalBasePath        = "/metal/v1/"
+	uaEnvVar             = "TF_APPEND_USER_AGENT"
+	authorizationHeader  = "Authorization"
+	metalAuthTokenHeader = "X-Auth-Token"
 )
 
 var (
-	DefaultBaseURL = "https://api.equinix.com"
-	DefaultTimeout = 30
+	DefaultBaseURL       = "https://api.equinix.com"
+	DefaultTimeout       = 30
+	HTTPLogLevel         = hclog.LevelFromString(os.Getenv(HTTPLoggingEnvVar))
+	sensitiveHTTPHeaders = []string{authorizationHeader, metalAuthTokenHeader}
 )
 
 // Config is the configuration structure used to instantiate the Equinix
@@ -99,11 +115,9 @@ func (c *Config) Load(ctx context.Context) error {
 	}
 
 	authClient.Timeout = c.requestTimeout()
-	//nolint:staticcheck // We should move to subsystem loggers, but that is a much bigger change
-	authClient.Transport = logging.NewTransport("Equinix", authClient.Transport)
+	authClient.Transport = logging.NewHTTPLoggingTransport(equinixClientSubsystem, authClient.Transport, sensitiveHTTPHeaders, HTTPLogLevel)
 	c.authClient = authClient
 	neClient := ne.NewClient(ctx, c.BaseURL, authClient)
-
 	if c.PageSize > 0 {
 		neClient.SetPageSize(c.PageSize)
 	}
@@ -141,8 +155,7 @@ func (c *Config) NewFabricClientForTesting() *fabricv4.APIClient {
 // newFabricClient returns the base fabricv4 client that is then used for either the sdkv2 or framework
 // implementations of the Terraform Provider with exported Methods
 func (c *Config) newFabricClient() *fabricv4.APIClient {
-	//nolint:staticcheck // We should move to subsystem loggers, but that is a much bigger change
-	transport := logging.NewTransport("Equinix Fabric (fabricv4)", c.authClient.Transport)
+	transport := logging.NewHTTPLoggingTransport(fabricClientSubsystem, c.authClient.Transport, sensitiveHTTPHeaders, HTTPLogLevel)
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient.Transport = transport
@@ -172,8 +185,7 @@ func (c *Config) newFabricClient() *fabricv4.APIClient {
 // Deprecated: migrate to NewMetalClientForSdk or NewMetalClientForFramework instead
 func (c *Config) NewMetalClient() *packngo.Client {
 	transport := http.DefaultTransport
-	//nolint:staticcheck // We should move to subsystem loggers, but that is a much bigger change
-	transport = logging.NewTransport("Equinix Metal (packngo)", transport)
+	transport = logging.NewHTTPLoggingTransport(packetClientSubsystem, transport, sensitiveHTTPHeaders, HTTPLogLevel)
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient.Transport = transport
 	retryClient.RetryMax = c.MaxRetries
@@ -219,8 +231,7 @@ func (c *Config) NewMetalClientForTesting() *metalv1.APIClient {
 
 func (c *Config) newMetalClient() *metalv1.APIClient {
 	transport := http.DefaultTransport
-	//nolint:staticcheck // We should move to subsystem loggers, but that is a much bigger change
-	transport = logging.NewTransport("Equinix Metal (metal-go)", transport)
+	transport = logging.NewHTTPLoggingTransport(metalClientSubsystem, transport, sensitiveHTTPHeaders, HTTPLogLevel)
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient.Transport = transport
 	retryClient.RetryMax = c.MaxRetries
@@ -238,7 +249,7 @@ func (c *Config) newMetalClient() *metalv1.APIClient {
 		},
 	}
 	configuration.HTTPClient = standardClient
-	configuration.AddDefaultHeader("X-Auth-Token", c.AuthToken)
+	configuration.AddDefaultHeader(metalAuthTokenHeader, c.AuthToken)
 	client := metalv1.NewAPIClient(configuration)
 	return client
 }

--- a/internal/logging/transport.go
+++ b/internal/logging/transport.go
@@ -1,0 +1,36 @@
+package logging
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+)
+
+type HTTPLoggingTransport struct {
+	subsystem       string
+	transport       http.RoundTripper
+	sensitiveFields []string
+	level           hclog.Level
+}
+
+var _ http.RoundTripper = (*HTTPLoggingTransport)(nil)
+
+func NewHTTPLoggingTransport(subsystem string, transport http.RoundTripper, sensitiveFields []string, level hclog.Level) *HTTPLoggingTransport {
+	return &HTTPLoggingTransport{
+		subsystem:       subsystem,
+		transport:       logging.NewSubsystemLoggingHTTPTransport(subsystem, transport),
+		sensitiveFields: sensitiveFields,
+		level:           level,
+	}
+}
+
+func (t *HTTPLoggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	ctx := tflog.NewSubsystem(r.Context(), t.subsystem, tflog.WithLevel(t.level))
+	ctx = tflog.SubsystemMaskFieldValuesWithFieldKeys(ctx, t.subsystem, t.sensitiveFields...)
+
+	requestWithSubsystem := r.WithContext(ctx)
+
+	return t.transport.RoundTrip(requestWithSubsystem)
+}


### PR DESCRIPTION
This addresses a linting issue that was bypassed in #736 to constrain the scope of that PR.  The logging transport we were previously using for HTTP clients is deprecated, but the new Terraform logging plugin is more context-aware and requires--or at least enables--specifying separate subsystems for each provider component that will write logs.

This adds a new `HTTPLoggingTransport` type that encapsulates the logic of creating a subsystem HTTP logging transport, ensuring the necessary subsystem exists in any relevant HTTP request context, and masking any sensitive values in the request.

The `Config` type is updated to create a separate `HTTPLoggingTransport` for each API client.  For now, the log level for all of the new transports is wired up to the `TF_LOG` environment variable.  This matches the previous behavior of the deprecated HTTP logging transport.