### PR TITLE
chore(docs): fix badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,10 @@ The Terraform Equinix provider is a plugin for Terraform that allows for lifecyc
 management of Equinix Platform resources.
 
 [![Go Tests](https://github.com/equinix/terraform-provider-equinix/actions/workflows/test.yml/badge.svg)](https://github.com/equinix/terraform-provider-equinix/actions/workflows/test.yml)
-[![Acceptance Tests](https://github.com/equinix/terraform-provider-equinix/actions/workflows/acctest.yml/badge.svg)](https://github.com/equinix/terraform-provider-equinix/actions/workflows/acctest.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/equinix/terraform-provider-equinix)](https://goreportcard.com/report/github.com/equinix/terraform-provider-equinix)
 [![GoDoc](https://godoc.org/github.com/go-resty/resty?status.svg)](https://godoc.org/github.com/equinix/terraform-provider-equinix)
 ![GitHub](https://img.shields.io/github/license/equinix/terraform-provider-equinix)
-
-[![Equinix Metal Slack](https://slack.equinixmetal.com/badge.svg)](https://slack.equinixmetal.com)
-[![Equinix Metal Twitter](https://img.shields.io/twitter/follow/equinixmetal.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=equinixmetal)
+[![Equinix Community](https://img.shields.io/badge/Equinix%20Community-E8272C.svg)](https://[https://community.equinix.com/](https://community.equinix.com/))
 
 ---
 


### PR DESCRIPTION
The Metal acceptance test workflow was renamed.  This removes the broken badge rather than adding working badges for the Metal and Fabric acceptance test workflows because both of those are failing at the moment, and advertising that is probably counterproductive.

This also replaces the Metal Slack & Twitter badges with an Equinix Community badge, since the provider covers more than just Metal and Community is the place to go for cross-product discussion.