### PR TITLE
chore(ci): tell golangci-lint to report all issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,5 @@
 run:
   modules-download-mode: readonly
-  skip-dirs:
-    - cmd/migration-tool
 linters:
   enable:
     - errcheck
@@ -11,3 +9,8 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-dirs:
+    - cmd/migration-tool

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,7 @@ ACCTEST_COUNT       ?= 1
 GOFMT_FILES         ?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME            =equinix
 
-GOLANGCI_LINT_VERSION=v1.56
+GOLANGCI_LINT_VERSION=v1.60
 GOLANGCI_LINT=go run github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 
 ifneq ($(origin TESTS_REGEXP), undefined)


### PR DESCRIPTION
By default, golangci-lint will only report a certain number of issues per linter and a certain number of the same issue per run.  That adds unnecessary turnaround time when fixing issues.

This PR updates our golangci-lint config file to tell the linter to report all errors.

The golangci-lint config structure has changed quite a bit since v1.56, so rather than fight their docs I'm also upgrading the linter to the latest.