### PR TITLE
fix: use pagination for data source metal_devices

### DIFF
--- a/equinix/data_source_metal_devices.go
+++ b/equinix/data_source_metal_devices.go
@@ -72,7 +72,7 @@ func getDevices(ctx context.Context, d *schema.ResourceData, meta interface{}, e
 		if len(search) > 0 {
 			query = query.Search(search)
 		}
-		devices, _, err = query.Execute()
+		devices, err = query.ExecuteWithPagination()
 	}
 
 	if len(orgID) > 0 {
@@ -81,7 +81,7 @@ func getDevices(ctx context.Context, d *schema.ResourceData, meta interface{}, e
 		if len(search) > 0 {
 			query = query.Search(search)
 		}
-		devices, _, err = query.Execute()
+		devices, err = query.ExecuteWithPagination()
 	}
 
 	for _, d := range devices.Devices {


### PR DESCRIPTION
The data source `metal_devices` fails to retrieve all hosts within a project. This PR uses `ExecuteWithPagination` to retrieve the full list of resources.