### PR TITLE
refactor: ignore HTTP response errors by status code

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -2,9 +2,11 @@ package errors
 
 import (
 	"fmt"
-	"github.com/equinix/equinix-sdk-go/services/fabricv4"
 	"net/http"
+	"slices"
 	"strings"
+
+	"github.com/equinix/equinix-sdk-go/services/fabricv4"
 
 	"github.com/equinix/rest-go"
 	"github.com/packethost/packngo"
@@ -191,21 +193,14 @@ func HasErrorCode(errors []fabricv4.Error, code string) bool {
 	return false
 }
 
-// ignoreHttpResponseErrors ignores http response errors when matched by one of the
-// provided checks
-func IgnoreHttpResponseErrors(ignore ...func(resp *http.Response, err error) bool) func(resp *http.Response, err error) error {
+// IgnoreHttpResponseErrors ignores http response errors when the status
+// code of the response matches one of the status codes in the ignore list
+func IgnoreHttpResponseErrors(ignore ...int) func(resp *http.Response, err error) error {
 	return func(resp *http.Response, err error) error {
-		mute := false
-		for _, ignored := range ignore {
-			if ignored(resp, err) {
-				mute = true
-				break
-			}
-		}
-
-		if mute {
+		if resp != nil && slices.Contains(ignore, resp.StatusCode) {
 			return nil
 		}
+
 		return err
 	}
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -28,11 +28,6 @@ func FriendlyError(err error) error {
 	return err
 }
 
-func FriendlyErrorForMetalGo(err error, resp *http.Response) error {
-	errors := Errors([]string{err.Error()})
-	return convertToFriendlyError(errors, resp)
-}
-
 func convertToFriendlyError(errors Errors, resp *http.Response) error {
 	er := &ErrorResponse{
 		StatusCode: resp.StatusCode,

--- a/internal/resources/fabric/cloud_router/sweeper.go
+++ b/internal/resources/fabric/cloud_router/sweeper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/equinix/equinix-sdk-go/services/fabricv4"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
@@ -64,7 +65,7 @@ func testSweepCloudRouters(region string) error {
 		if sweep.IsSweepableFabricTestResource(cloudRouter.GetName()) {
 			log.Printf("[DEBUG] Deleting Cloud Routers: %s", cloudRouter.GetName())
 			resp, err := fabric.CloudRoutersApi.DeleteCloudRouterByUuid(ctx, cloudRouter.GetUuid()).Execute()
-			if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+			if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
 				errs = append(errs, fmt.Errorf("error deleting fabric Cloud Router: %s", err))
 			}
 		}

--- a/internal/resources/fabric/connection/sweeper.go
+++ b/internal/resources/fabric/connection/sweeper.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"net/http"
+
 	"github.com/equinix/equinix-sdk-go/services/fabricv4"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	"github.com/equinix/terraform-provider-equinix/internal/sweep"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"log"
 )
 
 func AddTestSweeper() {
@@ -64,7 +66,7 @@ func testSweepConnections(region string) error {
 		if sweep.IsSweepableFabricTestResource(connection.GetName()) {
 			log.Printf("[DEBUG] Deleting Connection: %s", connection.GetName())
 			_, resp, err := fabric.ConnectionsApi.DeleteConnectionByUuid(ctx, connection.GetUuid()).Execute()
-			if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+			if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
 				errs = append(errs, fmt.Errorf("error deleting fabric connection: %s", err))
 			}
 		}

--- a/internal/resources/fabric/connection/sweeper.go
+++ b/internal/resources/fabric/connection/sweeper.go
@@ -29,7 +29,11 @@ func testSweepConnections(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting configuration for sweeping Conections: %s", err)
 	}
-	meta.Load(ctx)
+	err = meta.Load(ctx)
+	if err != nil {
+		log.Printf("Error loading meta: %v", err)
+		return err
+	}
 	fabric := meta.NewFabricClientForTesting()
 
 	name := fabricv4.SEARCHFIELDNAME_NAME

--- a/internal/resources/fabric/route_filter/sweeper.go
+++ b/internal/resources/fabric/route_filter/sweeper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	"github.com/equinix/terraform-provider-equinix/internal/sweep"
@@ -71,7 +72,7 @@ func testSweepRouteFilters(region string) error {
 		if sweep.IsSweepableFabricTestResource(routeFilter.GetName()) {
 			log.Printf("[DEBUG] Deleting Route Filter: %s", routeFilter.GetName())
 			_, resp, err := fabric.RouteFiltersApi.DeleteRouteFilterByUuid(ctx, routeFilter.GetUuid()).Execute()
-			if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+			if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
 				errs = append(errs, fmt.Errorf("error deleting fabric route filter: %s", err))
 			}
 		}

--- a/internal/resources/metal/device/helpers.go
+++ b/internal/resources/metal/device/helpers.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/equinix/terraform-provider-equinix/internal/converters"
 
-	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
-
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -120,7 +118,6 @@ func hwReservationStateRefreshFunc(ctx context.Context, client *metalv1.APIClien
 		state := deprovisioning
 		switch {
 		case err != nil:
-			err = equinix_errors.FriendlyError(err)
 			state = errstate
 		case r != nil && r.GetProvisionable():
 			state = provisionable

--- a/internal/resources/metal/device/helpers_test.go
+++ b/internal/resources/metal/device/helpers_test.go
@@ -32,8 +32,6 @@ func Test_WaitUntilReservationProvisionable(t *testing.T) {
 				reservationId: "reservationId",
 				instanceId:    "instanceId",
 				handler: func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Add("Content-Type", "application/json")
-					w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 					w.WriteHeader(http.StatusInternalServerError)
 				},
 			},
@@ -75,7 +73,6 @@ func Test_WaitUntilReservationProvisionable(t *testing.T) {
 						}
 
 						w.Header().Add("Content-Type", "application/json")
-						w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 						w.WriteHeader(http.StatusOK)
 						_, err = w.Write(body)
 						if err != nil {
@@ -122,7 +119,6 @@ func Test_WaitUntilReservationProvisionable(t *testing.T) {
 						}
 
 						w.Header().Add("Content-Type", "application/json")
-						w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 						w.WriteHeader(http.StatusOK)
 						_, err = w.Write(body)
 						if err != nil {
@@ -151,7 +147,6 @@ func Test_WaitUntilReservationProvisionable(t *testing.T) {
 					}
 
 					w.Header().Add("Content-Type", "application/json")
-					w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 					w.WriteHeader(http.StatusOK)
 					_, err = w.Write(body)
 					if err != nil {

--- a/internal/resources/metal/device/resource.go
+++ b/internal/resources/metal/device/resource.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"path"
 	"reflect"
 	"regexp"
@@ -798,7 +799,7 @@ func resourceMetalDeviceDelete(ctx context.Context, d *schema.ResourceData, meta
 	start := time.Now()
 
 	resp, err := client.DevicesApi.DeleteDevice(ctx, d.Id()).ForceDelete(fdv).Execute()
-	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
 		return diag.FromErr(equinix_errors.FriendlyError(err))
 	}
 

--- a/internal/resources/metal/device/resource_test.go
+++ b/internal/resources/metal/device/resource_test.go
@@ -48,7 +48,6 @@ func TestMetalDevice_readErrorHandling(t *testing.T) {
 				newResource: false,
 				handler: func(w http.ResponseWriter, r *http.Request) {
 					w.Header().Add("Content-Type", "application/json")
-					w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 					w.WriteHeader(http.StatusForbidden)
 				},
 			},

--- a/internal/resources/metal/device/resource_test.go
+++ b/internal/resources/metal/device/resource_test.go
@@ -59,8 +59,6 @@ func TestMetalDevice_readErrorHandling(t *testing.T) {
 			args: args{
 				newResource: false,
 				handler: func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Add("Content-Type", "application/json")
-					w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 					w.WriteHeader(http.StatusNotFound)
 				},
 			},
@@ -71,8 +69,6 @@ func TestMetalDevice_readErrorHandling(t *testing.T) {
 			args: args{
 				newResource: true,
 				handler: func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Add("Content-Type", "application/json")
-					w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 					w.WriteHeader(http.StatusForbidden)
 				},
 			},
@@ -83,8 +79,6 @@ func TestMetalDevice_readErrorHandling(t *testing.T) {
 			args: args{
 				newResource: true,
 				handler: func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Add("Content-Type", "application/json")
-					w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 					w.WriteHeader(http.StatusNotFound)
 				},
 			},
@@ -95,8 +89,6 @@ func TestMetalDevice_readErrorHandling(t *testing.T) {
 			args: args{
 				newResource: true,
 				handler: func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Add("Content-Type", "application/json")
-					w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
 					w.WriteHeader(http.StatusBadRequest)
 				},
 			},

--- a/internal/resources/metal/gateway/resource.go
+++ b/internal/resources/metal/gateway/resource.go
@@ -172,27 +172,26 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	// only match one of MetalGateway or VrfMetalGateway if the included
 	// fields are present in the response
 	_, deleteResp, err := client.MetalGatewaysApi.DeleteMetalGateway(ctx, id).Include(includes).Execute()
-
-	if err != nil {
-		if deleteResp != nil {
-			err = equinix_errors.FriendlyErrorForMetalGo(err, deleteResp)
-		}
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(deleteResp, err) != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Failed to delete Metal Gateway %s", id), err.Error(),
+		)
 	}
+
 	if err == nil {
 		// Wait for the deletion to be completed
 		deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
-		deleteWaiter := getGatewayStateWaiter(
+		deleteWaiter := getGatewayDeleteWaiter(
 			ctx,
 			client,
 			id,
 			deleteTimeout,
 			[]string{string(metalv1.METALGATEWAYSTATE_DELETING)},
-			[]string{},
 		)
 		_, err = deleteWaiter.WaitForStateContext(ctx)
 	}
 
-	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(nil, err) != nil {
+	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete Metal Gateway %s", id), err.Error(),
 		)
@@ -215,17 +214,25 @@ func getGatewayAndParse(ctx context.Context, client *metalv1.APIClient, state *R
 	return diags, nil
 }
 
-func getGatewayStateWaiter(ctx context.Context, client *metalv1.APIClient, id string, timeout time.Duration, pending, target []string) *retry.StateChangeConf {
+func getGatewayDeleteWaiter(ctx context.Context, client *metalv1.APIClient, id string, timeout time.Duration, pending []string) *retry.StateChangeConf {
+	// deletedMarker is a terraform-provider-only value that is used by the waiter
+	// to indicate that the gateway appears to be deleted successfully based on
+	// status code
+	deletedMarker := "tf-marker-for-deleted-gateway"
+
+	target := []string{deletedMarker}
+
 	return &retry.StateChangeConf{
 		Pending: pending,
 		Target:  target,
 		Refresh: func() (interface{}, string, error) {
 			gw, resp, err := client.MetalGatewaysApi.FindMetalGatewayById(ctx, id).Include(includes).Execute()
 			if err != nil {
-				if resp != nil {
-					err = equinix_errors.FriendlyErrorForMetalGo(err, resp)
+				if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
+					return gw, "", err
+				} else {
+					return gw, deletedMarker, nil
 				}
-				return 0, "", err
 			}
 			state := ""
 			if gw.MetalGateway != nil {

--- a/internal/resources/metal/gateway/resource.go
+++ b/internal/resources/metal/gateway/resource.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
@@ -191,7 +192,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		_, err = deleteWaiter.WaitForStateContext(ctx)
 	}
 
-	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(nil, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(nil, err) != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete Metal Gateway %s", id), err.Error(),
 		)

--- a/internal/resources/metal/gateway/resource.go
+++ b/internal/resources/metal/gateway/resource.go
@@ -202,7 +202,7 @@ func getGatewayAndParse(ctx context.Context, client *metalv1.APIClient, state *R
 	// API call to get the Metal Gateway
 	gw, _, err := client.MetalGatewaysApi.FindMetalGatewayById(ctx, id).Include(includes).Execute()
 	if err != nil {
-		return diags, equinix_errors.FriendlyError(err)
+		return diags, err
 	}
 
 	// Parse the API response into the Terraform state

--- a/internal/resources/metal/port/resource.go
+++ b/internal/resources/metal/port/resource.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
-	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	equinix_schema "github.com/equinix/terraform-provider-equinix/internal/schema"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
@@ -132,7 +131,7 @@ func resourceMetalPortUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	start := time.Now()
 	cpr, _, err := getClientPortResource(ctx, d, meta)
 	if err != nil {
-		return diag.FromErr(equinix_errors.FriendlyError(err))
+		return diag.FromErr(err)
 	}
 
 	for _, f := range [](func(context.Context, *ClientPortResource) error){
@@ -146,7 +145,7 @@ func resourceMetalPortUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		updateNativeVlan,
 	} {
 		if err := f(ctx, cpr); err != nil {
-			return diag.FromErr(equinix_errors.FriendlyError(err))
+			return diag.FromErr(err)
 		}
 	}
 

--- a/internal/resources/metal/project/bgp_config.go
+++ b/internal/resources/metal/project/bgp_config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
-	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	fwtypes "github.com/equinix/terraform-provider-equinix/internal/framework/types"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -15,10 +14,9 @@ func fetchBGPConfig(ctx context.Context, client *metalv1.APIClient, projectID st
 
 	bgpConfig, _, err := client.BGPApi.FindBgpConfigByProject(ctx, projectID).Execute()
 	if err != nil {
-		friendlyErr := equinix_errors.FriendlyError(err)
 		diags.AddError(
 			"Error reading BGP configuration",
-			"Could not read BGP configuration for project with ID "+projectID+": "+friendlyErr.Error(),
+			"Could not read BGP configuration for project with ID "+projectID+": "+err.Error(),
 		)
 		return nil, diags
 	}
@@ -64,9 +62,8 @@ func handleBGPConfigChanges(ctx context.Context, client *metalv1.APIClient, plan
 			)
 			return nil, diags
 		}
-		createResp, err := client.BGPApi.RequestBgpConfig(ctx, projectID).BgpConfigRequestInput(*bgpCreateRequest).Execute()
+		_, err = client.BGPApi.RequestBgpConfig(ctx, projectID).BgpConfigRequestInput(*bgpCreateRequest).Execute()
 		if err != nil {
-			err = equinix_errors.FriendlyErrorForMetalGo(err, createResp)
 			diags.AddError(
 				"Error creating BGP configuration",
 				"Could not create BGP configuration for project: "+err.Error(),

--- a/internal/resources/metal/project/resource.go
+++ b/internal/resources/metal/project/resource.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
@@ -292,7 +293,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 
 	// API call to delete the project
 	deleteResp, err := client.ProjectsApi.DeleteProject(ctx, id).Execute()
-	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(deleteResp, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(deleteResp, err) != nil {
 		err = equinix_errors.FriendlyErrorForMetalGo(err, deleteResp)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete Project %s", id),

--- a/internal/resources/metal/project/resource.go
+++ b/internal/resources/metal/project/resource.go
@@ -63,11 +63,11 @@ func (r *Resource) Create(
 	}
 
 	// API call to create the project
-	project, createResp, err := client.ProjectsApi.CreateProject(ctx).ProjectCreateFromRootInput(createRequest).Execute()
+	project, _, err := client.ProjectsApi.CreateProject(ctx).ProjectCreateFromRootInput(createRequest).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating project",
-			"Could not create project: "+equinix_errors.FriendlyErrorForMetalGo(err, createResp).Error(),
+			"Could not create project: "+err.Error(),
 		)
 		return
 	}
@@ -83,9 +83,8 @@ func (r *Resource) Create(
 			return
 		}
 
-		createResp, err = client.BGPApi.RequestBgpConfig(ctx, project.GetId()).BgpConfigRequestInput(*bgpCreateRequest).Execute()
+		_, err = client.BGPApi.RequestBgpConfig(ctx, project.GetId()).BgpConfigRequestInput(*bgpCreateRequest).Execute()
 		if err != nil {
-			err = equinix_errors.FriendlyErrorForMetalGo(err, createResp)
 			resp.Diagnostics.AddError(
 				"Error creating BGP configuration",
 				"Could not create BGP configuration for project: "+err.Error(),
@@ -99,9 +98,8 @@ func (r *Resource) Create(
 		pur := metalv1.ProjectUpdateInput{
 			BackendTransferEnabled: plan.BackendTransfer.ValueBoolPointer(),
 		}
-		_, updateResp, err := client.ProjectsApi.UpdateProject(ctx, project.GetId()).ProjectUpdateInput(pur).Execute()
+		_, _, err := client.ProjectsApi.UpdateProject(ctx, project.GetId()).ProjectUpdateInput(pur).Execute()
 		if err != nil {
-			err = equinix_errors.FriendlyErrorForMetalGo(err, updateResp)
 			resp.Diagnostics.AddError(
 				"Error enabling Backend Transfer",
 				"Could not enable Backend Transfer for project with ID "+project.GetId()+": "+err.Error(),
@@ -186,10 +184,8 @@ func fetchProject(ctx context.Context, client *metalv1.APIClient, projectID stri
 
 	project, apiResp, err := client.ProjectsApi.FindProjectById(ctx, projectID).Execute()
 	if err != nil {
-		err = equinix_errors.FriendlyErrorForMetalGo(err, apiResp)
-
 		// Check if the Project no longer exists
-		if equinix_errors.IsNotFound(err) {
+		if apiResp.StatusCode == http.StatusNotFound {
 			diags.AddWarning(
 				"Project not found",
 				fmt.Sprintf("Project (%s) not found, removing from state", projectID),
@@ -248,12 +244,11 @@ func (r *Resource) Update(
 	// Check if any update was requested
 	if !reflect.DeepEqual(updateRequest, metalv1.ProjectUpdateInput{}) {
 		// API call to update the project
-		_, updateResp, err := client.ProjectsApi.UpdateProject(ctx, id).ProjectUpdateInput(updateRequest).Execute()
+		_, _, err := client.ProjectsApi.UpdateProject(ctx, id).ProjectUpdateInput(updateRequest).Execute()
 		if err != nil {
-			friendlyErr := equinix_errors.FriendlyErrorForMetalGo(err, updateResp)
 			resp.Diagnostics.AddError(
 				"Error updating project",
-				"Could not update project with ID "+id+": "+friendlyErr.Error(),
+				"Could not update project with ID "+id+": "+err.Error(),
 			)
 			return
 		}
@@ -294,7 +289,6 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	// API call to delete the project
 	deleteResp, err := client.ProjectsApi.DeleteProject(ctx, id).Execute()
 	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(deleteResp, err) != nil {
-		err = equinix_errors.FriendlyErrorForMetalGo(err, deleteResp)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete Project %s", id),
 			err.Error(),

--- a/internal/resources/metal/project/resource_test.go
+++ b/internal/resources/metal/project/resource_test.go
@@ -62,30 +62,7 @@ func TestAccMetalProject_errorHandling(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      providerConfig + "\n" + projectConfig,
-				ExpectError: regexp.MustCompile(`\bCould not create project: HTTP 422\b`),
-			},
-		},
-	})
-}
-
-// TODO(displague) How do we test this without TF_ACC set?
-func TestAccMetalProject_apiErrorHandling(t *testing.T) {
-	rInt := acctest.RandInt()
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Content-Type", "application/json")
-		w.Header().Add("X-Request-Id", "needed for equinix_errors.FriendlyError")
-		w.WriteHeader(http.StatusUnprocessableEntity)
-	}
-	mockAPI := httptest.NewServer(http.HandlerFunc(handler))
-	providerConfig := testAccMetalProviderConfig(mockAPI.URL, "fake-for-mock-test", "fake-for-mock-test")
-	projectConfig := testAccMetalProjectConfig_basic(rInt)
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: mockProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config:      providerConfig + "\n" + projectConfig,
-				ExpectError: regexp.MustCompile(`\bCould not create project: API Error HTTP 422\b`),
+				ExpectError: regexp.MustCompile(`\bCould not create project: 422 Unprocessable Entity\b`),
 			},
 		},
 	})

--- a/internal/resources/metal/project_ssh_key/datasource.go
+++ b/internal/resources/metal/project_ssh_key/datasource.go
@@ -2,7 +2,6 @@ package project_ssh_key
 
 import (
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
-	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	"github.com/equinix/terraform-provider-equinix/internal/framework"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 
@@ -51,7 +50,6 @@ func (r *DataSource) Read(
 	// Use API client to list SSH keys
 	keysList, _, err := client.SSHKeysApi.FindProjectSSHKeys(ctx, projectID).Query(search).Execute()
 	if err != nil {
-		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
 			"Error listing project ssh keys",
 			err.Error(),

--- a/internal/resources/metal/project_ssh_key/resource.go
+++ b/internal/resources/metal/project_ssh_key/resource.go
@@ -3,6 +3,7 @@ package project_ssh_key
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
@@ -182,7 +183,7 @@ func (r *Resource) Delete(
 
 	// Use API client to delete the resource
 	deleteResp, err := client.SSHKeysApi.DeleteSSHKey(ctx, id).Execute()
-	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(deleteResp, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(deleteResp, err) != nil {
 		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete Project SSHKey %s", id),

--- a/internal/resources/metal/project_ssh_key/resource.go
+++ b/internal/resources/metal/project_ssh_key/resource.go
@@ -54,7 +54,7 @@ func (r *Resource) Create(
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to create Project SSH Key",
-			equinix_errors.FriendlyError(err).Error(),
+			err.Error(),
 		)
 		return
 	}
@@ -87,13 +87,11 @@ func (r *Resource) Read(
 	id := state.ID.ValueString()
 
 	// Use API client to get the current state of the resource
-	key, _, err := client.SSHKeysApi.FindSSHKeyById(ctx, id).Include(nil).Execute()
+	key, apiResp, err := client.SSHKeysApi.FindSSHKeyById(ctx, id).Include(nil).Execute()
 	if err != nil {
-		err = equinix_errors.FriendlyError(err)
-
 		// If the key is somehow already destroyed, mark as
 		// succesfully gone
-		if equinix_errors.IsNotFound(err) {
+		if apiResp.StatusCode == http.StatusNotFound {
 			resp.Diagnostics.AddWarning(
 				"Equinix Metal Project SSHKey not found during refresh",
 				fmt.Sprintf("[WARN] SSHKey (%s) not found, removing from state", id),
@@ -146,7 +144,6 @@ func (r *Resource) Update(
 	// Update the resource
 	key, _, err := client.SSHKeysApi.UpdateSSHKey(ctx, id).SSHKeyInput(*updateRequest).Execute()
 	if err != nil {
-		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
 			"Error updating resource",
 			"Could not update resource with ID "+id+": "+err.Error(),
@@ -184,7 +181,6 @@ func (r *Resource) Delete(
 	// Use API client to delete the resource
 	deleteResp, err := client.SSHKeysApi.DeleteSSHKey(ctx, id).Execute()
 	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(deleteResp, err) != nil {
-		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete Project SSHKey %s", id),
 			err.Error(),

--- a/internal/resources/metal/ssh_key/resource.go
+++ b/internal/resources/metal/ssh_key/resource.go
@@ -3,6 +3,7 @@ package ssh_key
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
 	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
@@ -180,7 +181,7 @@ func (r *Resource) Delete(
 
 	// Use API client to delete the resource
 	deleteResp, err := client.SSHKeysApi.DeleteSSHKey(ctx, id).Execute()
-	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(deleteResp, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(deleteResp, err) != nil {
 		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete SSHKey %s", id),

--- a/internal/resources/metal/ssh_key/resource.go
+++ b/internal/resources/metal/ssh_key/resource.go
@@ -52,7 +52,7 @@ func (r *Resource) Create(
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to create SSH Key",
-			equinix_errors.FriendlyError(err).Error(),
+			err.Error(),
 		)
 		return
 	}
@@ -85,13 +85,11 @@ func (r *Resource) Read(
 	id := state.ID.ValueString()
 
 	// Use API client to get the current state of the resource
-	key, _, err := client.SSHKeysApi.FindSSHKeyById(ctx, id).Include(nil).Execute()
+	key, apiResp, err := client.SSHKeysApi.FindSSHKeyById(ctx, id).Include(nil).Execute()
 	if err != nil {
-		err = equinix_errors.FriendlyError(err)
-
 		// If the key is somehow already destroyed, mark as
 		// succesfully gone
-		if equinix_errors.IsNotFound(err) {
+		if apiResp.StatusCode != http.StatusNotFound {
 			resp.Diagnostics.AddWarning(
 				"Equinix Metal SSHKey not found during refresh",
 				fmt.Sprintf("[WARN] SSHKey (%s) not found, removing from state", id),
@@ -144,7 +142,6 @@ func (r *Resource) Update(
 	// Update the resource
 	key, _, err := client.SSHKeysApi.UpdateSSHKey(ctx, id).SSHKeyInput(*updateRequest).Execute()
 	if err != nil {
-		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
 			"Error updating resource",
 			"Could not update resource with ID "+id+": "+err.Error(),
@@ -182,7 +179,6 @@ func (r *Resource) Delete(
 	// Use API client to delete the resource
 	deleteResp, err := client.SSHKeysApi.DeleteSSHKey(ctx, id).Execute()
 	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(deleteResp, err) != nil {
-		err = equinix_errors.FriendlyError(err)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to delete SSHKey %s", id),
 			err.Error(),

--- a/internal/resources/metal/virtual_circuit/resource.go
+++ b/internal/resources/metal/virtual_circuit/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/http"
 	"regexp"
 	"strconv"
 	"time"
@@ -528,7 +529,7 @@ func resourceMetalVirtualCircuitDelete(ctx context.Context, d *schema.ResourceDa
 			// in order to use existing checks for equinix_errors.IgnoreHttpResponseErrors
 			err = equinix_errors.FriendlyErrorForMetalGo(err, resp)
 		}
-		if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+		if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -543,7 +544,7 @@ func resourceMetalVirtualCircuitDelete(ctx context.Context, d *schema.ResourceDa
 	)
 
 	_, err = deleteWaiter.WaitForStateContext(ctx)
-	if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(nil, err) != nil {
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(nil, err) != nil {
 		return diag.Errorf("Error deleting virtual circuit %s: %s", d.Id(), err)
 	}
 	d.SetId("")

--- a/internal/resources/metal/virtual_circuit/resource.go
+++ b/internal/resources/metal/virtual_circuit/resource.go
@@ -315,7 +315,7 @@ func resourceMetalVirtualCircuitRead(ctx context.Context, d *schema.ResourceData
 	if connectionID != "" {
 		errs = append(errs, d.Set("connection_id", connectionID))
 	}
-	d.Set("port_id", portID)
+	errs = append(errs, d.Set("port_id", portID))
 
 	if vc.VlanVirtualCircuit != nil {
 		errs = append(errs, d.Set("project_id", vc.VlanVirtualCircuit.Project.GetId()))

--- a/internal/resources/metal/virtual_circuit/resource.go
+++ b/internal/resources/metal/virtual_circuit/resource.go
@@ -355,19 +355,35 @@ func resourceMetalVirtualCircuitRead(ctx context.Context, d *schema.ResourceData
 	return diag.FromErr(errors.Join(errs...))
 }
 
+// Waiting for delete is different from waiting for a status, because we explicitly _want_
+// to get a 404 from the API on delete so that we know the resource is truly gone.
+// We may want to have a separate wait function for deletions so that it is easier
+// to understand the code
 func getVCStateWaiter(ctx context.Context, client *metalv1.APIClient, id string, timeout time.Duration, pending, target []string) *retry.StateChangeConf {
+	// deletedMarker is a terraform-provider-only value that is used by the waiter
+	// to indicate that the virtual circuit appears to be deleted successfully based on
+	// status code
+	deletedMarker := "tf-marker-for-deleted-virtual-circuit"
+
+	// Per current usage, when waiting for delete we pass in an empty target
+	// list; therefore, if the target list is empty we assume that a 404 or 403
+	// from the API is a success rather than a failure.
+	isWaitForDelete := len(target) == 0
+
+	if isWaitForDelete {
+		target = append(target, deletedMarker)
+	}
+
 	return &retry.StateChangeConf{
 		Pending: pending,
 		Target:  target,
 		Refresh: func() (interface{}, string, error) {
 			vc, resp, err := client.InterconnectionsApi.GetVirtualCircuit(ctx, id).Execute()
 			if err != nil {
-				if resp != nil {
-					// The resource delete function uses this waiter and relies
-					// on it to return an ErrorResponse error so it can treat
-					// a 404 as success.  This conversion is done here for now
-					// to avoid a larger refactoring.
-					err = equinix_errors.FriendlyErrorForMetalGo(err, resp)
+				if isWaitForDelete {
+					if equinix_errors.IgnoreHttpResponseErrors(http.StatusNotFound, http.StatusForbidden)(resp, err) == nil {
+						return 0, deletedMarker, nil
+					}
 				}
 				return 0, "", err
 			}
@@ -522,16 +538,8 @@ func resourceMetalVirtualCircuitDelete(ctx context.Context, d *schema.ResourceDa
 	client := meta.(*config.Config).NewMetalClientForSDK(d)
 
 	_, resp, err := client.InterconnectionsApi.DeleteVirtualCircuit(ctx, d.Id()).Execute()
-	if err != nil {
-		if resp != nil {
-			// equinix_error.HttpNotFound and similar do not short-circuit
-			// based on response code, so we have to convert to a FriendlyError
-			// in order to use existing checks for equinix_errors.IgnoreHttpResponseErrors
-			err = equinix_errors.FriendlyErrorForMetalGo(err, resp)
-		}
-		if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
-			return diag.FromErr(err)
-		}
+	if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
+		return diag.FromErr(err)
 	}
 
 	deleteWaiter := getVCStateWaiter(

--- a/internal/resources/metal/virtual_circuit/sweeper.go
+++ b/internal/resources/metal/virtual_circuit/sweeper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/equinix/equinix-sdk-go/services/metalv1"
 
@@ -54,7 +55,7 @@ func testSweepVirtualCircuits(region string) error {
 						if sweep.IsSweepableTestResource(vcName) {
 							log.Printf("[INFO][SWEEPER_LOG] Deleting VirtualCircuit: %s", vcName)
 							_, resp, err := metal.InterconnectionsApi.DeleteVirtualCircuit(context.Background(), vcId).Execute()
-							if equinix_errors.IgnoreHttpResponseErrors(equinix_errors.HttpForbidden, equinix_errors.HttpNotFound)(resp, err) != nil {
+							if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
 								errs = append(errs, fmt.Errorf("error deleting VirtualCircuit: %s", err))
 							}
 						}


### PR DESCRIPTION
This was broken out of #782 since it involves a widely-used helper function and will impact more than just the Metal VLAN resource.

Previously, the `IgnoreHttpResponseErrors` helper function accepted as arguments a number of other, existing helper functions that are meant to evaluate whether a particular API response has a certain HTTP status.  Here's [an example helper function for checking if the response is a 403](https://github.com/equinix/terraform-provider-equinix/blob/b1ed71b389705513308c1e47e7ac6ff0c46891cd/internal/errors/errors.go#L119-L130):

```go
func HttpForbidden(resp *http.Response, err error) bool {
	if resp != nil && (resp.StatusCode != http.StatusForbidden) {
		return false
	}

	switch err := err.(type) {
	case *ErrorResponse, *packngo.ErrorResponse:
		return IsForbidden(err)
	}

	return false
}
```

This function immediately returns false if the response status code _is not_ 403; otherwise it tries to convert the error argument to an `ErrorResponse` or a `packngo.ErrorResponse` and then use a different helper function to determine if that error represents a 403.  This assumes that the error object contains a copy of the response, which is only certain to be the case for code that uses `packngo`.  In practice we almost never did the necessary conversion to `ErrorResponse` for non-`packngo` resources and data sources, so in many cases we were probably not successfully ignoring the desired response codes.

This refactors  `IgnoreHttpResponseErrors` to inspect HTTP status codes directly in the response instead of relying on helper functions for specific custom error types.

This also removes the `FriendlyErrorForMetalGo` function which only existed in order to convert a separate HTTP response and error into an `ErrorResponse`, which is no longer necessary.  Some usage of `FriendlyError` is also removed in cases where that function had no or minimal effect.