### PR TITLE
chore: allow teams to add/remove resources & data sources

### DIFF
--- a/equinix/fabric_provider_maps.go
+++ b/equinix/fabric_provider_maps.go
@@ -1,0 +1,48 @@
+package equinix
+
+import (
+	fabric_connection "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/connection"
+	fabric_connection_route_filter "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/connection_route_filter"
+	fabric_market_place_subscription "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/marketplace"
+	fabric_network "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/network"
+	fabric_route_filter "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/route_filter"
+	fabric_route_filter_rule "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/route_filter_rule"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func fabricDatasources() map[string]*schema.Resource {
+	return map[string]*schema.Resource{
+		"equinix_fabric_routing_protocol":          dataSourceRoutingProtocol(),
+		"equinix_fabric_connection":                fabric_connection.DataSource(),
+		"equinix_fabric_connections":               fabric_connection.DataSourceSearch(),
+		"equinix_fabric_connection_route_filter":   fabric_connection_route_filter.DataSource(),
+		"equinix_fabric_connection_route_filters":  fabric_connection_route_filter.DataSourceGetAllRules(),
+		"equinix_fabric_cloud_router":              dataSourceFabricCloudRouter(),
+		"equinix_fabric_cloud_routers":             dataSourceFabricGetCloudRouters(),
+		"equinix_fabric_market_place_subscription": fabric_market_place_subscription.DataSourceFabricMarketplaceSubscription(),
+		"equinix_fabric_network":                   fabric_network.DataSource(),
+		"equinix_fabric_networks":                  fabric_network.DataSourceSearch(),
+		"equinix_fabric_port":                      dataSourceFabricPort(),
+		"equinix_fabric_ports":                     dataSourceFabricGetPortsByName(),
+		"equinix_fabric_route_filter":              fabric_route_filter.DataSource(),
+		"equinix_fabric_route_filters":             fabric_route_filter.DataSourceSearch(),
+		"equinix_fabric_route_filter_rule":         fabric_route_filter_rule.DataSource(),
+		"equinix_fabric_route_filter_rules":        fabric_route_filter_rule.DataSourceGetAllRules(),
+		"equinix_fabric_service_profile":           dataSourceFabricServiceProfileReadByUuid(),
+		"equinix_fabric_service_profiles":          dataSourceFabricSearchServiceProfilesByName(),
+	}
+}
+
+func fabricResources() map[string]*schema.Resource {
+	return map[string]*schema.Resource{
+		"equinix_fabric_network":                 fabric_network.Resource(),
+		"equinix_fabric_cloud_router":            resourceFabricCloudRouter(),
+		"equinix_fabric_connection":              fabric_connection.Resource(),
+		"equinix_fabric_connection_route_filter": fabric_connection_route_filter.Resource(),
+		"equinix_fabric_route_filter":            fabric_route_filter.Resource(),
+		"equinix_fabric_route_filter_rule":       fabric_route_filter_rule.Resource(),
+		"equinix_fabric_routing_protocol":        resourceFabricRoutingProtocol(),
+		"equinix_fabric_service_profile":         resourceFabricServiceProfile(),
+	}
+}

--- a/equinix/metal_provider_maps.go
+++ b/equinix/metal_provider_maps.go
@@ -1,0 +1,47 @@
+package equinix
+
+import (
+	metal_device "github.com/equinix/terraform-provider-equinix/internal/resources/metal/device"
+	metal_port "github.com/equinix/terraform-provider-equinix/internal/resources/metal/port"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/virtual_circuit"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vrf"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func metalDatasources() map[string]*schema.Resource {
+	return map[string]*schema.Resource{
+		"equinix_metal_hardware_reservation": dataSourceMetalHardwareReservation(),
+		"equinix_metal_metro":                dataSourceMetalMetro(),
+		"equinix_metal_facility":             dataSourceMetalFacility(),
+		"equinix_metal_ip_block_ranges":      dataSourceMetalIPBlockRanges(),
+		"equinix_metal_precreated_ip_block":  dataSourceMetalPreCreatedIPBlock(),
+		"equinix_metal_operating_system":     dataSourceOperatingSystem(),
+		"equinix_metal_spot_market_price":    dataSourceSpotMarketPrice(),
+		"equinix_metal_device":               metal_device.DataSource(),
+		"equinix_metal_devices":              metal_device.ListDataSource(),
+		"equinix_metal_device_bgp_neighbors": dataSourceMetalDeviceBGPNeighbors(),
+		"equinix_metal_plans":                dataSourceMetalPlans(),
+		"equinix_metal_port":                 metal_port.DataSource(),
+		"equinix_metal_reserved_ip_block":    dataSourceMetalReservedIPBlock(),
+		"equinix_metal_spot_market_request":  dataSourceMetalSpotMarketRequest(),
+		"equinix_metal_virtual_circuit":      virtual_circuit.DataSource(),
+		"equinix_metal_vrf":                  vrf.DataSource(),
+	}
+}
+
+func metalResources() map[string]*schema.Resource {
+	return map[string]*schema.Resource{
+		"equinix_metal_user_api_key":         resourceMetalUserAPIKey(),
+		"equinix_metal_project_api_key":      resourceMetalProjectAPIKey(),
+		"equinix_metal_device":               metal_device.Resource(),
+		"equinix_metal_device_network_type":  resourceMetalDeviceNetworkType(),
+		"equinix_metal_port":                 metal_port.Resource(),
+		"equinix_metal_reserved_ip_block":    resourceMetalReservedIPBlock(),
+		"equinix_metal_ip_attachment":        resourceMetalIPAttachment(),
+		"equinix_metal_spot_market_request":  resourceMetalSpotMarketRequest(),
+		"equinix_metal_virtual_circuit":      virtual_circuit.Resource(),
+		"equinix_metal_vrf":                  vrf.Resource(),
+		"equinix_metal_bgp_session":          resourceMetalBGPSession(),
+		"equinix_metal_port_vlan_attachment": resourceMetalPortVlanAttachment(),
+	}
+}

--- a/equinix/network_edge_provider_maps.go
+++ b/equinix/network_edge_provider_maps.go
@@ -1,0 +1,27 @@
+package equinix
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func networkEdgeDatasources() map[string]*schema.Resource {
+	return map[string]*schema.Resource{
+		"equinix_network_account":         dataSourceNetworkAccount(),
+		"equinix_network_device":          dataSourceNetworkDevice(),
+		"equinix_network_device_type":     dataSourceNetworkDeviceType(),
+		"equinix_network_device_software": dataSourceNetworkDeviceSoftware(),
+		"equinix_network_device_platform": dataSourceNetworkDevicePlatform(),
+	}
+}
+
+func networkEdgeResources() map[string]*schema.Resource {
+	return map[string]*schema.Resource{
+		"equinix_network_device":       resourceNetworkDevice(),
+		"equinix_network_ssh_user":     resourceNetworkSSHUser(),
+		"equinix_network_bgp":          resourceNetworkBGP(),
+		"equinix_network_ssh_key":      resourceNetworkSSHKey(),
+		"equinix_network_acl_template": resourceNetworkACLTemplate(),
+		"equinix_network_device_link":  resourceNetworkDeviceLink(),
+		"equinix_network_file":         resourceNetworkFile(),
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,14 +5,7 @@ import (
 	"fmt"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
-	metalconnection "github.com/equinix/terraform-provider-equinix/internal/resources/metal/connection"
-	metalgateway "github.com/equinix/terraform-provider-equinix/internal/resources/metal/gateway"
-	metalorganization "github.com/equinix/terraform-provider-equinix/internal/resources/metal/organization"
-	metalorganizationmember "github.com/equinix/terraform-provider-equinix/internal/resources/metal/organization_member"
-	metalproject "github.com/equinix/terraform-provider-equinix/internal/resources/metal/project"
-	metalprojectsshkey "github.com/equinix/terraform-provider-equinix/internal/resources/metal/project_ssh_key"
-	metalsshkey "github.com/equinix/terraform-provider-equinix/internal/resources/metal/ssh_key"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vlan"
+	"github.com/equinix/terraform-provider-equinix/internal/provider/services"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -113,25 +106,19 @@ func (p *FrameworkProvider) MetaSchema(
 }
 
 func (p *FrameworkProvider) Resources(ctx context.Context) []func() resource.Resource {
-	return []func() resource.Resource{
-		metalgateway.NewResource,
-		metalproject.NewResource,
-		metalprojectsshkey.NewResource,
-		metalsshkey.NewResource,
-		metalconnection.NewResource,
-		metalorganization.NewResource,
-		metalorganizationmember.NewResource,
-		vlan.NewResource,
-	}
+	resources := []func() resource.Resource{}
+	resources = append(resources, services.FabricResources()...)
+	resources = append(resources, services.MetalResources()...)
+	resources = append(resources, services.NetworkEdgeResources()...)
+
+	return resources
 }
 
 func (p *FrameworkProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{
-		metalgateway.NewDataSource,
-		metalproject.NewDataSource,
-		metalprojectsshkey.NewDataSource,
-		metalconnection.NewDataSource,
-		metalorganization.NewDataSource,
-		vlan.NewDataSource,
-	}
+	datasources := []func() datasource.DataSource{}
+	datasources = append(datasources, services.FabricDatasources()...)
+	datasources = append(datasources, services.MetalDatasources()...)
+	datasources = append(datasources, services.NetworkEdgeDatasources()...)
+
+	return datasources
 }

--- a/internal/provider/services/fabric.go
+++ b/internal/provider/services/fabric.go
@@ -1,0 +1,14 @@
+package services
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func FabricResources() []func() resource.Resource {
+	return []func() resource.Resource{}
+}
+
+func FabricDatasources() []func() datasource.DataSource {
+	return []func() datasource.DataSource{}
+}

--- a/internal/provider/services/metal.go
+++ b/internal/provider/services/metal.go
@@ -1,0 +1,38 @@
+package services
+
+import (
+	metalconnection "github.com/equinix/terraform-provider-equinix/internal/resources/metal/connection"
+	metalgateway "github.com/equinix/terraform-provider-equinix/internal/resources/metal/gateway"
+	metalorganization "github.com/equinix/terraform-provider-equinix/internal/resources/metal/organization"
+	metalorganizationmember "github.com/equinix/terraform-provider-equinix/internal/resources/metal/organization_member"
+	metalproject "github.com/equinix/terraform-provider-equinix/internal/resources/metal/project"
+	metalprojectsshkey "github.com/equinix/terraform-provider-equinix/internal/resources/metal/project_ssh_key"
+	metalsshkey "github.com/equinix/terraform-provider-equinix/internal/resources/metal/ssh_key"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vlan"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func MetalResources() []func() resource.Resource {
+	return []func() resource.Resource{
+		metalgateway.NewResource,
+		metalproject.NewResource,
+		metalprojectsshkey.NewResource,
+		metalsshkey.NewResource,
+		metalconnection.NewResource,
+		metalorganization.NewResource,
+		metalorganizationmember.NewResource,
+		vlan.NewResource,
+	}
+}
+
+func MetalDatasources() []func() datasource.DataSource {
+	return []func() datasource.DataSource{
+		metalgateway.NewDataSource,
+		metalproject.NewDataSource,
+		metalprojectsshkey.NewDataSource,
+		metalconnection.NewDataSource,
+		metalorganization.NewDataSource,
+		vlan.NewDataSource,
+	}
+}

--- a/internal/provider/services/network_edge.go
+++ b/internal/provider/services/network_edge.go
@@ -1,0 +1,14 @@
+package services
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func NetworkEdgeResources() []func() resource.Resource {
+	return []func() resource.Resource{}
+}
+
+func NetworkEdgeDatasources() []func() datasource.DataSource {
+	return []func() datasource.DataSource{}
+}


### PR DESCRIPTION
This refactors the SDKv2 and framework providers so that the data sources and resources for each Equinix service are defined in separate files.  This enables each team to add or remove their own data sources and resources without requiring review from DRE.