### PR TITLE
chore: upgrade go to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/equinix/terraform-provider-equinix
 
-go 1.22
+go 1.23
 
 require (
 	github.com/equinix/equinix-sdk-go v0.46.0


### PR DESCRIPTION
Renovate seems to be tripping on the new Go version as part of upgrading Go dependencies.