### PR TITLE
chore(ci): delay release publish until after artifacts are attached

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,39 @@ on:
 
 jobs:
 
-  goreleaser:
+  release:
     name: Release
     runs-on: ubuntu-latest
 
-    steps:
+    outputs:
+      new_release_published: ${{ steps.release.outputs.new_release_published }}
+      new_release_git_tag: ${{ steps.release.outputs.new_release_git_tag }}
 
-    - name: Check out code into the Go module directory
+    steps:
+    - name: Check out code
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
+    - name: Release
+      id: release
+      uses: cycjimmy/semantic-release-action@v4
+      with:
+        extra_plugins: |
+          conventional-changelog-conventionalcommits@8.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        ref: "${{ needs.release.outputs.new_release_git_tag }}"
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -27,17 +50,6 @@ jobs:
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         passphrase: ${{ secrets.PASSPHRASE }}
-
-    - name: Release
-      uses: cycjimmy/semantic-release-action@v3
-      with:
-        semantic_version: 19.0.5
-        extra_plugins: |
-          @semantic-release/exec@6.0.3
-          @semantic-release/git@10.0.0
-          conventional-changelog-conventionalcommits@4.6.3
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,45 +32,15 @@ builds:
       - goos: darwin
         goarch: "386"
     binary: "{{ .ProjectName }}_v{{ .Version }}"
-  - id: migration-tool
-    dir: ./cmd/migration-tool/
-    env:
-      # goreleaser does not work with CGO, it could also complicate
-      # usage by users in CI/CD systems like Terraform Cloud where
-      # they are unable to install libraries.
-      - CGO_ENABLED=0
-    mod_timestamp: "{{ .CommitTimestamp }}"
-    flags:
-      - -trimpath
-    ldflags:
-      - "-s -w -X main.Version={{.Version}}"
-    goos:
-      - freebsd
-      - windows
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - "386"
-      - arm
-      - arm64
-    ignore:
-      - goos: darwin
-        goarch: "386"
-    binary: equinix-migration-tool/equinix-migration-tool
 archives:
   - format: zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     builds:
       - provider
-      - migration-tool
     files:
       - LICENSE*
       - README*
       - CHANGELOG*
-      - src: "cmd/migration-tool/*.md"
-        dst: equinix-migration-tool
-        strip_parent: true
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
@@ -88,5 +58,6 @@ signs:
       - "${artifact}"
 release:
   mode: "keep-existing"
+  use_existing_draft: true
 changelog:
   disable: true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -21,16 +21,8 @@
       {
         "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
         "labels": false,
-        "releasedLabels": false
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "message": "ci: regenerate code for version ${nextRelease.version}",
-        "assets": [
-          "."
-        ]
+        "releasedLabels": false,
+        "draftRelease": true
       }
     ]
   ]


### PR DESCRIPTION
We have intermittently seen provider releases fail to show up in the Terraform registry.  When that happens we can usually redeliver the GitHub release webhook event and get the registry to find the new release.

While working on changes to the Equinix Python SDK, it occurred to me that the webhook issues we are seeing might be related to how we do automatic releases.  The semantic-release-action creates the GitHub release, and then the provider artifacts are built and uploaded by GoReleaser after the GitHub release has been created.  The webhook event is sent to the Terraform registry when the release is created, not after the artifacts are uploaded; it's possible that the registry attempts to load the release only to find that it does not include a provider, and that that is why our provider releases sometimes do not show up in the registry right away.

This PR updates the semantic-release configuration so that semantic-release-action creates a draft release, and the release is not published until after GoReleaser builds and uploads the necessary artifacts.  The release and publish steps are split into separate jobs in the release workflow so that we can more easily re-run specific parts of the workflow and easily skip the publish step if no new release was created.  These changes may resolve our issues with releases not showing up in the registry, but even if they don't, this is still a worthwhile quality-of-life improvement for the release workflow.