### PR TITLE
docs: remove/update incorrect provider documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ management of Equinix Platform resources.
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) 0.12+
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.0
 
 ## Using the provider
 

--- a/docs/guides/migration_guide_equinix_metal.md
+++ b/docs/guides/migration_guide_equinix_metal.md
@@ -13,18 +13,6 @@ Before starting to migrate your Terraform templates, please upgrade
 * equinix/metal provider to the latest version (3.2.1)
 * Terraform to version at least v0.13
 
-## Fast migration with Equinix Migration Tool
-
-As part of the release v1.5.0, a migration tool has been supplied that will automatically update your `Metal` terraform plans and state files to work with the unified `Equinix` provider. The latest version of the `Equinix Migration Tool` can be found [here](https://github.com/equinix/terraform-provider-equinix/releases/latest). You will need to download the zip file corresponding to your operating system from the `Assets` section. Once unzipped you will find a folder `equinix-migration-tool` with the tool binary. Please, refer to the migration tool [readme file](https://github.com/equinix/terraform-provider-equinix/tree/main/cmd/migration-tool#readme) for further details.
-
-Once downloaded, you will need to unzip the file and use the binary corresponding to your OS. Running this tool against your terraform project directory will:
-
-* Transform all the "metal_" resource and datasource definitions and references to the "equinix_" name.
-* Transform all "metal" references in .tfstate file to the "equinix" provider name.
-* Transform the "metal" provider block and the "required_providers" section to match the latest "equinix" provider version.
-
-Alternatively, you can make the changes manually following one of the options described below.
-
 ## Fast migration with replace-provider and sed
 
 Just like the Terraform HCL templates, the Terraform state is a file containing resource names and their attributes in structured text. We can attempt the migration as a text substitution task, basically replacing `metal_` with `equinix_metal_` wherever possible, and fixing the provider source reference.

--- a/docs/guides/migration_guide_packet.md
+++ b/docs/guides/migration_guide_packet.md
@@ -13,18 +13,6 @@ Before starting to migrate your Terraform templates, please upgrade
 * packethost/packet provider to the latest version (3.2.1)
 * Terraform to version at least v0.13
 
-## Fast migration with Equinix Migration Tool
-
-As part of the release v1.5.0, a migration tool has been supplied that will automatically update your `Packet` terraform plans and state files to work with the unified `Equinix` provider. The latest version of the `Equinix Migration Tool` can be found [here](https://github.com/equinix/terraform-provider-equinix/releases/tag/v1.5.0). You will need to download the zip file corresponding to your operating system from the `Assets` section. Once unzipped you will find a folder `equinix-migration-tool` with the tool binary. Please, refer to the migration tool [readme file](https://github.com/equinix/terraform-provider-equinix/tree/v1.5.0/cmd/migration-tool#readme) for further details.
-
-Once downloaded, you will need to unzip the file and use the binary corresponding to your OS. Running this tool against your terraform project directory will:
-
-* Transform all the "packet_" resource and datasource definitions and references to the "equinix_" name.
-* Transform all "packet" references in .tfstate file to the "equinix" provider name.
-* Transform the "packet" provider block and the "required_providers" section to match the latest "equinix" provider version.
-
-Alternatively, you can make the changes manually following one of the options described below.
-
 ## Fast migration with replace-provider and sed
 
 Just like the Terraform HCL templates, the Terraform state is a file containing resource names and their attributes in structured text. We can attempt the migration as a text substitution task, basically replacing `packet_` with `equinix_metal_` wherever possible, and fixing the provider source reference.

--- a/templates/guides/migration_guide_equinix_metal.md
+++ b/templates/guides/migration_guide_equinix_metal.md
@@ -13,18 +13,6 @@ Before starting to migrate your Terraform templates, please upgrade
 * equinix/metal provider to the latest version (3.2.1)
 * Terraform to version at least v0.13
 
-## Fast migration with Equinix Migration Tool
-
-As part of the release v1.5.0, a migration tool has been supplied that will automatically update your `Metal` terraform plans and state files to work with the unified `Equinix` provider. The latest version of the `Equinix Migration Tool` can be found [here](https://github.com/equinix/terraform-provider-equinix/releases/latest). You will need to download the zip file corresponding to your operating system from the `Assets` section. Once unzipped you will find a folder `equinix-migration-tool` with the tool binary. Please, refer to the migration tool [readme file](https://github.com/equinix/terraform-provider-equinix/tree/main/cmd/migration-tool#readme) for further details.
-
-Once downloaded, you will need to unzip the file and use the binary corresponding to your OS. Running this tool against your terraform project directory will:
-
-* Transform all the "metal_" resource and datasource definitions and references to the "equinix_" name.
-* Transform all "metal" references in .tfstate file to the "equinix" provider name.
-* Transform the "metal" provider block and the "required_providers" section to match the latest "equinix" provider version.
-
-Alternatively, you can make the changes manually following one of the options described below.
-
 ## Fast migration with replace-provider and sed
 
 Just like the Terraform HCL templates, the Terraform state is a file containing resource names and their attributes in structured text. We can attempt the migration as a text substitution task, basically replacing `metal_` with `equinix_metal_` wherever possible, and fixing the provider source reference.

--- a/templates/guides/migration_guide_packet.md
+++ b/templates/guides/migration_guide_packet.md
@@ -13,18 +13,6 @@ Before starting to migrate your Terraform templates, please upgrade
 * packethost/packet provider to the latest version (3.2.1)
 * Terraform to version at least v0.13
 
-## Fast migration with Equinix Migration Tool
-
-As part of the release v1.5.0, a migration tool has been supplied that will automatically update your `Packet` terraform plans and state files to work with the unified `Equinix` provider. The latest version of the `Equinix Migration Tool` can be found [here](https://github.com/equinix/terraform-provider-equinix/releases/tag/v1.5.0). You will need to download the zip file corresponding to your operating system from the `Assets` section. Once unzipped you will find a folder `equinix-migration-tool` with the tool binary. Please, refer to the migration tool [readme file](https://github.com/equinix/terraform-provider-equinix/tree/v1.5.0/cmd/migration-tool#readme) for further details.
-
-Once downloaded, you will need to unzip the file and use the binary corresponding to your OS. Running this tool against your terraform project directory will:
-
-* Transform all the "packet_" resource and datasource definitions and references to the "equinix_" name.
-* Transform all "packet" references in .tfstate file to the "equinix" provider name.
-* Transform the "packet" provider block and the "required_providers" section to match the latest "equinix" provider version.
-
-Alternatively, you can make the changes manually following one of the options described below.
-
 ## Fast migration with replace-provider and sed
 
 Just like the Terraform HCL templates, the Terraform state is a file containing resource names and their attributes in structured text. We can attempt the migration as a text substitution task, basically replacing `packet_` with `equinix_metal_` wherever possible, and fixing the provider source reference.


### PR DESCRIPTION
This updates the docs to remove the incorrect mention of support for Terraform <1, which was dropped in v3 of this provider, as well as references to the migration tool, which has been unmaintained for some time, is no longer included in provider releases, and will be removed from this codebase entirely in the near future.