### PR TITLE
feat: Create Test Sweeper for Networks

### DIFF
--- a/internal/resources/fabric/network/sweeper.go
+++ b/internal/resources/fabric/network/sweeper.go
@@ -21,7 +21,7 @@ func AddTestSweeper() {
 	})
 }
 
-func testSweeperNetworks(region string) error {
+func testSweeperNetworks(_ string) error {
 	var errs []error
 	log.Printf("[DEBUG] Sweeping Fabric Networks")
 	ctx := context.Background()

--- a/internal/resources/fabric/network/sweeper.go
+++ b/internal/resources/fabric/network/sweeper.go
@@ -16,7 +16,7 @@ import (
 
 func AddTestSweeper() {
 	resource.AddTestSweepers("equinix_fabric_network", &resource.Sweeper{
-		Name:         "equinix_fabric_connection",
+		Name:         "equinix_fabric_network",
 		Dependencies: []string{},
 		F:            testSweepNetworks,
 	})
@@ -49,11 +49,6 @@ func testSweepNetworks(region string) error {
 					Property: &name,
 					Operator: &likeOperator,
 					Values:   []string{"%_PFCR"},
-				},
-				{
-					Property: &name,
-					Operator: &likeOperator,
-					Values:   []string{"%_PFNV"},
 				},
 			},
 		},

--- a/internal/resources/fabric/network/sweeper.go
+++ b/internal/resources/fabric/network/sweeper.go
@@ -1,0 +1,80 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/equinix/equinix-sdk-go/services/fabricv4"
+	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
+	"net/http"
+
+	"github.com/equinix/terraform-provider-equinix/internal/sweep"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"log"
+)
+
+func AddTestSweeper() {
+	resource.AddTestSweepers("equinix_fabric_network", &resource.Sweeper{
+		Name:         "equinix_fabric_connection",
+		Dependencies: []string{},
+		F:            testSweepNetworks,
+	})
+}
+
+func testSweepNetworks(region string) error {
+	var errs []error
+	log.Printf("[DEBUG] Sweeping Fabric Networks")
+	ctx := context.Background()
+	meta, err := sweep.GetConfigForFabric()
+	if err != nil {
+		return fmt.Errorf("error getting configuration for sweeping Networks: %s", err)
+	}
+	err = meta.Load(ctx)
+	if err != nil {
+		log.Printf("Error loading meta: %v", err)
+		return err
+	}
+	fabric := meta.NewFabricClientForTesting()
+
+	name := fabricv4.NETWORKSEARCHFIELDNAME_NAME
+	likeOperator := fabricv4.NETWORKFILTEROPERATOR_LIKE
+	limit := int32(100)
+	offset := int32(10)
+
+	networkSearchRequest := fabricv4.NetworkSearchRequest{
+		Filter: &fabricv4.NetworkFilter{
+			And: []fabricv4.NetworkFilter{
+				{
+					Property: &name,
+					Operator: &likeOperator,
+					Values:   []string{"%_PFCR"},
+				},
+				{
+					Property: &name,
+					Operator: &likeOperator,
+					Values:   []string{"%_PFNV"},
+				},
+			},
+		},
+		Pagination: &fabricv4.PaginationRequest{
+			Offset: &offset,
+			Limit:  &limit,
+		},
+	}
+	networks, _, err := fabric.NetworksApi.SearchNetworks(ctx).NetworkSearchRequest(networkSearchRequest).Execute()
+	if err != nil {
+		return fmt.Errorf("error searching networks: %s", err)
+	}
+
+	for _, network := range networks.Data {
+		if sweep.IsSweepableFabricTestResource(network.GetName()) {
+			log.Printf("[DEBUG] Deleting Networks: %s", network.GetName())
+			_, resp, err := fabric.NetworksApi.DeleteNetworkByUuid(ctx, network.GetUuid()).Execute()
+			if equinix_errors.IgnoreHttpResponseErrors(http.StatusForbidden, http.StatusNotFound)(resp, err) != nil {
+				errs = append(errs, fmt.Errorf("error deleting network: %s", err))
+			}
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/resources/fabric/network/sweeper.go
+++ b/internal/resources/fabric/network/sweeper.go
@@ -39,7 +39,7 @@ func testSweeperNetworks(region string) error {
 	name := fabricv4.NETWORKSEARCHFIELDNAME_NAME
 	likeOperator := fabricv4.NETWORKFILTEROPERATOR_LIKE
 	limit := int32(100)
-	offset := int32(10)
+	offset := int32(0)
 
 	networkSearchRequest := fabricv4.NetworkSearchRequest{
 		Filter: &fabricv4.NetworkFilter{

--- a/internal/resources/fabric/network/sweeper.go
+++ b/internal/resources/fabric/network/sweeper.go
@@ -34,7 +34,7 @@ func testSweeperNetworks(region string) error {
 		log.Printf("Error loading meta: %v", err)
 		return err
 	}
-	fabric := meta.NewFabricClientForTesting()
+	fabric := meta.NewFabricClientForTesting(ctx)
 
 	name := fabricv4.NETWORKSEARCHFIELDNAME_NAME
 	likeOperator := fabricv4.NETWORKFILTEROPERATOR_LIKE

--- a/internal/resources/fabric/network/sweeper.go
+++ b/internal/resources/fabric/network/sweeper.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/equinix/equinix-sdk-go/services/fabricv4"
-	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
+	"log"
 	"net/http"
 
+	"github.com/equinix/equinix-sdk-go/services/fabricv4"
+	equinix_errors "github.com/equinix/terraform-provider-equinix/internal/errors"
 	"github.com/equinix/terraform-provider-equinix/internal/sweep"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"log"
 )
 
 func AddTestSweeper() {

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -1,6 +1,7 @@
 package sweep_test
 
 import (
+	"github.com/equinix/terraform-provider-equinix/internal/resources/fabric/network"
 	"testing"
 
 	fabric_cloud_router "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/cloud_router"
@@ -35,6 +36,7 @@ func addTestSweepers() {
 	fabric_connection.AddTestSweeper()
 	fabric_route_filter.AddTestSweeper()
 	fabric_stream.AddTestSweeper()
+	network.AddTestSweeper()
 	organization.AddTestSweeper()
 	project.AddTestSweeper()
 	ssh_key.AddTestSweeper()

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -1,7 +1,6 @@
 package sweep_test
 
 import (
-	"github.com/equinix/terraform-provider-equinix/internal/resources/fabric/network"
 	"testing"
 
 	fabric_cloud_router "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/cloud_router"
@@ -9,6 +8,7 @@ import (
 	fabric_route_filter "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/route_filter"
 	fabric_stream "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/stream"
 
+	"github.com/equinix/terraform-provider-equinix/internal/resources/fabric/network"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/connection"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/device"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/organization"


### PR DESCRIPTION
 **Test Sweeper for Networks:** 
 -Added test sweeper in`internal/resources/fabric/network/sweeper.go`
 -Added `network.AddTestSweeper()` function call in `internal/sweep/sweep_test.go`
 
A screenshot of the sweeper test run: 
![image](https://github.com/user-attachments/assets/5f1c960d-3a9b-4134-ad2c-27303ad07b82)
