### PR TITLE
chore: Enable revive and stylecheck in golangci linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,8 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+    - revive
+    - stylecheck
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,3 +15,11 @@ linters:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    # Allow underscores in names in test files because the
+    # HashiCorp-recommended/documented convention uses
+    # underscores in function names
+    - path: _test\.go
+      linters:
+        - revive
+      text: "^var-naming"


### PR DESCRIPTION
* Enable `revive` and `stylecheck` linters