### PR TITLE
chore: update local lint task to only lint changed files

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,6 +25,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          args: --whole-files # Remove along with only-new-issues by 2025
+          args: --whole-files
           version: ${{ steps.golangcilint.outputs.version }}
-          only-new-issues: true # Remove along with pull-requests: read permission by 2025
+          only-new-issues: true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,6 +13,7 @@ PKG_NAME            =equinix
 
 GOLANGCI_LINT_VERSION=v1.60
 GOLANGCI_LINT=go run github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+LINT_BASE_REF=origin/main
 
 ifneq ($(origin TESTS_REGEXP), undefined)
 	TESTARGS = -run='$(TESTS_REGEXP)'
@@ -49,7 +50,7 @@ clean:
 	rm -f ${BINARY}
 
 lint:
-	${GOLANGCI_LINT} run -v
+	${GOLANGCI_LINT} run -v --new-from-rev=${LINT_BASE_REF} --whole-files
 
 vet:
 	@echo "go vet ."


### PR DESCRIPTION
Since we might periodically change linter configuration, as done in #849, we should keep the existing PR validation behavior that only lints the files that were changed in a particular PR.  This will allow us to continue to avoid unnecessarily large PRs to fix linting failures if and when the linter configuration changes.

If we're keeping the current, limited PR validation behavior, we should use the same behavior for the `make lint` task to that developers can easily identify the minimum necessary changes locally.  This updates the `make lint` task to only lint files that have been changed since `origin/main`, which should closely approximate the behavior of the PR validation workflow.