### PR TITLE
chore: allow underscores in names in test files

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,3 +23,7 @@ issues:
       linters:
         - revive
       text: "^var-naming"
+    - path: _test\.go
+      linters:
+        - stylecheck
+      text: "^ST1003"


### PR DESCRIPTION
HashiCorp examples encourage the use of underscores in names in Terraform provider tests.  To avoid unnecessary churn due to renaming things in test files, we disabled the relevant `revive` rule for tests, but it turns out there's a similar `stylecheck` rule that also needs to be skipped.  This PR disables that rule for test files.