### PR TITLE
fix: Update method should pull from config instead of plan

### DIFF
--- a/internal/resources/fabric/stream_subscription/resource.go
+++ b/internal/resources/fabric/stream_subscription/resource.go
@@ -136,7 +136,7 @@ func (r *Resource) Update(
 
 	// Retrieve values from plan
 	var state, plan resourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -144,7 +144,6 @@ func (r *Resource) Update(
 
 	id := state.ID.ValueString()
 	streamID := state.StreamID.ValueString()
-
 	updateRequest, diags := buildUpdateRequest(ctx, plan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/internal/resources/fabric/stream_subscription/resource.go
+++ b/internal/resources/fabric/stream_subscription/resource.go
@@ -144,7 +144,7 @@ func (r *Resource) Update(
 
 	id := state.ID.ValueString()
 	streamID := state.StreamID.ValueString()
-	
+
 	updateRequest, diags := buildUpdateRequest(ctx, plan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/internal/resources/fabric/stream_subscription/resource.go
+++ b/internal/resources/fabric/stream_subscription/resource.go
@@ -144,6 +144,7 @@ func (r *Resource) Update(
 
 	id := state.ID.ValueString()
 	streamID := state.StreamID.ValueString()
+	
 	updateRequest, diags := buildUpdateRequest(ctx, plan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
* Pulling from `plan` for update method causes issues because it will use the results of computed values from state instead of just what is present from user input
* Use config instead of plan to just get user input