### PR TITLE
feat:  Addition of E-Tree Network Type

### DIFF
--- a/docs/data-sources/fabric_network.md
+++ b/docs/data-sources/fabric_network.md
@@ -59,7 +59,7 @@ output "region" {
 - `project` (Set of Object) Fabric Network project (see [below for nested schema](#nestedatt--project))
 - `scope` (String) Fabric Network scope
 - `state` (String) Fabric Network overall state
-- `type` (String) Supported Network types - EVPLAN, EPLAN, IPWAN
+- `type` (String) Supported Network types - EVPLAN, EPLAN, IPWAN, EVPTREE, EPTREE
 
 <a id="nestedatt--change"></a>
 ### Nested Schema for `change`

--- a/docs/resources/fabric_network.md
+++ b/docs/resources/fabric_network.md
@@ -36,7 +36,7 @@ resource "equinix_fabric_network" "new_network" {
 - `notifications` (Block List, Min: 1) Preferences for notifications on Fabric Network configuration or status changes (see [below for nested schema](#nestedblock--notifications))
 - `project` (Block Set, Min: 1) Fabric Network project (see [below for nested schema](#nestedblock--project))
 - `scope` (String) Fabric Network scope
-- `type` (String) Supported Network types - EVPLAN, EPLAN, IPWAN
+- `type` (String) Supported Network types - EVPLAN, EPLAN, IPWAN, EVPTREE, EPTREE
 
 ### Optional
 

--- a/internal/resources/fabric/network/resource_schema.go
+++ b/internal/resources/fabric/network/resource_schema.go
@@ -75,8 +75,8 @@ func fabricNetworkResourceSchema() map[string]*schema.Schema {
 		"type": {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: validation.StringInSlice([]string{"IPWAN", "EPLAN", "EVPLAN"}, true),
-			Description:  "Supported Network types - EVPLAN, EPLAN, IPWAN",
+			ValidateFunc: validation.StringInSlice([]string{"IPWAN", "EPLAN", "EVPLAN", "EVPTREE", "EPTREE"}, true),
+			Description:  "Supported Network types - EVPLAN, EPLAN, IPWAN, EVPTREE, EPTREE",
 		},
 		"location": {
 			Type:        schema.TypeSet,

--- a/internal/resources/fabric/network/resource_test.go
+++ b/internal/resources/fabric/network/resource_test.go
@@ -21,7 +21,7 @@ func init() {
 	})
 }
 
-func testSweepNetworks(region string) error {
+func testSweepNetworks(_ string) error {
 	return nil
 }
 
@@ -125,7 +125,7 @@ func TestAccFabricNetworkCreateMixedParameters_PFCR(t *testing.T) {
 	})
 }
 func testAccNetworkCreateMixedParameterConfig_PFCR() string {
-	return fmt.Sprintf(`
+	return `
 	resource "equinix_fabric_network" "example2" {
 		type = "IPWAN"
 		name = "Tf_Network_PFCR"
@@ -141,7 +141,7 @@ func testAccNetworkCreateMixedParameterConfig_PFCR() string {
 			project_id = "291639000636552"
 		}
 	}
-`)
+`
 }
 
 func TestAccFabricCreateEVPTREE_Network_PFCR(t *testing.T) {
@@ -151,7 +151,7 @@ func TestAccFabricCreateEVPTREE_Network_PFCR(t *testing.T) {
 		CheckDestroy: checkNetworkDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkCreateEVPTREE_Network_Config_PFCR(),
+				Config: testAccNetworkCreateEVPTREENetworkConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("equinix_fabric_network.example3", "name", "Tf_ETree_Network_PFCR"),
 					resource.TestCheckResourceAttrSet("equinix_fabric_network.example3", "state"),
@@ -174,8 +174,8 @@ func TestAccFabricCreateEVPTREE_Network_PFCR(t *testing.T) {
 	})
 }
 
-func testAccNetworkCreateEVPTREE_Network_Config_PFCR() string {
-	return fmt.Sprintf(`
+func testAccNetworkCreateEVPTREENetworkConfig() string {
+	return `
 	resource "equinix_fabric_network" "example3" {
 		type = "EVPTREE"
 		name = "Tf_ETree_Network_PFCR"
@@ -188,5 +188,5 @@ func testAccNetworkCreateEVPTREE_Network_Config_PFCR() string {
 			project_id = "291639000636552"
 		}
 	}
-`)
+`
 }

--- a/internal/resources/fabric/network/resource_test.go
+++ b/internal/resources/fabric/network/resource_test.go
@@ -143,3 +143,50 @@ func testAccNetworkCreateMixedParameterConfig_PFCR() string {
 	}
 `)
 }
+
+func TestAccFabricCreateEVPTREE_Network_PFCR(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t); acceptance.TestAccPreCheckProviderConfigured(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: checkNetworkDelete,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkCreateEVPTREE_Network_Config_PFCR(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("equinix_fabric_network.example3", "name", "Tf_ETree_Network_PFCR"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_network.example3", "state"),
+					resource.TestCheckResourceAttr("equinix_fabric_network.example3", "connections_count", "0"),
+					resource.TestCheckResourceAttr("equinix_fabric_network.example3", "type", "EVPTREE"),
+					resource.TestCheckResourceAttr("equinix_fabric_network.example3", "notifications.0.type", "ALL"),
+					resource.TestCheckResourceAttr("equinix_fabric_network.example3", "notifications.0.emails.0", "test@equinix.com"),
+					resource.TestCheckResourceAttr("equinix_fabric_network.example3", "scope", "LOCAL"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_network.example3", "href"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_network.example3", "uuid"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_network.example3", "change_log.0.created_by"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_network.example3", "change_log.0.created_by_full_name"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_network.example3", "change_log.0.created_by_email"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_network.example3", "change_log.0.created_date_time"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_network.example3", "operation.0.equinix_status"),
+				),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccNetworkCreateEVPTREE_Network_Config_PFCR() string {
+	return fmt.Sprintf(`
+	resource "equinix_fabric_network" "example3" {
+		type = "EVPTREE"
+		name = "Tf_ETree_Network_PFCR"
+		scope = "LOCAL"
+		notifications {
+			type = "ALL"
+			emails = ["test@equinix.com","test1@equinix.com"]
+		}
+		project{
+			project_id = "291639000636552"
+		}
+	}
+`)
+}


### PR DESCRIPTION
- Add `EVPTREE` and `EPTREE` Network Type in  `internal/resources/fabric/network/resource_schema.go`
- Generate docs (Updates `docs/data-sources/fabric_network.md` and `docs/resources/fabric_network.md`) 
- Tested network creation in `terraform-equinix-fabric` modules (network created successfully) 
- Add acceptance test - `TestAccFabricCreateEVPTREE_Network_PFCR` in `resource_test.go`