### PR TITLE
fix: Replace EOL ubuntu_20_04 operating system with current ubuntu_24_04 os

### DIFF
--- a/docs/data-sources/metal_operating_system.md
+++ b/docs/data-sources/metal_operating_system.md
@@ -11,7 +11,7 @@ Use this data source to get Equinix Metal Operating System image.
 ```terraform
 data "equinix_metal_operating_system" "example" {
   distro           = "ubuntu"
-  version          = "20.04"
+  version          = "24.04"
   provisionable_on = "c3.medium.x86"
 }
 

--- a/docs/data-sources/metal_plans.md
+++ b/docs/data-sources/metal_plans.md
@@ -90,7 +90,7 @@ resource "equinix_metal_device" "example" {
   hostname         = "example"
   plan             = data.equinix_metal_plans.example.plans[0].name
   metro            = data.equinix_metal_plans.example.plans[0].available_in_metros[0]
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = var.project_id
 

--- a/docs/data-sources/metal_port.md
+++ b/docs/data-sources/metal_port.md
@@ -19,7 +19,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "tfacc-test-device-port"
   plan             = "c3.medium.x86"
   metro            = "sv"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }

--- a/docs/data-sources/metal_precreated_ip_block.md
+++ b/docs/data-sources/metal_precreated_ip_block.md
@@ -27,7 +27,7 @@ resource "equinix_metal_device" "web1" {
   hostname         = "web1"
   plan             = "c3.small.x86"
   metro            = "sv"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 

--- a/docs/data-sources/metal_spot_market_request.md
+++ b/docs/data-sources/metal_spot_market_request.md
@@ -22,7 +22,7 @@ resource "equinix_metal_spot_market_request" "req" {
   instance_parameters {
     hostname         = "testspot"
     billing_cycle    = "hourly"
-    operating_system = "ubuntu_20_04"
+    operating_system = "ubuntu_24_04"
     plan             = "c3.small.x86"
   }
 }

--- a/docs/guides/migration_guide_equinix_metal.md
+++ b/docs/guides/migration_guide_equinix_metal.md
@@ -121,7 +121,7 @@ resource "metal_device" "example" {
   project_id       = local.project_id
   facilities       = ["sv15"]
   plan             = "c3.medium.x86"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   hostname         = "test"
   billing_cycle    = "hourly"
 
@@ -196,7 +196,7 @@ resource "equinix_metal_device" "example" {
   project_id       = local.project_id
   facilities       = ["sv15"]
   plan             = "c3.medium.x86"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   hostname         = "test"
   billing_cycle    = "hourly"
 

--- a/docs/guides/migration_guide_packet.md
+++ b/docs/guides/migration_guide_packet.md
@@ -121,7 +121,7 @@ resource "packet_device" "example" {
   project_id       = local.project_id
   facilities       = ["sv15"]
   plan             = "c3.medium.x86"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   hostname         = "test"
   billing_cycle    = "hourly"
 
@@ -196,7 +196,7 @@ resource "equinix_metal_device" "example" {
   project_id       = local.project_id
   facilities       = ["sv15"]
   plan             = "c3.medium.x86"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   hostname         = "test"
   billing_cycle    = "hourly"
 

--- a/docs/guides/network_types.md
+++ b/docs/guides/network_types.md
@@ -141,7 +141,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-port-vlan-attachment-test"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -173,7 +173,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "test${count.index}"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -202,7 +202,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-port-vlan-attachment-test"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }

--- a/docs/resources/metal_bgp_session.md
+++ b/docs/resources/metal_bgp_session.md
@@ -46,7 +46,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "terraform-test-bgp-sesh"
   plan             = "c3.small.x86"
   metro            = ["ny"]
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }

--- a/docs/resources/metal_device.md
+++ b/docs/resources/metal_device.md
@@ -17,7 +17,7 @@ resource "equinix_metal_device" "web1" {
   hostname         = "tf.coreos2"
   plan             = "c3.small.x86"
   metro            = "sv"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -46,7 +46,7 @@ resource "equinix_metal_device" "web1" {
   hostname         = "tf.coreos2"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
   ip_address {
@@ -63,7 +63,7 @@ resource "equinix_metal_device" "web1" {
   hostname                = "tftest"
   plan                    = "c3.small.x86"
   metro                   = "ny"
-  operating_system        = "ubuntu_20_04"
+  operating_system        = "ubuntu_24_04"
   billing_cycle           = "hourly"
   project_id              = local.project_id
   hardware_reservation_id = "next-available"

--- a/docs/resources/metal_port_vlan_attachment.md
+++ b/docs/resources/metal_port_vlan_attachment.md
@@ -30,7 +30,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "test"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -54,7 +54,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "test"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }

--- a/docs/resources/metal_project_ssh_key.md
+++ b/docs/resources/metal_project_ssh_key.md
@@ -23,7 +23,7 @@ resource "equinix_metal_device" "test" {
   hostname            = "test"
   plan                = "c3.medium.x86"
   metro               = "ny"
-  operating_system    = "ubuntu_20_04"
+  operating_system    = "ubuntu_24_04"
   billing_cycle       = "hourly"
   project_ssh_key_ids = [equinix_metal_project_ssh_key.test.id]
   project_id          = local.project_id

--- a/docs/resources/metal_reserved_ip_block.md
+++ b/docs/resources/metal_reserved_ip_block.md
@@ -63,7 +63,7 @@ resource "equinix_metal_device" "nodes" {
   project_id       = local.project_id
   metro            = "sv"
   plan             = "c3.small.x86"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   hostname         = "test"
   billing_cycle    = "hourly"
 

--- a/docs/resources/metal_spot_market_request.md
+++ b/docs/resources/metal_spot_market_request.md
@@ -20,7 +20,7 @@ resource "equinix_metal_spot_market_request" "req" {
   instance_parameters {
     hostname         = "testspot"
     billing_cycle    = "hourly"
-    operating_system = "ubuntu_20_04"
+    operating_system = "ubuntu_24_04"
     plan             = "c3.small.x86"
   }
 }

--- a/docs/resources/metal_ssh_key.md
+++ b/docs/resources/metal_ssh_key.md
@@ -23,7 +23,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "test-device"
   plan             = "c3.small.x86"
   metro            = "sv"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
   depends_on       = ["equinix_metal_ssh_key.key1"]

--- a/equinix/common_test.go
+++ b/equinix/common_test.go
@@ -10,7 +10,7 @@ import (
 var (
 	preferable_plans  = []string{"x1.small.x86", "t1.small.x86", "c2.medium.x86", "c3.small.x86", "c3.medium.x86", "m3.small.x86"}
 	preferable_metros = []string{"ch", "ny", "sv", "ty", "am"}
-	preferable_os     = []string{"ubuntu_20_04"}
+	preferable_os     = []string{"ubuntu_24_04"}
 )
 
 // Deprecated: use the identical TestDeviceTerminationTime from internal/acceptance instead

--- a/equinix/common_test.go
+++ b/equinix/common_test.go
@@ -14,7 +14,7 @@ var (
 	preferable_os     = []string{"ubuntu_24_04"}
 )
 
-// Deprecated: use the identical TestDeviceTerminationTime from internal/acceptance instead
+// Deprecated: use the identical DeviceTerminationTime from internal/acceptance instead
 func testDeviceTerminationTime() string {
 	return time.Now().UTC().Add(60 * time.Minute).Format(time.RFC3339)
 }

--- a/equinix/common_test.go
+++ b/equinix/common_test.go
@@ -1,3 +1,4 @@
+// Package common test
 package equinix
 
 import (

--- a/equinix/data_source_metal_operating_system_acc_test.go
+++ b/equinix/data_source_metal_operating_system_acc_test.go
@@ -26,7 +26,7 @@ func TestAccDataSourceMetalOperatingSystem_basic(t *testing.T) {
 const testAccDataSourceMetalOperatingSystemConfig_basic = `
 	data "equinix_metal_operating_system" "example" {
 		distro  = "ubuntu"
-		version = "20.04"
+		version = "24.04"
 	  }`
 
 var matchErrOSNotFound = regexp.MustCompile(".*There are no operating systems*")

--- a/equinix/data_source_metal_operating_system_acc_test.go
+++ b/equinix/data_source_metal_operating_system_acc_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceMetalOperatingSystem_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceMetalOperatingSystemConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.equinix_metal_operating_system.example", "slug", "ubuntu_20_04"),
+					resource.TestCheckResourceAttr("data.equinix_metal_operating_system.example", "slug", "ubuntu_24_04"),
 				),
 			},
 		},

--- a/examples/data-sources/equinix_metal_operating_system/example_1.tf
+++ b/examples/data-sources/equinix_metal_operating_system/example_1.tf
@@ -1,6 +1,6 @@
 data "equinix_metal_operating_system" "example" {
   distro           = "ubuntu"
-  version          = "20.04"
+  version          = "24.04"
   provisionable_on = "c3.medium.x86"
 }
 

--- a/examples/data-sources/equinix_metal_plans/example_3.tf
+++ b/examples/data-sources/equinix_metal_plans/example_3.tf
@@ -20,7 +20,7 @@ resource "equinix_metal_device" "example" {
   hostname         = "example"
   plan             = data.equinix_metal_plans.example.plans[0].name
   metro            = data.equinix_metal_plans.example.plans[0].available_in_metros[0]
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = var.project_id
 

--- a/examples/data-sources/equinix_metal_port/example_1.tf
+++ b/examples/data-sources/equinix_metal_port/example_1.tf
@@ -6,7 +6,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "tfacc-test-device-port"
   plan             = "c3.medium.x86"
   metro            = "sv"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }

--- a/examples/data-sources/equinix_metal_precreated_ip_block/example_1.tf
+++ b/examples/data-sources/equinix_metal_precreated_ip_block/example_1.tf
@@ -10,7 +10,7 @@ resource "equinix_metal_device" "web1" {
   hostname         = "web1"
   plan             = "c3.small.x86"
   metro            = "sv"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 

--- a/examples/data-sources/equinix_metal_spot_market_request/example_1.tf
+++ b/examples/data-sources/equinix_metal_spot_market_request/example_1.tf
@@ -11,7 +11,7 @@ resource "equinix_metal_spot_market_request" "req" {
   instance_parameters {
     hostname         = "testspot"
     billing_cycle    = "hourly"
-    operating_system = "ubuntu_20_04"
+    operating_system = "ubuntu_24_04"
     plan             = "c3.small.x86"
   }
 }

--- a/examples/resources/equinix_metal_bgp_session/example_1.tf
+++ b/examples/resources/equinix_metal_bgp_session/example_1.tf
@@ -24,7 +24,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "terraform-test-bgp-sesh"
   plan             = "c3.small.x86"
   metro            = ["ny"]
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }

--- a/examples/resources/equinix_metal_device/example_1.tf
+++ b/examples/resources/equinix_metal_device/example_1.tf
@@ -2,7 +2,7 @@ resource "equinix_metal_device" "web1" {
   hostname         = "tf.coreos2"
   plan             = "c3.small.x86"
   metro            = "sv"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }

--- a/examples/resources/equinix_metal_device/example_3.tf
+++ b/examples/resources/equinix_metal_device/example_3.tf
@@ -2,7 +2,7 @@ resource "equinix_metal_device" "web1" {
   hostname         = "tf.coreos2"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
   ip_address {

--- a/examples/resources/equinix_metal_device/example_4.tf
+++ b/examples/resources/equinix_metal_device/example_4.tf
@@ -2,7 +2,7 @@ resource "equinix_metal_device" "web1" {
   hostname                = "tftest"
   plan                    = "c3.small.x86"
   metro                   = "ny"
-  operating_system        = "ubuntu_20_04"
+  operating_system        = "ubuntu_24_04"
   billing_cycle           = "hourly"
   project_id              = local.project_id
   hardware_reservation_id = "next-available"

--- a/examples/resources/equinix_metal_port_vlan_attachment/example_1.tf
+++ b/examples/resources/equinix_metal_port_vlan_attachment/example_1.tf
@@ -8,7 +8,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "test"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }

--- a/examples/resources/equinix_metal_port_vlan_attachment/example_2.tf
+++ b/examples/resources/equinix_metal_port_vlan_attachment/example_2.tf
@@ -2,7 +2,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "test"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }

--- a/examples/resources/equinix_metal_project_ssh_key/example_1.tf
+++ b/examples/resources/equinix_metal_project_ssh_key/example_1.tf
@@ -12,7 +12,7 @@ resource "equinix_metal_device" "test" {
   hostname            = "test"
   plan                = "c3.medium.x86"
   metro               = "ny"
-  operating_system    = "ubuntu_20_04"
+  operating_system    = "ubuntu_24_04"
   billing_cycle       = "hourly"
   project_ssh_key_ids = [equinix_metal_project_ssh_key.test.id]
   project_id          = local.project_id

--- a/examples/resources/equinix_metal_reserved_ip_block/example_2.tf
+++ b/examples/resources/equinix_metal_reserved_ip_block/example_2.tf
@@ -11,7 +11,7 @@ resource "equinix_metal_device" "nodes" {
   project_id       = local.project_id
   metro            = "sv"
   plan             = "c3.small.x86"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   hostname         = "test"
   billing_cycle    = "hourly"
 

--- a/examples/resources/equinix_metal_spot_market_request/example_1.tf
+++ b/examples/resources/equinix_metal_spot_market_request/example_1.tf
@@ -9,7 +9,7 @@ resource "equinix_metal_spot_market_request" "req" {
   instance_parameters {
     hostname         = "testspot"
     billing_cycle    = "hourly"
-    operating_system = "ubuntu_20_04"
+    operating_system = "ubuntu_24_04"
     plan             = "c3.small.x86"
   }
 }

--- a/examples/resources/equinix_metal_ssh_key/example_1.tf
+++ b/examples/resources/equinix_metal_ssh_key/example_1.tf
@@ -10,7 +10,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "test-device"
   plan             = "c3.small.x86"
   metro            = "sv"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
   depends_on       = ["equinix_metal_ssh_key.key1"]

--- a/internal/acceptance/device_helpers.go
+++ b/internal/acceptance/device_helpers.go
@@ -10,7 +10,7 @@ import (
 var (
 	Preferable_plans  = []string{"x1.small.x86", "t1.small.x86", "c2.medium.x86", "c3.small.x86", "c3.medium.x86", "m3.small.x86"}
 	Preferable_metros = []string{"ch", "ny", "sv", "ty", "am"}
-	Preferable_os     = []string{"ubuntu_20_04"}
+	Preferable_os     = []string{"ubuntu_24_04"}
 )
 
 func TestDeviceTerminationTime() string {

--- a/internal/acceptance/device_helpers.go
+++ b/internal/acceptance/device_helpers.go
@@ -13,8 +13,8 @@ var (
 	PreferableOs     = []string{"ubuntu_24_04"}
 )
 
-// TestDeviceTerminationTime returns the time 60 minutes in the future
-func TestDeviceTerminationTime() string {
+// DeviceTerminationTime returns the time 60 minutes in the future
+func DeviceTerminationTime() string {
 	return time.Now().UTC().Add(60 * time.Minute).Format(time.RFC3339)
 }
 

--- a/internal/acceptance/device_helpers.go
+++ b/internal/acceptance/device_helpers.go
@@ -8,22 +8,22 @@ import (
 
 // list of plans and metros and os used as filter criteria to find available hardware to run tests
 var (
-	Preferable_plans  = []string{"x1.small.x86", "t1.small.x86", "c2.medium.x86", "c3.small.x86", "c3.medium.x86", "m3.small.x86"}
-	Preferable_metros = []string{"ch", "ny", "sv", "ty", "am"}
-	Preferable_os     = []string{"ubuntu_24_04"}
+	PreferablePlans  = []string{"x1.small.x86", "t1.small.x86", "c2.medium.x86", "c3.small.x86", "c3.medium.x86", "m3.small.x86"}
+	PreferableMetros = []string{"ch", "ny", "sv", "ty", "am"}
+	PreferableOs     = []string{"ubuntu_24_04"}
 )
-
+// TestDeviceTerminationTime returns the time 60 minutes in the future
 func TestDeviceTerminationTime() string {
 	return time.Now().UTC().Add(60 * time.Minute).Format(time.RFC3339)
 }
 
-// This function should be used to find available plans in all test where a metal_device resource is needed.
+// ConfAccMetalDeviceBase should be used to find available plans in all test where a metal_device resource is needed.
 //
 // TODO consider adding a datasource for equinix_metal_operating_system and making the local.os conditional
 //
 //	https://github.com/equinix/terraform-provider-equinix/pull/220#discussion_r915418418equinix_metal_operating_system
 //	https://github.com/equinix/terraform-provider-equinix/discussions/221
-func ConfAccMetalDevice_base(plans, metros, os []string) string {
+func ConfAccMetalDeviceBase(plans, metros, os []string) string {
 	return fmt.Sprintf(`
 data "equinix_metal_plans" "test" {
     sort {

--- a/internal/acceptance/device_helpers.go
+++ b/internal/acceptance/device_helpers.go
@@ -12,6 +12,7 @@ var (
 	PreferableMetros = []string{"ch", "ny", "sv", "ty", "am"}
 	PreferableOs     = []string{"ubuntu_24_04"}
 )
+
 // TestDeviceTerminationTime returns the time 60 minutes in the future
 func TestDeviceTerminationTime() string {
 	return time.Now().UTC().Add(60 * time.Minute).Format(time.RFC3339)

--- a/internal/acceptance/device_helpers_test.go
+++ b/internal/acceptance/device_helpers_test.go
@@ -1,0 +1,58 @@
+package acceptance
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeviceTerminationTime(t *testing.T) {
+	expectedTime := time.Now().UTC().Add(60 * time.Minute)
+	result := DeviceTerminationTime()
+
+	parsedTime, err := time.Parse(time.RFC3339, result)
+	if err != nil {
+		t.Fatalf("Failed to parse time: %v", err)
+	}
+	drift := parsedTime.Sub(expectedTime)
+
+	if drift < 0 {
+		drift = -drift // get absolute value
+	}
+
+	if drift > time.Second {
+		t.Errorf("Expected time close to %v, but got %v", expectedTime, parsedTime)
+	}
+}
+
+func TestConfAccMetalDeviceBase(t *testing.T) {
+	plans := []string{"c3.small.x86", "m3.large.x86"}
+	metros := []string{"ny5", "sv15"}
+	os := []string{"ubuntu_22_04"}
+
+	result := ConfAccMetalDeviceBase(plans, metros, os)
+
+	// Check that all plans are included
+	for _, plan := range plans {
+		if !strings.Contains(result, plan) {
+			t.Errorf("Expected plan %q to be in result", plan)
+		}
+	}
+
+	// Check that all metros are included
+	for _, metro := range metros {
+		if !strings.Contains(result, metro) {
+			t.Errorf("Expected metro %q to be in result", metro)
+		}
+	}
+
+	// Check that the OS is included
+	if !strings.Contains(result, os[0]) {
+		t.Errorf("Expected OS %q to be in result", os[0])
+	}
+
+	// Check for correct quoting
+	if !strings.Contains(result, `"c3.small.x86"`) {
+		t.Errorf("Expected quoted plan name in result")
+	}
+}

--- a/internal/resources/metal/device/datasource_test.go
+++ b/internal/resources/metal/device/datasource_test.go
@@ -60,7 +60,7 @@ resource "equinix_metal_device" "test" {
 data "equinix_metal_device" "test" {
   project_id       = equinix_metal_project.test.id
   hostname         = equinix_metal_device.test.hostname
-}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.DeviceTerminationTime())
 }
 
 func TestAccDataSourceMetalDevice_byID(t *testing.T) {
@@ -113,5 +113,5 @@ resource "equinix_metal_device" "test" {
 
 data "equinix_metal_device" "test" {
   device_id       = equinix_metal_device.test.id
-}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.DeviceTerminationTime())
 }

--- a/internal/resources/metal/device/datasource_test.go
+++ b/internal/resources/metal/device/datasource_test.go
@@ -60,7 +60,7 @@ resource "equinix_metal_device" "test" {
 data "equinix_metal_device" "test" {
   project_id       = equinix_metal_project.test.id
   hostname         = equinix_metal_device.test.hostname
-}`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime())
 }
 
 func TestAccDataSourceMetalDevice_byID(t *testing.T) {
@@ -113,5 +113,5 @@ resource "equinix_metal_device" "test" {
 
 data "equinix_metal_device" "test" {
   device_id       = equinix_metal_device.test.id
-}`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime())
 }

--- a/internal/resources/metal/device/list_datasource_test.go
+++ b/internal/resources/metal/device/list_datasource_test.go
@@ -79,5 +79,5 @@ data "equinix_metal_devices" "test_search" {
   project_id = equinix_metal_project.test.id
   search     = "unlikelystring"
   depends_on = [equinix_metal_device.dev_search]
-}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.DeviceTerminationTime())
 }

--- a/internal/resources/metal/device/list_datasource_test.go
+++ b/internal/resources/metal/device/list_datasource_test.go
@@ -79,5 +79,5 @@ data "equinix_metal_devices" "test_search" {
   project_id = equinix_metal_project.test.id
   search     = "unlikelystring"
   depends_on = [equinix_metal_device.dev_search]
-}`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime())
 }

--- a/internal/resources/metal/device/resource_test.go
+++ b/internal/resources/metal/device/resource_test.go
@@ -315,7 +315,7 @@ func TestAccMetalDevice_IPXEConflictingFields(t *testing.T) {
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccMetalDeviceConfig_ipxe_conflict, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), rs),
+				Config: fmt.Sprintf(testAccMetalDeviceConfig_ipxe_conflict, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), rs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMetalDeviceExists(r, &device),
 				),
@@ -337,7 +337,7 @@ func TestAccMetalDevice_IPXEConfigMissing(t *testing.T) {
 		CheckDestroy:             testAccMetalDeviceCheckDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccMetalDeviceConfig_ipxe_missing, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), rs),
+				Config: fmt.Sprintf(testAccMetalDeviceConfig_ipxe_missing, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), rs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMetalDeviceExists(r, &device),
 				),
@@ -595,7 +595,7 @@ resource "equinix_metal_device" "test" {
   tags             = ["%d"]
   termination_time = "%s"
 }
-`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, rInt, rInt, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, acceptance.TestDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_reinstall(rInt int, projSuffix string) string {
@@ -622,7 +622,7 @@ resource "equinix_metal_device" "test" {
 	  deprovision_fast = true
   }
 }
-`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, rInt, rInt, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, acceptance.TestDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_allowAttributeChanges(rInt int, projSuffix string, userdata string, customdata string, attributeName string) string {
@@ -651,7 +651,7 @@ resource "equinix_metal_device" "test" {
     ]
   }
 }
-`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, rInt, rInt, userdata, customdata, acceptance.TestDeviceTerminationTime(), attributeName)
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, userdata, customdata, acceptance.TestDeviceTerminationTime(), attributeName)
 }
 
 func testAccMetalDeviceConfig_varname(rInt int, projSuffix string) string {
@@ -673,7 +673,7 @@ resource "equinix_metal_device" "test" {
   tags             = ["%d"]
   termination_time = "%s"
 }
-`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, rInt, rInt, rInt, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, rInt, acceptance.TestDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_minimal(projSuffix string) string {
@@ -689,7 +689,7 @@ resource "equinix_metal_device" "test" {
   metro            = local.metro
   operating_system = local.os
   project_id       = "${equinix_metal_project.test.id}"
-}`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix)
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix)
 }
 
 func testAccMetalDeviceConfig_basic(projSuffix string) string {
@@ -709,7 +709,7 @@ resource "equinix_metal_device" "test" {
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
   termination_time = "%s"
-}`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_ssh_key(projSuffix, userSSHKey, projSSHKey string) string {
@@ -741,7 +741,7 @@ resource "equinix_metal_device" "test" {
 	user_ssh_key_ids = [equinix_metal_ssh_key.test.owner_id]
 	project_ssh_key_ids = [equinix_metal_project_ssh_key.test.id]
   }
-`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, projSuffix, userSSHKey, projSSHKey, projSSHKey)
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, projSuffix, userSSHKey, projSSHKey, projSSHKey)
 }
 
 func testAccMetalDeviceConfig_ipxe_script_url(projSuffix, url, pxe string) string {
@@ -764,7 +764,7 @@ resource "equinix_metal_device" "test_ipxe_script_url"  {
   ipxe_script_url  = "%s"
   always_pxe       = "%s"
   termination_time = "%s"
-}`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, url, pxe, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, url, pxe, acceptance.TestDeviceTerminationTime())
 }
 
 var testAccMetalDeviceConfig_ipxe_conflict = `
@@ -836,7 +836,7 @@ resource "equinix_metal_device" "test" {
     delete = "%s"
   }
 }
-`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, acceptance.TestDeviceTerminationTime(), createTimeout, updateTimeout, deleteTimeout)
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime(), createTimeout, updateTimeout, deleteTimeout)
 }
 
 func testAccMetalDeviceConfig_reinstall_timeout(projSuffix, updateTimeout string) string {
@@ -870,7 +870,7 @@ resource "equinix_metal_device" "test" {
 	update = "%s"
   }
 }
-`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, acceptance.TestDeviceTerminationTime(), updateTimeout)
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime(), updateTimeout)
 }
 
 func testAccWaitForMetalDeviceActive(project, deviceHostName string) resource.ImportStateIdFunc {
@@ -1017,5 +1017,5 @@ resource "equinix_metal_device" "test" {
   project_id       = "${equinix_metal_project.test.id}"
   locked           = %v
   termination_time = "%s"
-}`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), projSuffix, locked, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, locked, acceptance.TestDeviceTerminationTime())
 }

--- a/internal/resources/metal/device/resource_test.go
+++ b/internal/resources/metal/device/resource_test.go
@@ -595,7 +595,7 @@ resource "equinix_metal_device" "test" {
   tags             = ["%d"]
   termination_time = "%s"
 }
-`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, acceptance.DeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_reinstall(rInt int, projSuffix string) string {
@@ -622,7 +622,7 @@ resource "equinix_metal_device" "test" {
 	  deprovision_fast = true
   }
 }
-`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, acceptance.DeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_allowAttributeChanges(rInt int, projSuffix string, userdata string, customdata string, attributeName string) string {
@@ -651,7 +651,7 @@ resource "equinix_metal_device" "test" {
     ]
   }
 }
-`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, userdata, customdata, acceptance.TestDeviceTerminationTime(), attributeName)
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, userdata, customdata, acceptance.DeviceTerminationTime(), attributeName)
 }
 
 func testAccMetalDeviceConfig_varname(rInt int, projSuffix string) string {
@@ -673,7 +673,7 @@ resource "equinix_metal_device" "test" {
   tags             = ["%d"]
   termination_time = "%s"
 }
-`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, rInt, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, rInt, rInt, rInt, acceptance.DeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_minimal(projSuffix string) string {
@@ -709,7 +709,7 @@ resource "equinix_metal_device" "test" {
   billing_cycle    = "hourly"
   project_id       = "${equinix_metal_project.test.id}"
   termination_time = "%s"
-}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.DeviceTerminationTime())
 }
 
 func testAccMetalDeviceConfig_ssh_key(projSuffix, userSSHKey, projSSHKey string) string {
@@ -764,7 +764,7 @@ resource "equinix_metal_device" "test_ipxe_script_url"  {
   ipxe_script_url  = "%s"
   always_pxe       = "%s"
   termination_time = "%s"
-}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, url, pxe, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, url, pxe, acceptance.DeviceTerminationTime())
 }
 
 var testAccMetalDeviceConfig_ipxe_conflict = `
@@ -836,7 +836,7 @@ resource "equinix_metal_device" "test" {
     delete = "%s"
   }
 }
-`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime(), createTimeout, updateTimeout, deleteTimeout)
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.DeviceTerminationTime(), createTimeout, updateTimeout, deleteTimeout)
 }
 
 func testAccMetalDeviceConfig_reinstall_timeout(projSuffix, updateTimeout string) string {
@@ -870,7 +870,7 @@ resource "equinix_metal_device" "test" {
 	update = "%s"
   }
 }
-`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.TestDeviceTerminationTime(), updateTimeout)
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, acceptance.DeviceTerminationTime(), updateTimeout)
 }
 
 func testAccWaitForMetalDeviceActive(project, deviceHostName string) resource.ImportStateIdFunc {
@@ -1017,5 +1017,5 @@ resource "equinix_metal_device" "test" {
   project_id       = "${equinix_metal_project.test.id}"
   locked           = %v
   termination_time = "%s"
-}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, locked, acceptance.TestDeviceTerminationTime())
+}`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), projSuffix, locked, acceptance.DeviceTerminationTime())
 }

--- a/internal/resources/metal/port/datasource_test.go
+++ b/internal/resources/metal/port/datasource_test.go
@@ -51,7 +51,7 @@ data "equinix_metal_port" "test" {
     name      = "eth0"
 }
 
-`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), name, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), name, acceptance.TestDeviceTerminationTime())
 }
 
 func TestAccDataSourceMetalPort_byId(t *testing.T) {
@@ -94,5 +94,5 @@ resource "equinix_metal_device" "test" {
 data "equinix_metal_port" "test" {
   port_id        = equinix_metal_device.test.ports[0].id
 }
-`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), name, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), name, acceptance.TestDeviceTerminationTime())
 }

--- a/internal/resources/metal/port/datasource_test.go
+++ b/internal/resources/metal/port/datasource_test.go
@@ -51,7 +51,7 @@ data "equinix_metal_port" "test" {
     name      = "eth0"
 }
 
-`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), name, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), name, acceptance.DeviceTerminationTime())
 }
 
 func TestAccDataSourceMetalPort_byId(t *testing.T) {
@@ -94,5 +94,5 @@ resource "equinix_metal_device" "test" {
 data "equinix_metal_port" "test" {
   port_id        = equinix_metal_device.test.ports[0].id
 }
-`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), name, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), name, acceptance.DeviceTerminationTime())
 }

--- a/internal/resources/metal/port/resource_test.go
+++ b/internal/resources/metal/port/resource_test.go
@@ -45,7 +45,7 @@ locals {
   eth0_id  = [for p in equinix_metal_device.test.ports: p.id if p.name == "eth0"][0]
 }
 
-`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), name, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), name, acceptance.DeviceTerminationTime())
 }
 
 func confAccMetalPort_L3(name string) string {

--- a/internal/resources/metal/port/resource_test.go
+++ b/internal/resources/metal/port/resource_test.go
@@ -45,7 +45,7 @@ locals {
   eth0_id  = [for p in equinix_metal_device.test.ports: p.id if p.name == "eth0"][0]
 }
 
-`, acceptance.ConfAccMetalDevice_base(acceptance.Preferable_plans, acceptance.Preferable_metros, acceptance.Preferable_os), name, acceptance.TestDeviceTerminationTime())
+`, acceptance.ConfAccMetalDeviceBase(acceptance.PreferablePlans, acceptance.PreferableMetros, acceptance.PreferableOs), name, acceptance.TestDeviceTerminationTime())
 }
 
 func confAccMetalPort_L3(name string) string {

--- a/internal/resources/metal/project_ssh_key/resource_test.go
+++ b/internal/resources/metal/project_ssh_key/resource_test.go
@@ -45,7 +45,7 @@ resource "equinix_metal_device" "test" {
 		acceptance.PreferableOs),
 		name,
 		publicSshKey,
-		acceptance.TestDeviceTerminationTime())
+		acceptance.DeviceTerminationTime())
 }
 
 func TestAccMetalProjectSSHKey_basic(t *testing.T) {

--- a/internal/resources/metal/project_ssh_key/resource_test.go
+++ b/internal/resources/metal/project_ssh_key/resource_test.go
@@ -39,10 +39,10 @@ resource "equinix_metal_device" "test" {
     termination_time    = "%s"
 }
 
-`, acceptance.ConfAccMetalDevice_base(
-		acceptance.Preferable_plans,
-		acceptance.Preferable_metros,
-		acceptance.Preferable_os),
+`, acceptance.ConfAccMetalDeviceBase(
+		acceptance.PreferablePlans,
+		acceptance.PreferableMetros,
+		acceptance.PreferableOs),
 		name,
 		publicSshKey,
 		acceptance.TestDeviceTerminationTime())

--- a/templates/guides/migration_guide_equinix_metal.md
+++ b/templates/guides/migration_guide_equinix_metal.md
@@ -121,7 +121,7 @@ resource "metal_device" "example" {
   project_id       = local.project_id
   facilities       = ["sv15"]
   plan             = "c3.medium.x86"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   hostname         = "test"
   billing_cycle    = "hourly"
 
@@ -196,7 +196,7 @@ resource "equinix_metal_device" "example" {
   project_id       = local.project_id
   facilities       = ["sv15"]
   plan             = "c3.medium.x86"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   hostname         = "test"
   billing_cycle    = "hourly"
 

--- a/templates/guides/migration_guide_packet.md
+++ b/templates/guides/migration_guide_packet.md
@@ -121,7 +121,7 @@ resource "packet_device" "example" {
   project_id       = local.project_id
   facilities       = ["sv15"]
   plan             = "c3.medium.x86"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   hostname         = "test"
   billing_cycle    = "hourly"
 
@@ -196,7 +196,7 @@ resource "equinix_metal_device" "example" {
   project_id       = local.project_id
   facilities       = ["sv15"]
   plan             = "c3.medium.x86"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   hostname         = "test"
   billing_cycle    = "hourly"
 

--- a/templates/guides/network_types.md
+++ b/templates/guides/network_types.md
@@ -141,7 +141,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-port-vlan-attachment-test"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -173,7 +173,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "test${count.index}"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }
@@ -202,7 +202,7 @@ resource "equinix_metal_device" "test" {
   hostname         = "tfacc-device-port-vlan-attachment-test"
   plan             = "c3.small.x86"
   metro            = "ny"
-  operating_system = "ubuntu_20_04"
+  operating_system = "ubuntu_24_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
 }


### PR DESCRIPTION
Ubuntu 20.04 will reach end of life on May 31 on Equinix Metal. This PR will replace any mention of `ubuntu_20_04` with the newer `ubuntu_24_04` version of the operating system.