### PR TITLE
[Feature]: Allow update of VLAN description

### DIFF
--- a/internal/resources/metal/vlan/resource.go
+++ b/internal/resources/metal/vlan/resource.go
@@ -19,11 +19,17 @@ var (
 	vlanDefaultIncludes = []string{"assigned_to", "facility", "metro"}
 )
 
+// Resource defines the Terraform resource implementation for managing VLANs.
+// It embeds framework.BaseResource to inherit core resource behavior and
+// framework.WithTimeouts to support customizable operation timeouts.
 type Resource struct {
 	framework.BaseResource
 	framework.WithTimeouts
 }
 
+// NewResource creates and returns a new instance of the VLAN Terraform resource.
+// It initializes the resource with a base configuration, including its name,
+// and returns it as a framework-compatible resource.Resource interface
 func NewResource() resource.Resource {
 	r := Resource{
 		BaseResource: framework.NewBaseResource(
@@ -36,9 +42,13 @@ func NewResource() resource.Resource {
 	return &r
 }
 
+// Schema defines the Terraform schema for the equinix_metal_vlan resource.
+// It retrieves the base schema using resourceSchema, ensures the Blocks map is initialized,
+// and assigns the resulting schema to the response. This method is called by the Terraform
+// framework during provider initialization to understand the structure of the resource.
 func (r *Resource) Schema(
 	ctx context.Context,
-	req resource.SchemaRequest,
+	_ resource.SchemaRequest,
 	resp *resource.SchemaResponse,
 ) {
 	s := resourceSchema(ctx)
@@ -49,6 +59,17 @@ func (r *Resource) Schema(
 	resp.Schema = s
 }
 
+// Create provisions a new VLAN resource in Equinix Metal using the Terraform framework.
+// It performs the following steps:
+//    1. Adds the Terraform framework module to the Equinix Metal user agent.
+//    2. Parses and validates the input configuration from the Terraform plan.
+//    3. Validates that either a facility or metro is specified, and that VXLAN is only set for metro VLANs.
+//    4. Constructs a VirtualNetworkCreateRequest and sends it to the Equinix Metal API.
+//    5. Retrieves the newly created VLAN with default include fields to ensure full state population.
+//    6. Parses the API response into the Terraform state model.
+//    7. Sets the final state for Terraform to track.
+//
+// Any errors encountered during these steps are added to the diagnostics response to inform the user.
 func (r *Resource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	r.Meta.AddFwModuleToMetalUserAgent(ctx, request.ProviderMeta)
 	client := r.Meta.Metal
@@ -140,6 +161,16 @@ func (r *Resource) Read(ctx context.Context, request resource.ReadRequest, respo
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
+// Update modifies an existing VLAN resource in Equinix Metal based on the desired state
+// provided in the Terraform plan. It performs the following steps:
+//    1. Initializes a new Metal client using the provider metadata.
+//    2. Retrieves the current and planned state from the Terraform request.
+//    3. Compares relevant fields (currently only Description) and constructs an update request.
+//    4. Sends the update request to the Equinix Metal API.
+//    5. Parses the updated VLAN response into the Terraform state model.
+//    6. Updates the Terraform state with the new data.
+//
+// Any errors encountered during the update process are added to the diagnostics response.
 func (r *Resource) Update(
 	ctx context.Context,
 	req resource.UpdateRequest,
@@ -164,7 +195,7 @@ func (r *Resource) Update(
 	}
 
 	// Update the resource
-	vlan, _, err := client.VLANsApi.UpdateVirtualNetwork(ctx, id).VirtualNetworkUpdateInput(*updateRequest).Execute()
+	vlan, _, err := client.VLANsApi.UpdateVirtualNetwork(ctx, id).VirtualNetworkUpdateInput(*updateRequest).Include([]string{"assigned_to"}).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating resource",
@@ -183,6 +214,16 @@ func (r *Resource) Update(
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
+// Delete removes a VLAN resource from Equinix Metal using the Terraform framework.
+// It performs the following steps:
+//    1. Adds the Terraform framework module to the Equinix Metal user agent.
+//    2. Retrieves the current state of the resource from Terraform.
+//    3. Fetches the VLAN from the Equinix Metal API, including related instances and ports.
+//    4. Iterates through all attached devices and unassigns the VLAN from their ports.
+//    5. Deletes the VLAN from the Equinix Metal project.
+//
+// If the VLAN is not found or access is forbidden, the method exits gracefully with a warning.
+// Any other errors encountered during unassignment or deletion are added to the diagnostics response.
 func (r *Resource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
 	r.Meta.AddFwModuleToMetalUserAgent(ctx, request.ProviderMeta)
 	client := r.Meta.Metal

--- a/internal/resources/metal/vlan/resource_schema.go
+++ b/internal/resources/metal/vlan/resource_schema.go
@@ -14,7 +14,7 @@ import (
 	equinixplanmodifiers "github.com/equinix/terraform-provider-equinix/internal/planmodifiers"
 )
 
-func resourceSchema(ctx context.Context) schema.Schema {
+func resourceSchema(_ context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -34,9 +34,6 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"description": schema.StringAttribute{
 				Description: "Description string",
 				Optional:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"facility": schema.StringAttribute{
 				Description:        "Facility where to create the VLAN",

--- a/internal/resources/metal/vlan/resource_test.go
+++ b/internal/resources/metal/vlan/resource_test.go
@@ -91,6 +91,22 @@ func TestAccMetalVlan_metro(t *testing.T) {
 				Config:   testAccCheckMetalVlanConfig_metro(rs, strings.ToLower(upperDallas), "tfacc-vlan"),
 				PlanOnly: true,
 			},
+			{
+				// Update VLAN with description "tfacc-vlan-updated"
+				Config: testAccCheckMetalVlanConfig_metro(rs, strings.ToLower(upperDallas), "tfacc-vlan-updated"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("equinix_metal_vlan.foovlan", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMetalVlanExists("equinix_metal_vlan.foovlan", &vlan),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_vlan.foovlan", "description", "tfacc-vlan-updated"),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_vlan.foovlan", "metro", upperDallas),
+				),
+			},
 		},
 	})
 }

--- a/internal/resources/metal/vlan/resource_test.go
+++ b/internal/resources/metal/vlan/resource_test.go
@@ -91,9 +91,37 @@ func TestAccMetalVlan_metro(t *testing.T) {
 				Config:   testAccCheckMetalVlanConfig_metro(rs, strings.ToLower(upperDallas), "tfacc-vlan"),
 				PlanOnly: true,
 			},
+		},
+	})
+}
+
+func TestAccMetalVlan_descriptionUpdate(t *testing.T) {
+	var vlan packngo.VirtualNetwork
+	rs := acctest.RandString(10)
+	metro := "sv"
+	description := "tfacc-vlan"
+	updatedDescription := "tfacc-vlan-updated"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccMetalVlanCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// Create VLAN with description
+				Config: testAccCheckMetalVlanConfig_metro(rs, metro, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMetalVlanExists("equinix_metal_vlan.foovlan", &vlan),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_vlan.foovlan", "description", description),
+					resource.TestCheckResourceAttr(
+						"equinix_metal_vlan.foovlan", "metro", metro),
+				),
+			},
 			{
 				// Update VLAN with description "tfacc-vlan-updated"
-				Config: testAccCheckMetalVlanConfig_metro(rs, strings.ToLower(upperDallas), "tfacc-vlan-updated"),
+				Config: testAccCheckMetalVlanConfig_metro(rs, metro, updatedDescription),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("equinix_metal_vlan.foovlan", plancheck.ResourceActionUpdate),
@@ -102,9 +130,9 @@ func TestAccMetalVlan_metro(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetalVlanExists("equinix_metal_vlan.foovlan", &vlan),
 					resource.TestCheckResourceAttr(
-						"equinix_metal_vlan.foovlan", "description", "tfacc-vlan-updated"),
+						"equinix_metal_vlan.foovlan", "description", updatedDescription),
 					resource.TestCheckResourceAttr(
-						"equinix_metal_vlan.foovlan", "metro", upperDallas),
+						"equinix_metal_vlan.foovlan", "metro", metro),
 				),
 			},
 		},


### PR DESCRIPTION
[closes #898]

This PR will update the metal vlan resource, to support in place update of the Description attribute. As [packngo](https://github.com/equinixmetal-archive/packngo/blob/master/virtualnetworks.go) doesn't support the update method, I had to use the [equinix-sdk-go](https://github.com/equinix/equinix-sdk-go/blob/main/services/metalv1/model_virtual_network.go) implementation of the virtual network resource. 