### PR TITLE
chore: enable code review by service owners for test sweepers

### DIFF
--- a/internal/sweep/services/fabric.go
+++ b/internal/sweep/services/fabric.go
@@ -1,0 +1,27 @@
+// Package services for registering service-specific test sweepers
+package services
+
+import (
+	"github.com/equinix/terraform-provider-equinix/internal/resources/fabric/streamalertrule"
+
+	fabric_cloud_router "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/cloud_router"
+	fabric_connection "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/connection"
+	fabric_route_filter "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/route_filter"
+	fabric_route_aggregation "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/routeaggregation"
+	fabric_stream "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/stream"
+
+	"github.com/equinix/terraform-provider-equinix/internal/resources/fabric/network"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/fabric/serviceprofile"
+)
+
+// AddFabricTestSweepers registers test sweepers for Fabric resources
+func AddFabricTestSweepers() {
+	fabric_cloud_router.AddTestSweeper()
+	fabric_connection.AddTestSweeper()
+	fabric_route_filter.AddTestSweeper()
+	fabric_route_aggregation.AddTestSweeper()
+	fabric_stream.AddTestSweeper()
+	network.AddTestSweeper()
+	serviceprofile.AddTestSweeper()
+	streamalertrule.AddTestSweeper()
+}

--- a/internal/sweep/services/metal.go
+++ b/internal/sweep/services/metal.go
@@ -1,0 +1,27 @@
+// Package services for registering service-specific test sweepers
+package services
+
+import (
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/connection"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/device"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/organization"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/project"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/ssh_key"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/user_api_key"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/virtual_circuit"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vlan"
+	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vrf"
+)
+
+// AddMetalTestSweepers registers test sweepers for Fabric resources
+func AddMetalTestSweepers() {
+	connection.AddTestSweeper()
+	device.AddTestSweeper()
+	organization.AddTestSweeper()
+	project.AddTestSweeper()
+	ssh_key.AddTestSweeper()
+	user_api_key.AddTestSweeper()
+	virtual_circuit.AddTestSweeper()
+	vlan.AddTestSweeper()
+	vrf.AddTestSweeper()
+}

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -3,52 +3,14 @@ package sweep_test
 import (
 	"testing"
 
-	"github.com/equinix/terraform-provider-equinix/internal/resources/fabric/streamalertrule"
-
-	fabric_cloud_router "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/cloud_router"
-	fabric_connection "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/connection"
-	fabric_route_filter "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/route_filter"
-	fabric_route_aggregation "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/routeaggregation"
-	fabric_stream "github.com/equinix/terraform-provider-equinix/internal/resources/fabric/stream"
-
-	"github.com/equinix/terraform-provider-equinix/internal/resources/fabric/network"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/fabric/serviceprofile"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/connection"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/device"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/organization"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/project"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/ssh_key"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/user_api_key"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/virtual_circuit"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vlan"
-	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vrf"
-
+	"github.com/equinix/terraform-provider-equinix/internal/sweep/services"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestMain(m *testing.M) {
 	// Register sweepers for individual resource packages
-	addTestSweepers()
+	services.AddFabricTestSweepers()
+	services.AddMetalTestSweepers()
 
 	resource.TestMain(m)
-}
-
-func addTestSweepers() {
-	connection.AddTestSweeper()
-	device.AddTestSweeper()
-	fabric_cloud_router.AddTestSweeper()
-	fabric_connection.AddTestSweeper()
-	fabric_route_filter.AddTestSweeper()
-	fabric_route_aggregation.AddTestSweeper()
-	fabric_stream.AddTestSweeper()
-	network.AddTestSweeper()
-	organization.AddTestSweeper()
-	project.AddTestSweeper()
-	serviceprofile.AddTestSweeper()
-	ssh_key.AddTestSweeper()
-	streamalertrule.AddTestSweeper()
-	user_api_key.AddTestSweeper()
-	virtual_circuit.AddTestSweeper()
-	vlan.AddTestSweeper()
-	vrf.AddTestSweeper()
 }


### PR DESCRIPTION
This replicates the approach taken for provider resource and data source registration in #797 and applies it to test sweeper registration so that service teams can add and remove test sweepers for their own resources as needed without waiting for review from a cross-cutting team.