### PR TITLE
feat: Add extension to renovate to do gha action digest pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "postUpdateOptions": [
     "gomodTidy"


### PR DESCRIPTION
* Instead of manually updating commit digests as shown in #913 , this renovate extension should perform the same changes in a less copy-paste error prone manner