### PR TITLE
chore: deprecate spot-market requests

### DIFF
--- a/docs/data-sources/metal_spot_market_request.md
+++ b/docs/data-sources/metal_spot_market_request.md
@@ -2,7 +2,7 @@
 subcategory: "Metal"
 ---
 
-> **DEPRECATED:** This data source is deprecated and will be removed in a future release.
+> **DEPRECATED:** This data source has been deprecated and and is no longer supported.
 
 # equinix_metal_spot_market_request (Data Source)
 

--- a/docs/data-sources/metal_spot_market_request.md
+++ b/docs/data-sources/metal_spot_market_request.md
@@ -4,7 +4,6 @@ subcategory: "Metal"
 
 # equinix_metal_spot_market_request (Data Source)
 
-This endpoint has been sunset.
 Provides an Equinix Metal spot_market_request datasource. The datasource will contain list of device IDs created by referenced Spot Market Request.
 
 ## Example Usage

--- a/docs/data-sources/metal_spot_market_request.md
+++ b/docs/data-sources/metal_spot_market_request.md
@@ -4,6 +4,7 @@ subcategory: "Metal"
 
 # equinix_metal_spot_market_request (Data Source)
 
+This endpoint has been sunset.
 Provides an Equinix Metal spot_market_request datasource. The datasource will contain list of device IDs created by referenced Spot Market Request.
 
 ## Example Usage

--- a/docs/data-sources/metal_spot_market_request.md
+++ b/docs/data-sources/metal_spot_market_request.md
@@ -2,6 +2,8 @@
 subcategory: "Metal"
 ---
 
+> **DEPRECATED:** This data source is deprecated and will be removed in a future release.
+
 # equinix_metal_spot_market_request (Data Source)
 
 Provides an Equinix Metal spot_market_request datasource. The datasource will contain list of device IDs created by referenced Spot Market Request.

--- a/docs/resources/metal_spot_market_request.md
+++ b/docs/resources/metal_spot_market_request.md
@@ -2,6 +2,8 @@
 subcategory: "Metal"
 ---
 
+> **DEPRECATED:** This data source is deprecated and will be removed in a future release.
+
 # equinix_metal_spot_market_request (Resource)
 
 Provides an Equinix Metal Spot Market Request resource to allow you to manage spot market requests on your account. For more detail on Spot Market, see [this article in Equinix Metal documentation](https://metal.equinix.com/developers/docs/deploy/spot-market/).

--- a/docs/resources/metal_spot_market_request.md
+++ b/docs/resources/metal_spot_market_request.md
@@ -2,7 +2,7 @@
 subcategory: "Metal"
 ---
 
-> **DEPRECATED:** This data source is deprecated and will be removed in a future release.
+> **DEPRECATED:** This resource has been deprecated and is no longer supported.
 
 # equinix_metal_spot_market_request (Resource)
 

--- a/equinix/data_source_metal_spot_market_request.go
+++ b/equinix/data_source_metal_spot_market_request.go
@@ -18,7 +18,8 @@ import (
 
 func dataSourceMetalSpotMarketRequest() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMetalSpotMarketRequestRead,
+		DeprecationMessage: "The Spot Market Requests API has been sunset.",
+		ReadContext:        dataSourceMetalSpotMarketRequestRead,
 
 		Schema: map[string]*schema.Schema{
 			"request_id": {
@@ -85,6 +86,12 @@ func dataSourceMetalSpotMarketRequest() *schema.Resource {
 }
 
 func dataSourceMetalSpotMarketRequestRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+	diags = append(diags, diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  "Spot Market Requests API has been sunset.",
+		Detail:   "This data source is no longer supported.",
+	})
 	client := meta.(*config.Config).Metal
 	id := d.Get("request_id").(string)
 

--- a/equinix/data_source_metal_spot_market_request.go
+++ b/equinix/data_source_metal_spot_market_request.go
@@ -1,3 +1,4 @@
+//nolint:all // These files will be removed in a future release and should never be changed before then
 package equinix
 
 import (

--- a/equinix/data_source_metal_spot_market_request.go
+++ b/equinix/data_source_metal_spot_market_request.go
@@ -86,12 +86,6 @@ func dataSourceMetalSpotMarketRequest() *schema.Resource {
 }
 
 func dataSourceMetalSpotMarketRequestRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	diags := diag.Diagnostics{}
-	diags = append(diags, diag.Diagnostic{
-		Severity: diag.Warning,
-		Summary:  "Spot Market Requests API has been sunset.",
-		Detail:   "This data source is no longer supported.",
-	})
 	client := meta.(*config.Config).Metal
 	id := d.Get("request_id").(string)
 

--- a/equinix/data_source_metal_spot_market_request.go
+++ b/equinix/data_source_metal_spot_market_request.go
@@ -1,6 +1,7 @@
 package equinix
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"time"
@@ -84,7 +85,7 @@ func dataSourceMetalSpotMarketRequest() *schema.Resource {
 	}
 }
 
-func dataSourceMetalSpotMarketRequestRead(_, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceMetalSpotMarketRequestRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).Metal
 	id := d.Get("request_id").(string)
 

--- a/equinix/data_source_metal_spot_market_request.go
+++ b/equinix/data_source_metal_spot_market_request.go
@@ -1,7 +1,6 @@
 package equinix
 
 import (
-	"context"
 	"sort"
 	"strings"
 	"time"
@@ -85,7 +84,7 @@ func dataSourceMetalSpotMarketRequest() *schema.Resource {
 	}
 }
 
-func dataSourceMetalSpotMarketRequestRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceMetalSpotMarketRequestRead(_, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.Config).Metal
 	id := d.Get("request_id").(string)
 

--- a/equinix/resource_metal_spot_market_request.go
+++ b/equinix/resource_metal_spot_market_request.go
@@ -29,9 +29,10 @@ var (
 
 func resourceMetalSpotMarketRequest() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceMetalSpotMarketRequestCreate,
-		ReadContext:   resourceMetalSpotMarketRequestRead,
-		DeleteContext: resourceMetalSpotMarketRequestDelete,
+		DeprecationMessage: "This resource is deprecated and does not work anymore.",
+		CreateContext:      resourceMetalSpotMarketRequestCreate,
+		ReadContext:        resourceMetalSpotMarketRequestRead,
+		DeleteContext:      resourceMetalSpotMarketRequestDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/equinix/resource_metal_spot_market_request.go
+++ b/equinix/resource_metal_spot_market_request.go
@@ -30,7 +30,7 @@ var (
 
 func resourceMetalSpotMarketRequest() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "This resource is deprecated and does not work anymore.",
+		DeprecationMessage: "This resource has been deprecated and is no longer supported.",
 		CreateContext:      resourceMetalSpotMarketRequestCreate,
 		ReadContext:        resourceMetalSpotMarketRequestRead,
 		DeleteContext:      resourceMetalSpotMarketRequestDelete,

--- a/equinix/resource_metal_spot_market_request.go
+++ b/equinix/resource_metal_spot_market_request.go
@@ -1,3 +1,4 @@
+//nolint:all // These files will be removed in a future release and should never be changed before then
 package equinix
 
 import (

--- a/templates/data-sources/metal_spot_market_request.md.tmpl
+++ b/templates/data-sources/metal_spot_market_request.md.tmpl
@@ -6,6 +6,8 @@ subcategory: "Metal"
 
 For example, the {{ .SchemaMarkdown }} template can be used to replace manual schema documentation if descriptions of schema attributes are added in the provider source code. */ -}}
 
+> **DEPRECATED:** This data source is deprecated and will be removed in a future release.
+
 # equinix_metal_spot_market_request (Data Source)
 
 Provides an Equinix Metal spot_market_request datasource. The datasource will contain list of device IDs created by referenced Spot Market Request.

--- a/templates/data-sources/metal_spot_market_request.md.tmpl
+++ b/templates/data-sources/metal_spot_market_request.md.tmpl
@@ -6,7 +6,7 @@ subcategory: "Metal"
 
 For example, the {{ .SchemaMarkdown }} template can be used to replace manual schema documentation if descriptions of schema attributes are added in the provider source code. */ -}}
 
-> **DEPRECATED:** This data source is deprecated and will be removed in a future release.
+> **DEPRECATED:** This data source has been deprecated and and is no longer supported.
 
 # equinix_metal_spot_market_request (Data Source)
 

--- a/templates/resources/metal_spot_market_request.md.tmpl
+++ b/templates/resources/metal_spot_market_request.md.tmpl
@@ -5,7 +5,7 @@ subcategory: "Metal"
 {{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.
 
 For example, the {{ .SchemaMarkdown }} template can be used to replace manual schema documentation if descriptions of schema attributes are added in the provider source code. */ -}}
-> **DEPRECATED:** This data source is deprecated and will be removed in a future release.
+> **DEPRECATED:** This resource has been deprecated and is no longer supported.
 
 # equinix_metal_spot_market_request (Resource)
 

--- a/templates/resources/metal_spot_market_request.md.tmpl
+++ b/templates/resources/metal_spot_market_request.md.tmpl
@@ -5,6 +5,7 @@ subcategory: "Metal"
 {{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.
 
 For example, the {{ .SchemaMarkdown }} template can be used to replace manual schema documentation if descriptions of schema attributes are added in the provider source code. */ -}}
+> **DEPRECATED:** This data source is deprecated and will be removed in a future release.
 
 # equinix_metal_spot_market_request (Resource)
 


### PR DESCRIPTION
To declare deprecation for spot market, this is to mark the endpoint as deprecated.
No customers are using spot market currently and have been communicated of sunset.