### PR TITLE
fix: Update terraform provider to add format field for grafana stream subscription

### DIFF
--- a/docs/data-sources/fabric_stream_subscription.md
+++ b/docs/data-sources/fabric_stream_subscription.md
@@ -114,6 +114,7 @@ Read-Only:
 - `application_key` (String)
 - `event_index` (String)
 - `event_uri` (String)
+- `format` (String)
 - `metric_index` (String)
 - `metric_uri` (String)
 - `source` (String)

--- a/docs/data-sources/fabric_stream_subscriptions.md
+++ b/docs/data-sources/fabric_stream_subscriptions.md
@@ -139,6 +139,7 @@ Read-Only:
 - `application_key` (String)
 - `event_index` (String)
 - `event_uri` (String)
+- `format` (String)
 - `metric_index` (String)
 - `metric_uri` (String)
 - `source` (String)

--- a/docs/resources/fabric_stream_subscription.md
+++ b/docs/resources/fabric_stream_subscription.md
@@ -174,6 +174,7 @@ Optional:
 - `application_key` (String)
 - `event_index` (String)
 - `event_uri` (String)
+- `format` (String)
 - `metric_index` (String)
 - `metric_uri` (String)
 - `source` (String)

--- a/internal/resources/fabric/stream_subscription/datasources_schema.go
+++ b/internal/resources/fabric/stream_subscription/datasources_schema.go
@@ -201,7 +201,7 @@ func getStreamSubscriptionSchema(ctx context.Context) map[string]schema.Attribut
 				"settings": schema.SingleNestedAttribute{
 					Description: "Stream subscription sink settings",
 					Computed:    true,
-					CustomType:  fwtypes.NewObjectTypeOf[sinkCredentialModel](ctx),
+					CustomType:  fwtypes.NewObjectTypeOf[sinkSettingsModel](ctx),
 					Attributes: map[string]schema.Attribute{
 						"event_index": schema.StringAttribute{
 							Computed: true,
@@ -219,6 +219,9 @@ func getStreamSubscriptionSchema(ctx context.Context) map[string]schema.Attribut
 							Computed: true,
 						},
 						"metric_uri": schema.StringAttribute{
+							Computed: true,
+						},
+						"format": schema.StringAttribute{
 							Computed: true,
 						},
 					},

--- a/internal/resources/fabric/stream_subscription/models.go
+++ b/internal/resources/fabric/stream_subscription/models.go
@@ -260,6 +260,7 @@ func (m *baseStreamSubscriptionModel) parse(ctx context.Context, streamSubscript
 		EventURI:       types.StringValue(streamSubSinkSettings.GetEventUri()),
 		MetricURI:      types.StringValue(streamSubSinkSettings.GetMetricUri()),
 	}
+	sink.Settings = fwtypes.NewObjectValueOf[sinkSettingsModel](ctx, &sinkSettings)
 
 	if !planSinkModel.Settings.IsNull() && !planSinkModel.Settings.IsUnknown() {
 		planSettingsModel := sinkSettingsModel{}

--- a/internal/resources/fabric/stream_subscription/models.go
+++ b/internal/resources/fabric/stream_subscription/models.go
@@ -90,6 +90,7 @@ type sinkSettingsModel struct {
 	ApplicationKey types.String `tfsdk:"application_key"`
 	EventURI       types.String `tfsdk:"event_uri"`
 	MetricURI      types.String `tfsdk:"metric_uri"`
+	Format         types.String `tfsdk:"format"`
 }
 
 type changeLogModel struct {
@@ -259,6 +260,7 @@ func (m *baseStreamSubscriptionModel) parse(ctx context.Context, streamSubscript
 		ApplicationKey: types.StringValue(streamSubSinkSettings.GetApplicationKey()),
 		EventURI:       types.StringValue(streamSubSinkSettings.GetEventUri()),
 		MetricURI:      types.StringValue(streamSubSinkSettings.GetMetricUri()),
+		Format:         types.StringValue(string(streamSubSinkSettings.GetFormat())),
 	}
 	sink.Settings = fwtypes.NewObjectValueOf[sinkSettingsModel](ctx, &sinkSettings)
 

--- a/internal/resources/fabric/stream_subscription/models.go
+++ b/internal/resources/fabric/stream_subscription/models.go
@@ -250,6 +250,7 @@ func (m *baseStreamSubscriptionModel) parse(ctx context.Context, streamSubscript
 	}
 
 	sink.Credential = fwtypes.NewObjectValueOf[sinkCredentialModel](ctx, &credentialModel)
+
 	streamSubSinkSettings := streamSubSink.GetSettings()
 	sinkSettings := sinkSettingsModel{
 		EventIndex:     types.StringValue(streamSubSinkSettings.GetEventIndex()),

--- a/internal/resources/fabric/stream_subscription/models.go
+++ b/internal/resources/fabric/stream_subscription/models.go
@@ -262,7 +262,6 @@ func (m *baseStreamSubscriptionModel) parse(ctx context.Context, streamSubscript
 		MetricURI:      types.StringValue(streamSubSinkSettings.GetMetricUri()),
 		Format:         types.StringValue(string(streamSubSinkSettings.GetFormat())),
 	}
-	sink.Settings = fwtypes.NewObjectValueOf[sinkSettingsModel](ctx, &sinkSettings)
 
 	if !planSinkModel.Settings.IsNull() && !planSinkModel.Settings.IsUnknown() {
 		planSettingsModel := sinkSettingsModel{}

--- a/internal/resources/fabric/stream_subscription/resource.go
+++ b/internal/resources/fabric/stream_subscription/resource.go
@@ -416,6 +416,9 @@ func buildStreamSubscriptionSink(ctx context.Context, sinkObject fwtypes.ObjectV
 		if !settingsModel.MetricURI.IsNull() && !settingsModel.MetricURI.IsUnknown() {
 			settings.SetMetricUri(settingsModel.MetricURI.ValueString())
 		}
+		if !settingsModel.Format.IsNull() && !settingsModel.Format.IsUnknown() {
+			settings.SetFormat(fabricv4.StreamSubscriptionSinkSettingFormat(settingsModel.Format.ValueString()))
+		}
 		sink.SetSettings(settings)
 	}
 

--- a/internal/resources/fabric/stream_subscription/resource_schema.go
+++ b/internal/resources/fabric/stream_subscription/resource_schema.go
@@ -252,6 +252,13 @@ Additional Documentation:
 									stringplanmodifier.UseStateForUnknown(),
 								},
 							},
+							"format": schema.StringAttribute{
+								Optional: true,
+								Computed: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Add new field - `format` (this is only present in webhook and grafana stream subscriptions) 
