### PR TITLE
chore(ci): fix code ownership for templates/guides/network_types.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,5 @@
 *data_source_network_*       @equinix/governor-ne-network-edge-engineering
 edge-networking              @equinix/governor-ne-network-edge-engineering
 network_*                    @equinix/governor-ne-network-edge-engineering
-docs/guides/network_types.md @equinix/governor-metal-client-interfaces
+*/guides/network_types.md    @equinix/governor-metal-client-interfaces
 equinix_network_*            @equinix/governor-ne-network-edge-engineering


### PR DESCRIPTION
#956 incorrectly requires code owner review from the Network Edge team; that PR does not touch any code or docs related to the Network Edge service.

The `CODEOWNERS` file was previously updated to grant code ownership for `docs/guides/network_types.md` to the Metal team.  This PR updates that rule to cover `templates/guides/network_types.md` as well, since I think the changes to that file are what is tagging Network Edge for review of the Metal docs PR.