### PR TITLE
CXF 116818: Fix Acceptance Tests

### DIFF
--- a/equinix/resource_fabric_routing_protocol.go
+++ b/equinix/resource_fabric_routing_protocol.go
@@ -484,12 +484,6 @@ func routingProtocolPayloadFromType(type_ string, d *schema.ResourceData) (fabri
 			bgpRP.SetCustomerAsn(customerASN)
 		}
 
-		equinixASNSchema := d.Get("equinix_asn")
-		if equinixASNSchema != nil {
-			equinixASN := int64(equinixASNSchema.(int))
-			bgpRP.SetEquinixAsn(equinixASN)
-		}
-
 		bgpAuthKey := d.Get("bgp_auth_key").(string)
 		if bgpAuthKey != "" {
 			bgpRP.SetBgpAuthKey(bgpAuthKey)

--- a/equinix/resource_fabric_routing_protocol_acc_test.go
+++ b/equinix/resource_fabric_routing_protocol_acc_test.go
@@ -64,6 +64,7 @@ func TestAccFabricCreateRoutingProtocols_PFCR(t *testing.T) {
 					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.inbound_med", "4"),
 					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.outbound_med", "7"),
 					resource.TestCheckResourceAttr("equinix_fabric_routing_protocol.bgp", "customer_asn", "100"),
+					resource.TestCheckResourceAttrSet("equinix_fabric_routing_protocol.bgp", "equinix_asn"),
 
 					resource.TestCheckResourceAttrSet("data.equinix_fabric_routing_protocol.direct", "id"),
 					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.direct", "type", "DIRECT"),
@@ -85,6 +86,7 @@ func TestAccFabricCreateRoutingProtocols_PFCR(t *testing.T) {
 					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.equinix_peer_ip", "190::1:1"),
 					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "bgp_ipv6.0.enabled", "true"),
 					resource.TestCheckResourceAttr("data.equinix_fabric_routing_protocol.bgp", "customer_asn", "100"),
+					resource.TestCheckResourceAttrSet("data.equinix_fabric_routing_protocol.bgp", "equinix_asn"),
 				),
 			},
 		},

--- a/equinix/resource_fabric_routing_protocol_acc_test.go
+++ b/equinix/resource_fabric_routing_protocol_acc_test.go
@@ -153,7 +153,7 @@ resource "equinix_fabric_connection" "this" {
 			}
 			link_protocol {
 				type= "DOT1Q"
-				vlan_tag= 1501
+				vlan_tag= 1600
 			}
 			location {
 				metro_code = "SV"

--- a/internal/resources/fabric/connection/datasources_test.go
+++ b/internal/resources/fabric/connection/datasources_test.go
@@ -67,7 +67,7 @@ func TestAccFabricDataSourceConnection_PFCR(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.equinix_fabric_connections.connections", "data.0.a_side.0.access_point.0.link_protocol.0.type", "DOT1Q"),
 					resource.TestCheckResourceAttr(
-						"data.equinix_fabric_connections.connections", "data.0.a_side.0.access_point.0.link_protocol.0.vlan_tag", "1350"),
+						"data.equinix_fabric_connections.connections", "data.0.a_side.0.access_point.0.link_protocol.0.vlan_tag", "123"),
 					resource.TestCheckResourceAttr(
 						"data.equinix_fabric_connections.connections", "data.0.a_side.0.access_point.0.location.0.metro_code", "DC"),
 					resource.TestCheckResourceAttr(
@@ -75,7 +75,7 @@ func TestAccFabricDataSourceConnection_PFCR(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.equinix_fabric_connections.connections", "data.0.z_side.0.access_point.0.link_protocol.0.type", "DOT1Q"),
 					resource.TestCheckResourceAttr(
-						"data.equinix_fabric_connections.connections", "data.0.z_side.0.access_point.0.link_protocol.0.vlan_tag", "1360"),
+						"data.equinix_fabric_connections.connections", "data.0.z_side.0.access_point.0.link_protocol.0.vlan_tag", "456"),
 					resource.TestCheckResourceAttr(
 						"data.equinix_fabric_connections.connections", "data.0.z_side.0.access_point.0.location.0.metro_code", "SV"),
 				),

--- a/internal/resources/fabric/connection/datasources_test.go
+++ b/internal/resources/fabric/connection/datasources_test.go
@@ -40,7 +40,7 @@ func TestAccFabricDataSourceConnection_PFCR(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.equinix_fabric_connection.test", "a_side.0.access_point.0.link_protocol.0.type", "DOT1Q"),
 					resource.TestCheckResourceAttr(
-						"data.equinix_fabric_connection.test", "a_side.0.access_point.0.link_protocol.0.vlan_tag", "1350"),
+						"data.equinix_fabric_connection.test", "a_side.0.access_point.0.link_protocol.0.vlan_tag", "123"),
 					resource.TestCheckResourceAttr(
 						"data.equinix_fabric_connection.test", "a_side.0.access_point.0.location.0.metro_code", "DC"),
 					resource.TestCheckResourceAttr(
@@ -48,7 +48,7 @@ func TestAccFabricDataSourceConnection_PFCR(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.equinix_fabric_connection.test", "z_side.0.access_point.0.link_protocol.0.type", "DOT1Q"),
 					resource.TestCheckResourceAttr(
-						"data.equinix_fabric_connection.test", "z_side.0.access_point.0.link_protocol.0.vlan_tag", "1360"),
+						"data.equinix_fabric_connection.test", "z_side.0.access_point.0.link_protocol.0.vlan_tag", "456"),
 					resource.TestCheckResourceAttr(
 						"data.equinix_fabric_connection.test", "z_side.0.access_point.0.location.0.metro_code", "SV"),
 					resource.TestCheckResourceAttrSet("data.equinix_fabric_connections.connections", "id"),
@@ -107,7 +107,7 @@ resource "equinix_fabric_connection" "test" {
 			}
 			link_protocol {
 				type= "DOT1Q"
-				vlan_tag= 1350
+				vlan_tag= 123
 			}
 		}
 	}
@@ -119,7 +119,7 @@ resource "equinix_fabric_connection" "test" {
 			}
 			link_protocol {
 				type= "DOT1Q"
-				vlan_tag= 1360
+				vlan_tag= 456
 			}
 		}
 	}

--- a/internal/resources/fabric/connection/resource_test.go
+++ b/internal/resources/fabric/connection/resource_test.go
@@ -314,7 +314,7 @@ func TestAccFabricCreateCloudRouter2PortConnection_PFCR(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"equinix_fabric_connection.test", "z_side.0.access_point.0.link_protocol.0.type", "DOT1Q"),
 					resource.TestCheckResourceAttr(
-						"equinix_fabric_connection.test", "z_side.0.access_point.0.link_protocol.0.vlan_tag", "1270"),
+						"equinix_fabric_connection.test", "z_side.0.access_point.0.link_protocol.0.vlan_tag", "101"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -385,7 +385,7 @@ func testAccFabricCreateCloudRouter2PortConnectionConfig(name, portUUID string) 
 				}
 				link_protocol {
 					type= "DOT1Q"
-					vlan_tag= 1270
+					vlan_tag= 101
 				}
 				location {
 					metro_code = "SV"
@@ -610,7 +610,7 @@ func CheckConnectionDelete(s *terraform.State) error {
 
 		err := connection.WaitUntilConnectionDeprovisioned(rs.Primary.ID, acceptance.TestAccProvider.Meta(), &schema.ResourceData{}, ctx, 10*time.Minute)
 		if err != nil {
-			return fmt.Errorf("API call failed while waiting for resource deletion")
+			return fmt.Errorf("connection %s was not properly deprovisioned: %v", rs.Primary.ID, err)
 		}
 	}
 	return nil

--- a/internal/resources/fabric/connection/resource_test.go
+++ b/internal/resources/fabric/connection/resource_test.go
@@ -78,7 +78,7 @@ func TestAccFabricCreatePort2SPConnection_PFCR(t *testing.T) {
 		CheckDestroy: CheckConnectionDelete,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFabricCreatePort2SPConnectionConfig(publicSPName, "port2sp_PFCR", portUUID, "SV"),
+				Config: testAccFabricCreatePort2SPConnectionConfig(publicSPName, "port2sp_PFCR", portUUID, "DC"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("equinix_fabric_connection.test", "id"),
 					resource.TestCheckResourceAttr(
@@ -96,7 +96,7 @@ func TestAccFabricCreatePort2SPConnection_PFCR(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"equinix_fabric_connection.test", "a_side.0.access_point.0.link_protocol.0.type", "DOT1Q"),
 					resource.TestCheckResourceAttr(
-						"equinix_fabric_connection.test", "a_side.0.access_point.0.link_protocol.0.vlan_tag", "1500"),
+						"equinix_fabric_connection.test", "a_side.0.access_point.0.link_protocol.0.vlan_tag", "1230"),
 					resource.TestCheckResourceAttr(
 						"equinix_fabric_connection.test", "z_side.0.access_point.0.type", "SP"),
 					resource.TestCheckResourceAttr(
@@ -104,7 +104,7 @@ func TestAccFabricCreatePort2SPConnection_PFCR(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"equinix_fabric_connection.test", "z_side.0.access_point.0.profile.0.name", publicSPName),
 					resource.TestCheckResourceAttr(
-						"equinix_fabric_connection.test", "z_side.0.access_point.0.location.0.metro_code", "SV"),
+						"equinix_fabric_connection.test", "z_side.0.access_point.0.location.0.metro_code", "DC"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -145,7 +145,7 @@ func testAccFabricCreatePort2SPConnectionConfig(spName, name, portUUID, zSideMet
 				}
 				link_protocol {
 					type= "DOT1Q"
-					vlan_tag= "1500"
+					vlan_tag= "1230"
 				}
 			}
 		}

--- a/internal/resources/fabric/connection_route_filter/resource.go
+++ b/internal/resources/fabric/connection_route_filter/resource.go
@@ -179,13 +179,14 @@ func WaitForDeletion(connectionId, routeFilterId string, meta interface{}, d *sc
 		},
 		Target: []string{
 			string(fabricv4.CONNECTIONROUTEAGGREGATIONDATAATTACHMENTSTATUS_DETACHED),
+			string(fabricv4.ROUTEFILTERSTATE_DEPROVISIONED),
 		},
 		Refresh: func() (interface{}, string, error) {
 			client := meta.(*config.Config).NewFabricClientForSDK(ctx, d)
 			connectionRouteFilter, body, err := client.RouteFiltersApi.GetConnectionRouteFilterByUuid(ctx, routeFilterId, connectionId).Execute()
 			if err != nil {
-				if body.StatusCode >= 400 && body.StatusCode <= 499 {
-					// Already deleted resource
+				if body != nil && body.StatusCode >= 400 && body.StatusCode <= 499 {
+					// Already deleted resource - return DEPROVISIONED state
 					return connectionRouteFilter, string(fabricv4.ROUTEFILTERSTATE_DEPROVISIONED), nil
 				}
 				return "", "", equinix_errors.FormatFabricError(err)

--- a/internal/resources/fabric/connection_route_filter/resource_test.go
+++ b/internal/resources/fabric/connection_route_filter/resource_test.go
@@ -133,7 +133,7 @@ func testAccFabricConnectionRouteFilterConfig(portUUID string) string {
 					}
 					link_protocol {
 						type= "DOT1Q"
-						vlan_tag= 2100
+						vlan_tag= 1000
 					}
 					location {
 						metro_code = "DC"

--- a/internal/resources/fabric/precision_time/resource_test.go
+++ b/internal/resources/fabric/precision_time/resource_test.go
@@ -104,7 +104,7 @@ func testAccFabricCreatePort2EPTNPTConfig(spName, name, portUuid, zSideMetro str
 				}
 				link_protocol {
 					type= "DOT1Q"
-					vlan_tag= 1700
+					vlan_tag= 101
 				}
 			}
 		}
@@ -246,7 +246,7 @@ func testAccFabricCreatePort2EPTPTPConfig(spName, name, portUuid, zSideMetro str
 				}
 				link_protocol {
 					type= "DOT1Q"
-					vlan_tag= "1355"
+					vlan_tag= "2000"
 				}
 			}
 		}

--- a/internal/resources/fabric/precision_time/resource_test.go
+++ b/internal/resources/fabric/precision_time/resource_test.go
@@ -246,7 +246,7 @@ func testAccFabricCreatePort2EPTPTPConfig(spName, name, portUuid, zSideMetro str
 				}
 				link_protocol {
 					type= "DOT1Q"
-					vlan_tag= "2000"
+					vlan_tag= "100"
 				}
 			}
 		}


### PR DESCRIPTION
This pull request updates test configurations and improves error handling for Equinix Fabric resources. The main changes include adjustments to VLAN tags and metro codes in test cases to ensure consistency, enhancements to error messages for resource deletion, and improvements to route filter deletion handling.

**Test configuration updates:**

* Updated VLAN tag values in multiple test files (`resource_fabric_routing_protocol_acc_test.go`, `datasources_test.go`, `resource_test.go`, `connection_route_filter/resource_test.go`, `precision_time/resource_test.go`) to ensure consistency and correctness across test scenarios. [[1]](diffhunk://#diff-3ee129d496ea086e9cf9dcd2bb9718ab2c8fbb0a635fe557546cfd8170e1a8dbL156-R158) [[2]](diffhunk://#diff-8cd0af9cae8e9179e2385e53bd7a51e2bed78adaf0223a1c4e44faa176401dd9L110-R110) [[3]](diffhunk://#diff-8cd0af9cae8e9179e2385e53bd7a51e2bed78adaf0223a1c4e44faa176401dd9L122-R122) [[4]](diffhunk://#diff-e08e53bb509612dc7397be6e15465bfa6ca34093f4a9f229efbf90587778e7a1L99-R107) [[5]](diffhunk://#diff-e08e53bb509612dc7397be6e15465bfa6ca34093f4a9f229efbf90587778e7a1L148-R148) [[6]](diffhunk://#diff-e08e53bb509612dc7397be6e15465bfa6ca34093f4a9f229efbf90587778e7a1L317-R317) [[7]](diffhunk://#diff-e08e53bb509612dc7397be6e15465bfa6ca34093f4a9f229efbf90587778e7a1L388-R388) [[8]](diffhunk://#diff-2eb77652b5e27e027393049e4532806d64b3f7c9a80f50d968dec36ed45d2b56L136-R136) [[9]](diffhunk://#diff-9db0130b76d45d887bc1693871dbe5afdf80dfe0e978d512be22f4eb39e8b5ceL107-R107) [[10]](diffhunk://#diff-9db0130b76d45d887bc1693871dbe5afdf80dfe0e978d512be22f4eb39e8b5ceL249-R249)
* Changed metro code values in test cases to align with updated requirements, such as switching from "SV" to "DC". [[1]](diffhunk://#diff-e08e53bb509612dc7397be6e15465bfa6ca34093f4a9f229efbf90587778e7a1L81-R81) [[2]](diffhunk://#diff-e08e53bb509612dc7397be6e15465bfa6ca34093f4a9f229efbf90587778e7a1L99-R107)

**Test validation improvements:**

* Added assertions to check that the `equinix_asn` attribute is set in routing protocol tests, improving test coverage for ASN fields. [[1]](diffhunk://#diff-3ee129d496ea086e9cf9dcd2bb9718ab2c8fbb0a635fe557546cfd8170e1a8dbR67) [[2]](diffhunk://#diff-3ee129d496ea086e9cf9dcd2bb9718ab2c8fbb0a635fe557546cfd8170e1a8dbR89)

**Error handling enhancements:**

* Improved error messages in the `CheckConnectionDelete` function to include the connection ID and error details, aiding debugging when resource deletion fails.
* Enhanced the `WaitForDeletion` function for route filters to handle 4xx errors by explicitly returning the DEPROVISIONED state, making deletion handling more robust.

**Code cleanup:**

* Removed unused code for setting the Equinix ASN in the routing protocol payload, as this is now handled elsewhere or is redundant.