### PR TITLE
feat!: remove deprecated Network Edge attributes

### DIFF
--- a/docs/resources/network_acl_template.md
+++ b/docs/resources/network_acl_template.md
@@ -39,12 +39,10 @@ The following arguments are supported:
 * `name` - (Required) ACL template name.
 * `project_id` - (Optional) Unique Identifier for the project resource where the acl template is scoped to.If you leave it out, the ACL template will be created under the default project id of your organization.
 * `description` - (Optional) ACL template description, up to 200 characters.
-* `metro_code` - (Deprecated) ACL template location metro code.
 * `inbound_rule` - (Required) One or more rules to specify allowed inbound traffic. Rules are ordered, matching traffic rule stops processing subsequent ones.
 
 The `inbound_rule` block has below fields:
 
-* `subnets` - (Deprecated) Inbound traffic source IP subnets in CIDR format.
 * `subnet` - (Required) Inbound traffic source IP subnet in CIDR format.
 * `protocol` - (Required) Inbound traffic protocol. One of `IP`, `TCP`, `UDP`.
 * `src_port` - (Required) Inbound traffic source ports. Allowed values are a comma separated list of ports, e.g., `20,22,23`, port range, e.g., `1023-1040` or word `any`.
@@ -56,7 +54,6 @@ The `inbound_rule` block has below fields:
 In addition to all arguments above, the following attributes are exported:
 
 * `uuid` - Unique identifier of ACL template resource.
-* `device_id` - (Deprecated) Identifier of a network device where template was applied.
 * `device_acl_status` - Status of ACL template provisioning process, where template was applied. One of `PROVISIONING`, `PROVISIONED`.
 * `device_details` - List of the devices where the ACL template is applied.
 

--- a/docs/resources/network_device_link.md
+++ b/docs/resources/network_device_link.md
@@ -25,10 +25,9 @@ resource "equinix_network_device_link" "test" {
     asn          = equinix_network_device.test.secondary_device[0].asn > 0 ? equinix_network_device.test.secondary_device[0].asn : 22333
     interface_id = 7
   }
-  link {
+  metro_link {
     account_number  = equinix_network_device.test.account_number
-    src_metro_code  = equinix_network_device.test.metro_code
-    dst_metro_code  = equinix_network_device.test.secondary_device[0].metro_code
+    metro_code      = equinix_network_device.test.metro_code
     throughput      = "50"
     throughput_unit = "Mbps"
   }
@@ -42,7 +41,6 @@ The following arguments are supported:
 * `name` - (Required) device link name.
 * `subnet` - (Optional) device link subnet in CIDR format. Not required for link between self configured devices.
 * `device` - (Required) definition of one or more devices belonging to the device link. See [Device](#device) section below for more details.
-* `link` - (Deprecated) definition of one or more, inter metro, connections belonging to the device link. See [Link](#link) section below for more details.
 * `metro_link` - (Optional) definition of one or more, inter metro, connections belonging to the device link. See [Metro Link](#metro_link) section below for more details.
 * `redundancy_type` - (Optional) Whether the connection should be created through Fabric's primary or secondary port. Supported values: `PRIMARY` (Default), `SECONDARY`, `HYBRID`
 * `project_id` - (Optional) Unique Identifier for the project resource where the device link is scoped to.If you leave it out, the device link will be created under the default project id of your organization.
@@ -54,18 +52,6 @@ The `device` block supports the following arguments:
 * `id` - (Required) Device identifier.
 * `asn` - (Optional) Device ASN number. Not required for self configured devices.
 * `interface_id` - (Optional) Device network interface identifier to use for device link connection.
-
-### Link
-
-The `link` block supports the following arguments:
-
-* `account_number` - (Required) billing account number to be used for connection charges
-* `throughput` - (Required) connection throughput.
-* `throughput_unit` - (Required) connection throughput unit (Mbps or Gbps).
-* `src_metro_code` - (Required) connection source metro code.
-* `dst_metro_code` - (Required) connection destination metro code.
-* `src_zone_code` - (Deprecated) connection source zone code is not required.
-* `dst_zone_code` - (Deprecated) connection destination zone code is not required.
 
 ### Metro_Link
 

--- a/equinix/resource_network_acl_template.go
+++ b/equinix/resource_network_acl_template.go
@@ -3,11 +3,9 @@ package equinix
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/equinix/terraform-provider-equinix/internal/config"
-	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	equinix_validation "github.com/equinix/terraform-provider-equinix/internal/validation"
 
 	"github.com/equinix/ne-go"
@@ -21,8 +19,6 @@ var networkACLTemplateSchemaNames = map[string]string{
 	"UUID":            "uuid",
 	"Name":            "name",
 	"Description":     "description",
-	"MetroCode":       "metro_code",
-	"DeviceUUID":      "device_id",
 	"DeviceACLStatus": "device_acl_status",
 	"InboundRules":    "inbound_rule",
 	"DeviceDetails":   "device_details",
@@ -33,8 +29,6 @@ var networkACLTemplateDescriptions = map[string]string{
 	"UUID":            "Unique identifier of ACL template resource",
 	"Name":            "ACL template name",
 	"Description":     "ACL template description, up to 200 characters",
-	"MetroCode":       "ACL template location metro code",
-	"DeviceUUID":      "Identifier of a network device where template was applied",
 	"DeviceACLStatus": "Status of ACL template provisioning process on a device, where template was applied",
 	"InboundRules":    "One or more rules to specify allowed inbound traffic. Rules are ordered, matching traffic rule stops processing subsequent ones.",
 	"DeviceDetails":   "Device Details to which ACL template is assigned to. ",
@@ -43,8 +37,6 @@ var networkACLTemplateDescriptions = map[string]string{
 
 var networkACLTemplateInboundRuleSchemaNames = map[string]string{
 	"SeqNo":       "sequence_number",
-	"SrcType":     "source_type",
-	"Subnets":     "subnets",
 	"Subnet":      "subnet",
 	"Protocol":    "protocol",
 	"SrcPort":     "src_port",
@@ -54,8 +46,6 @@ var networkACLTemplateInboundRuleSchemaNames = map[string]string{
 
 var networkACLTemplateInboundRuleDescriptions = map[string]string{
 	"SeqNo":       "Inbound rule sequence number",
-	"SrcType":     "Type of traffic source used in a given inbound rule",
-	"Subnets":     "Inbound traffic source IP subnets in CIDR format",
 	"Subnet":      "Inbound traffic source IP subnet in CIDR format",
 	"Protocol":    "Inbound traffic protocol. One of: `IP`, `TCP`, `UDP`",
 	"SrcPort":     "Inbound traffic source ports. Either up to 10, comma separated ports or port range or any word",
@@ -69,18 +59,6 @@ var networkACLTemplateDeviceDetailSchemaNames = map[string]string{
 	"ACLStatus": "acl_status",
 }
 
-var networkACLTemplateDeviceDetailDescription = map[string]string{
-	"UUID":      "Unique Identifier for the device",
-	"Name":      "Device Name",
-	"ACLStatus": "Device ACL Provisioning status",
-}
-
-var networkACLTemplateDeprecateDescriptions = map[string]string{
-	"DeviceUUID": "Refer to device details get device information",
-	"MetroCode":  "Metro Code is no longer required",
-	"Subnets":    "Use Subnet instead",
-}
-
 func resourceNetworkACLTemplate() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceNetworkACLTemplateCreate,
@@ -88,7 +66,7 @@ func resourceNetworkACLTemplate() *schema.Resource {
 		UpdateContext: resourceNetworkACLTemplateUpdate,
 		DeleteContext: resourceNetworkACLTemplateDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema:      createNetworkACLTemplateSchema(),
 		Description: "Resource allows creation and management of Equinix Network Edge device Access Control List templates",
@@ -113,19 +91,6 @@ func createNetworkACLTemplateSchema() map[string]*schema.Schema {
 			Optional:     true,
 			ValidateFunc: validation.StringLenBetween(1, 200),
 			Description:  networkACLTemplateDescriptions["Description"],
-		},
-		networkACLTemplateSchemaNames["MetroCode"]: {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Deprecated:   networkACLTemplateDeprecateDescriptions["MetroCode"],
-			ValidateFunc: equinix_validation.StringIsMetroCode,
-			Description:  networkACLTemplateDescriptions["MetroCode"],
-		},
-		networkACLTemplateSchemaNames["DeviceUUID"]: {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Deprecated:  networkACLTemplateDeprecateDescriptions["DeviceUUID"],
-			Description: networkACLTemplateDescriptions["DeviceUUID"],
 		},
 		networkACLTemplateSchemaNames["DeviceACLStatus"]: {
 			Type:        schema.TypeString,
@@ -166,23 +131,6 @@ func createNetworkACLTemplateInboundRuleSchema() map[string]*schema.Schema {
 			Type:        schema.TypeInt,
 			Computed:    true,
 			Description: networkACLTemplateInboundRuleDescriptions["SeqNo"],
-		},
-		networkACLTemplateInboundRuleSchemaNames["SrcType"]: {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: networkACLTemplateInboundRuleDescriptions["SrcType"],
-			Deprecated:  "Source Type will not be returned",
-		},
-		networkACLTemplateInboundRuleSchemaNames["Subnets"]: {
-			Type:     schema.TypeList,
-			Optional: true,
-			MinItems: 1,
-			Elem: &schema.Schema{
-				Type:         schema.TypeString,
-				ValidateFunc: validation.IsCIDR,
-			},
-			Description: networkACLTemplateInboundRuleDescriptions["Subnets"],
-			Deprecated:  networkACLTemplateDeprecateDescriptions["Subnets"],
 		},
 		networkACLTemplateInboundRuleSchemaNames["Subnet"]: {
 			Type:         schema.TypeString,
@@ -251,7 +199,7 @@ func resourceNetworkACLTemplateCreate(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceNetworkACLTemplateRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceNetworkACLTemplateRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*config.Config).Ne
 	m.(*config.Config).AddModuleToNEUserAgent(&client, d)
 	var diags diag.Diagnostics
@@ -283,15 +231,10 @@ func resourceNetworkACLTemplateUpdate(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceNetworkACLTemplateDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceNetworkACLTemplateDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*config.Config).Ne
 	m.(*config.Config).AddModuleToNEUserAgent(&client, d)
 	var diags diag.Diagnostics
-	if devID, ok := d.GetOk(networkACLTemplateSchemaNames["DeviceUUID"]); ok {
-		if err := client.NewDeviceUpdateRequest(devID.(string)).WithACLTemplate("").Execute(); err != nil {
-			log.Printf("[WARN] could not unassign ACL template %q from device %q: %s", d.Id(), devID, err)
-		}
-	}
 	if err := client.DeleteACLTemplate(d.Id()); err != nil {
 		return diag.FromErr(err)
 	}
@@ -308,9 +251,6 @@ func createACLTemplate(d *schema.ResourceData) ne.ACLTemplate {
 	}
 	if v, ok := d.GetOk(networkACLTemplateSchemaNames["ProjectID"]); ok {
 		template.ProjectID = ne.String(v.(string))
-	}
-	if v, ok := d.GetOk(networkACLTemplateSchemaNames["MetroCode"]); ok {
-		template.MetroCode = ne.String(v.(string))
 	}
 	if v, ok := d.GetOk(networkACLTemplateSchemaNames["InboundRules"]); ok {
 		template.InboundRules = expandACLTemplateInboundRules(v.([]interface{}))
@@ -334,11 +274,7 @@ func updateACLTemplateResource(template *ne.ACLTemplate, d *schema.ResourceData)
 	if err := d.Set(networkACLTemplateSchemaNames["ProjectID"], template.ProjectID); err != nil {
 		return fmt.Errorf("error reading %s: %s", networkACLTemplateSchemaNames["ProjectID"], err)
 	}
-	var inboundRules []ne.ACLTemplateInboundRule
-	if v, ok := d.GetOk(networkACLTemplateSchemaNames["InboundRules"]); ok {
-		inboundRules = expandACLTemplateInboundRules(v.([]interface{}))
-	}
-	if err := d.Set(networkACLTemplateSchemaNames["InboundRules"], flattenACLTemplateInboundRules(inboundRules, template.InboundRules)); err != nil {
+	if err := d.Set(networkACLTemplateSchemaNames["InboundRules"], flattenACLTemplateInboundRules(template.InboundRules)); err != nil {
 		return fmt.Errorf("error reading %s: %s", networkACLTemplateSchemaNames["InboundRules"], err)
 	}
 	if err := d.Set(networkACLTemplateSchemaNames["DeviceDetails"], flattenACLTemplateDeviceDetails(template.DeviceDetails)); err != nil {
@@ -354,9 +290,6 @@ func expandACLTemplateInboundRules(rules []interface{}) []ne.ACLTemplateInboundR
 		ruleMap := rules[i].(map[string]interface{})
 		rule := ne.ACLTemplateInboundRule{}
 		rule.SeqNo = ne.Int(i + 1)
-		if v, ok := ruleMap[networkACLTemplateInboundRuleSchemaNames["Subnets"]]; ok {
-			rule.Subnets = converters.IfArrToStringArr(v.([]interface{}))
-		}
 		if v, ok := ruleMap[networkACLTemplateInboundRuleSchemaNames["Subnet"]]; ok {
 			rule.Subnet = ne.String(v.(string))
 		}
@@ -377,33 +310,19 @@ func expandACLTemplateInboundRules(rules []interface{}) []ne.ACLTemplateInboundR
 	return transformed
 }
 
-func flattenACLTemplateInboundRules(existingRules []ne.ACLTemplateInboundRule, rules []ne.ACLTemplateInboundRule) interface{} {
-	setSubnets := checkExistingSubnets(existingRules)
+func flattenACLTemplateInboundRules(rules []ne.ACLTemplateInboundRule) interface{} {
 	transformed := make([]interface{}, len(rules))
 	for i := range rules {
 		transformedTemplate := make(map[string]interface{})
 		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["SeqNo"]] = rules[i].SeqNo
-		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["SrcType"]] = rules[i].SrcType
 		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["Protocol"]] = rules[i].Protocol
 		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["SrcPort"]] = rules[i].SrcPort
 		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["DstPort"]] = rules[i].DstPort
 		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["Subnet"]] = rules[i].Subnet
 		transformedTemplate[networkACLTemplateInboundRuleSchemaNames["Description"]] = rules[i].Description
-		if setSubnets {
-			transformedTemplate[networkACLTemplateInboundRuleSchemaNames["Subnets"]] = rules[i].Subnets
-		}
 		transformed[i] = transformedTemplate
 	}
 	return transformed
-}
-
-func checkExistingSubnets(existingRules []ne.ACLTemplateInboundRule) bool {
-	for i := range existingRules {
-		if existingRules[i].Subnets != nil && len(existingRules[i].Subnets) > 0 {
-			return true
-		}
-	}
-	return false
 }
 
 func flattenACLTemplateDeviceDetails(rules []ne.ACLTemplateDeviceDetails) interface{} {

--- a/equinix/resource_network_acl_template_test.go
+++ b/equinix/resource_network_acl_template_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/equinix/ne-go"
-	"github.com/equinix/terraform-provider-equinix/internal/converters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,12 +12,10 @@ func TestNetworkACLTemplate_createFromResourceData(t *testing.T) {
 	expected := ne.ACLTemplate{
 		Name:        ne.String("test"),
 		Description: ne.String("testTemplate"),
-		MetroCode:   ne.String("SV"),
 		ProjectID:   ne.String("68ccfd49-39b1-478e-957a-67c72f719d7a"),
 		InboundRules: []ne.ACLTemplateInboundRule{
 			{
 				SeqNo:       ne.Int(1),
-				Subnets:     []string{"10.0.0.0/24", "1.1.1.1/32"},
 				Subnet:      ne.String("10.0.0.0/24"),
 				Protocol:    ne.String("TCP"),
 				SrcPort:     ne.String("any"),
@@ -30,11 +27,12 @@ func TestNetworkACLTemplate_createFromResourceData(t *testing.T) {
 	rawData := map[string]interface{}{
 		networkACLTemplateSchemaNames["Name"]:        ne.StringValue(expected.Name),
 		networkACLTemplateSchemaNames["Description"]: ne.StringValue(expected.Description),
-		networkACLTemplateSchemaNames["MetroCode"]:   ne.StringValue(expected.MetroCode),
 		networkACLTemplateSchemaNames["ProjectID"]:   ne.StringValue(expected.ProjectID),
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkACLTemplateSchema(), rawData)
-	d.Set(networkACLTemplateSchemaNames["InboundRules"], flattenACLTemplateInboundRules(expected.InboundRules, expected.InboundRules))
+	if err := d.Set(networkACLTemplateSchemaNames["InboundRules"], flattenACLTemplateInboundRules(expected.InboundRules)); err != nil {
+		t.Fatal(err)
+	}
 	// when
 	result := createACLTemplate(d)
 	// then
@@ -45,11 +43,9 @@ func TestNetworkACLTemplate_updateResourceData(t *testing.T) {
 	initial := ne.ACLTemplate{
 		Name:        ne.String("test"),
 		Description: ne.String("testTemplate"),
-		MetroCode:   ne.String("SV"),
 		InboundRules: []ne.ACLTemplateInboundRule{
 			{
 				SeqNo:    ne.Int(1),
-				Subnets:  []string{"10.0.0.0/24", "1.1.1.1/32"},
 				Subnet:   ne.String("10.0.0.0/24"),
 				Protocol: ne.String("TCP"),
 				SrcPort:  ne.String("any"),
@@ -60,19 +56,18 @@ func TestNetworkACLTemplate_updateResourceData(t *testing.T) {
 	rawData := map[string]interface{}{
 		networkACLTemplateSchemaNames["Name"]:        ne.StringValue(initial.Name),
 		networkACLTemplateSchemaNames["Description"]: ne.StringValue(initial.Description),
-		networkACLTemplateSchemaNames["MetroCode"]:   ne.StringValue(initial.MetroCode),
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkACLTemplateSchema(), rawData)
-	d.Set(networkACLTemplateSchemaNames["InboundRules"], flattenACLTemplateInboundRules(initial.InboundRules, initial.InboundRules))
+	if err := d.Set(networkACLTemplateSchemaNames["InboundRules"], flattenACLTemplateInboundRules(initial.InboundRules)); err != nil {
+		t.Fatal(err)
+	}
 
 	input := &ne.ACLTemplate{
 		Name:        ne.String("test"),
 		Description: ne.String("testTemplate"),
-		MetroCode:   ne.String("SV"),
 		InboundRules: []ne.ACLTemplateInboundRule{
 			{
 				SeqNo:       ne.Int(1),
-				Subnets:     []string{"10.0.0.0/24", "1.1.1.1/32"},
 				Subnet:      ne.String("10.0.0.0/24"),
 				Protocol:    ne.String("TCP"),
 				SrcPort:     ne.String("any"),
@@ -94,7 +89,6 @@ func TestNetworkACLTemplate_updateResourceData(t *testing.T) {
 	assert.Nil(t, err, "Update of resource data does not return error")
 	assert.Equal(t, ne.StringValue(input.Name), d.Get(networkACLTemplateSchemaNames["Name"]), "Name matches")
 	assert.Equal(t, ne.StringValue(input.Description), d.Get(networkACLTemplateSchemaNames["Description"]), "Description matches")
-	assert.Equal(t, ne.StringValue(input.MetroCode), d.Get(networkACLTemplateSchemaNames["MetroCode"]), "MetroCode matches")
 	assert.Equal(t, input.InboundRules, expandACLTemplateInboundRules(d.Get(networkACLTemplateSchemaNames["InboundRules"]).([]interface{})), "InboundRules matches")
 }
 
@@ -102,7 +96,6 @@ func TestNetworkACLTemplate_expandInboundRules(t *testing.T) {
 	// given
 	input := []interface{}{
 		map[string]interface{}{
-			networkACLTemplateInboundRuleSchemaNames["Subnets"]:     []interface{}{"10.0.0.0/24", "1.1.1.1/32"},
 			networkACLTemplateInboundRuleSchemaNames["Protocol"]:    "TCP",
 			networkACLTemplateInboundRuleSchemaNames["SrcPort"]:     "any",
 			networkACLTemplateInboundRuleSchemaNames["DstPort"]:     "8080",
@@ -116,13 +109,11 @@ func TestNetworkACLTemplate_expandInboundRules(t *testing.T) {
 		},
 	}
 
-	var nilSubnet *string = nil
-	var nilSubnets []string = nil
+	var nilSubnet *string
 
 	expected := []ne.ACLTemplateInboundRule{
 		{
 			SeqNo:       ne.Int(1),
-			Subnets:     converters.IfArrToStringArr(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Subnets"]].([]interface{})),
 			Subnet:      nilSubnet,
 			Protocol:    ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Protocol"]].(string)),
 			SrcPort:     ne.String(input[0].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["SrcPort"]].(string)),
@@ -131,7 +122,6 @@ func TestNetworkACLTemplate_expandInboundRules(t *testing.T) {
 		},
 		{
 			SeqNo:    ne.Int(2),
-			Subnets:  nilSubnets,
 			Subnet:   ne.String(input[1].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Subnet"]].(string)),
 			Protocol: ne.String(input[1].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["Protocol"]].(string)),
 			SrcPort:  ne.String(input[1].(map[string]interface{})[networkACLTemplateInboundRuleSchemaNames["SrcPort"]].(string)),
@@ -148,8 +138,7 @@ func TestNetworkACLTemplate_flattenInboundRules(t *testing.T) {
 	input := []ne.ACLTemplateInboundRule{
 		{
 			SeqNo:       ne.Int(1),
-			SrcType:     ne.String("SUBNET"),
-			Subnets:     []string{"10.0.0.0/24", "1.1.1.1/32"},
+			Subnet:      ne.String("10.0.0.0/24"),
 			Protocol:    ne.String("TCP"),
 			SrcPort:     ne.String("any"),
 			DstPort:     ne.String("8080"),
@@ -157,19 +146,15 @@ func TestNetworkACLTemplate_flattenInboundRules(t *testing.T) {
 		},
 		{
 			SeqNo:    ne.Int(2),
-			SrcType:  ne.String("SUBNET"),
 			Subnet:   ne.String("3.3.3.3/32"),
 			Protocol: ne.String("IP"),
 			SrcPort:  ne.String("any"),
 			DstPort:  ne.String("any"),
 		},
 	}
-	initial := input
 	expected := []interface{}{
 		map[string]interface{}{
 			networkACLTemplateInboundRuleSchemaNames["SeqNo"]:       input[0].SeqNo,
-			networkACLTemplateInboundRuleSchemaNames["SrcType"]:     input[0].SrcType,
-			networkACLTemplateInboundRuleSchemaNames["Subnets"]:     input[0].Subnets,
 			networkACLTemplateInboundRuleSchemaNames["Subnet"]:      input[0].Subnet,
 			networkACLTemplateInboundRuleSchemaNames["Protocol"]:    input[0].Protocol,
 			networkACLTemplateInboundRuleSchemaNames["SrcPort"]:     input[0].SrcPort,
@@ -178,8 +163,6 @@ func TestNetworkACLTemplate_flattenInboundRules(t *testing.T) {
 		},
 		map[string]interface{}{
 			networkACLTemplateInboundRuleSchemaNames["SeqNo"]:       input[1].SeqNo,
-			networkACLTemplateInboundRuleSchemaNames["SrcType"]:     input[1].SrcType,
-			networkACLTemplateInboundRuleSchemaNames["Subnets"]:     input[1].Subnets,
 			networkACLTemplateInboundRuleSchemaNames["Subnet"]:      input[1].Subnet,
 			networkACLTemplateInboundRuleSchemaNames["Protocol"]:    input[1].Protocol,
 			networkACLTemplateInboundRuleSchemaNames["SrcPort"]:     input[1].SrcPort,
@@ -188,7 +171,7 @@ func TestNetworkACLTemplate_flattenInboundRules(t *testing.T) {
 		},
 	}
 	// when
-	result := flattenACLTemplateInboundRules(initial, input)
+	result := flattenACLTemplateInboundRules(input)
 	// then
 	assert.Equal(t, expected, result, "Flattened ACL template inbound rules match expected result")
 }

--- a/equinix/resource_network_device_link.go
+++ b/equinix/resource_network_device_link.go
@@ -25,7 +25,6 @@ var networkDeviceLinkSchemaNames = map[string]string{
 	"Name":           "name",
 	"Subnet":         "subnet",
 	"Devices":        "device",
-	"Links":          "link",
 	"MetroLinks":     "metro_link",
 	"RedundancyType": "redundancy_type",
 	"Status":         "status",
@@ -37,7 +36,6 @@ var networkDeviceLinkDescriptions = map[string]string{
 	"Name":       "Device link name",
 	"Subnet":     "Device link subnet CIDR.",
 	"Devices":    "Definition of one or more devices belonging to the device link",
-	"Links":      "Definition of one or more, inter metro connections belonging to the device link",
 	"MetroLinks": "Definition of one or more, inter or intra metro connections belonging to the device link",
 	"RedundancyType": "(Optional) Whether the connection should be created through " +
 		"Fabric's primary or secondary port. Supported values: `PRIMARY` (Default), `SECONDARY`, `HYBRID`",
@@ -67,18 +65,6 @@ var networkDeviceLinkConnectionSchemaNames = map[string]string{
 	"ThroughputUnit":       "throughput_unit",
 	"SourceMetroCode":      "src_metro_code",
 	"DestinationMetroCode": "dst_metro_code",
-	"SourceZoneCode":       "src_zone_code",
-	"DestinationZoneCode":  "dst_zone_code",
-}
-
-var networkDeviceLinkConnectionDescriptions = map[string]string{
-	"AccountNumber":        "Billing account number to be used for connection charges",
-	"Throughput":           "Connection throughput",
-	"ThroughputUnit":       "Connection throughput unit",
-	"SourceMetroCode":      "Connection source metro code",
-	"DestinationMetroCode": "Connection destination metro code",
-	"SourceZoneCode":       "Connection source zone code",
-	"DestinationZoneCode":  "Connection destination zone code",
 }
 
 var networkDeviceLinkMetroSchemaNames = map[string]string{
@@ -93,11 +79,6 @@ var networkDeviceLinkMetroDescriptions = map[string]string{
 	"metroCode":      "Connection source metro code",
 	"Throughput":     "Connection throughput",
 	"ThroughputUnit": "Connection throughput unit",
-}
-
-var networkDeviceLinkDeprecatedDescriptions = map[string]string{
-	"SourceZoneCode":      "SourceZoneCode is not required",
-	"DestinationZoneCode": "DestinationZoneCode is not required",
 }
 
 func resourceNetworkDeviceLink() *schema.Resource {
@@ -156,8 +137,8 @@ func createNetworkDeviceLinkResourceSchema() map[string]*schema.Schema {
 			ForceNew:     true,
 			Default:      "PRIMARY",
 			ValidateFunc: validation.StringInSlice([]string{"PRIMARY", "SECONDARY", "HYBRID"}, true),
-			DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-				return old == strings.ToUpper(new)
+			DiffSuppressFunc: func(_, old, newVal string, _ *schema.ResourceData) bool {
+				return old == strings.ToUpper(newVal)
 			},
 			Description: networkDeviceLinkDescriptions["RedundancyType"],
 		},
@@ -170,16 +151,6 @@ func createNetworkDeviceLinkResourceSchema() map[string]*schema.Schema {
 			},
 			Set:         networkDeviceLinkDeviceHash,
 			Description: networkDeviceLinkDescriptions["Device"],
-		},
-		networkDeviceLinkSchemaNames["Links"]: {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: createNetworkDeviceLinkConnectionResourceSchema(),
-			},
-			Set:         networkDeviceLinkConnectionHash,
-			Deprecated:  "Links is deprecated. Please use metro links instead.",
-			Description: networkDeviceLinkDescriptions["Links"],
 		},
 		networkDeviceLinkSchemaNames["MetroLinks"]: {
 			Type:     schema.TypeSet,
@@ -221,55 +192,6 @@ func createNetworkDeviceLinkDeviceResourceSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: networkDeviceLinkDeviceDescriptions["IPAddress"],
-		},
-	}
-}
-
-func createNetworkDeviceLinkConnectionResourceSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		networkDeviceLinkConnectionSchemaNames["AccountNumber"]: {
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-			Description:  networkDeviceLinkConnectionDescriptions["AccountNumber"],
-		},
-		networkDeviceLinkConnectionSchemaNames["Throughput"]: {
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-			Description:  networkDeviceLinkConnectionDescriptions["Throughput"],
-		},
-		networkDeviceLinkConnectionSchemaNames["ThroughputUnit"]: {
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: validation.StringInSlice([]string{"Mbps", "Gbps"}, false),
-			Description:  networkDeviceLinkConnectionDescriptions["ThroughputUnit"],
-		},
-		networkDeviceLinkConnectionSchemaNames["SourceMetroCode"]: {
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: equinix_validation.StringIsMetroCode,
-			Description:  networkDeviceLinkConnectionDescriptions["SourceMetroCode"],
-		},
-		networkDeviceLinkConnectionSchemaNames["DestinationMetroCode"]: {
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: equinix_validation.StringIsMetroCode,
-			Description:  networkDeviceLinkConnectionDescriptions["DestinationMetroCode"],
-		},
-		networkDeviceLinkConnectionSchemaNames["SourceZoneCode"]: {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-			Deprecated:   networkDeviceLinkDeprecatedDescriptions["SourceZoneCode"],
-			Description:  networkDeviceLinkConnectionDescriptions["SourceZoneCode"],
-		},
-		networkDeviceLinkConnectionSchemaNames["DestinationZoneCode"]: {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-			Deprecated:   networkDeviceLinkDeprecatedDescriptions["DestinationZoneCode"],
-			Description:  networkDeviceLinkConnectionDescriptions["DestinationZoneCode"],
 		},
 	}
 }
@@ -355,7 +277,7 @@ func resourceNetworkDeviceLinkUpdate(ctx context.Context, d *schema.ResourceData
 	var diags diag.Diagnostics
 	changes := equinix_schema.GetResourceDataChangedKeys([]string{
 		networkDeviceLinkSchemaNames["Name"], networkDeviceLinkSchemaNames["Subnet"],
-		networkDeviceLinkSchemaNames["Devices"], networkDeviceLinkSchemaNames["Links"], networkDeviceLinkSchemaNames["MetroLinks"],
+		networkDeviceLinkSchemaNames["Devices"], networkDeviceLinkSchemaNames["MetroLinks"],
 	}, d)
 	updateReq := client.NewDeviceLinkGroupUpdateRequest(d.Id())
 	for change, changeValue := range changes {
@@ -369,9 +291,6 @@ func resourceNetworkDeviceLinkUpdate(ctx context.Context, d *schema.ResourceData
 		case networkDeviceLinkSchemaNames["Devices"]:
 			deviceList := expandNetworkDeviceLinkDevices(changeValue.(*schema.Set))
 			updateReq.WithDevices(deviceList)
-		case networkDeviceLinkSchemaNames["Links"]:
-			connectionList := expandNetworkDeviceLinkConnections(changeValue.(*schema.Set))
-			updateReq.WithLinks(connectionList)
 		case networkDeviceLinkSchemaNames["MetroLinks"]:
 			metroLinkList := expandNetworkDeviceLinkMetroLinks(changeValue.(*schema.Set))
 			updateReq.WithMetroLinks(metroLinkList)
@@ -430,9 +349,6 @@ func createNetworkDeviceLink(d *schema.ResourceData) ne.DeviceLinkGroup {
 	if v, ok := d.GetOk(networkDeviceLinkSchemaNames["Devices"]); ok {
 		link.Devices = expandNetworkDeviceLinkDevices(v.(*schema.Set))
 	}
-	if v, ok := d.GetOk(networkDeviceLinkSchemaNames["Links"]); ok {
-		link.Links = expandNetworkDeviceLinkConnections(v.(*schema.Set))
-	}
 	if v, ok := d.GetOk(networkDeviceLinkSchemaNames["MetroLinks"]); ok {
 		link.MetroLinks = expandNetworkDeviceLinkMetroLinks(v.(*schema.Set))
 	}
@@ -457,9 +373,6 @@ func updateNetworkDeviceLinkResource(link *ne.DeviceLinkGroup, d *schema.Resourc
 	}
 	if err := d.Set(networkDeviceLinkSchemaNames["Devices"], flattenNetworkDeviceLinkDevices(d.Get(networkDeviceLinkSchemaNames["Devices"]).(*schema.Set), link.Devices)); err != nil {
 		return fmt.Errorf("error setting Devices: %s", err)
-	}
-	if err := d.Set(networkDeviceLinkSchemaNames["Links"], flattenNetworkDeviceLinkConnections(d.Get(networkDeviceLinkSchemaNames["Devices"]).(*schema.Set), link.Links)); err != nil {
-		return fmt.Errorf("error setting Links: %s", err)
 	}
 	if err := d.Set(networkDeviceLinkSchemaNames["MetroLinks"], flattenNetworkDeviceLinkMetroLinks(d.Get(networkDeviceLinkSchemaNames["Devices"]).(*schema.Set), link.MetroLinks)); err != nil {
 		return fmt.Errorf("error setting Metro Links: %s", err)
@@ -499,24 +412,6 @@ func flattenNetworkDeviceLinkDevices(_ *schema.Set, devices []ne.DeviceLinkGroup
 	return transformed
 }
 
-func expandNetworkDeviceLinkConnections(connections *schema.Set) []ne.DeviceLinkGroupLink {
-	connectionList := connections.List()
-	transformed := make([]ne.DeviceLinkGroupLink, len(connectionList))
-	for i := range connectionList {
-		connectionMap := connectionList[i].(map[string]interface{})
-		transformed[i] = ne.DeviceLinkGroupLink{
-			AccountNumber:        ne.String(connectionMap[networkDeviceLinkConnectionSchemaNames["AccountNumber"]].(string)),
-			Throughput:           ne.String(connectionMap[networkDeviceLinkConnectionSchemaNames["Throughput"]].(string)),
-			ThroughputUnit:       ne.String(connectionMap[networkDeviceLinkConnectionSchemaNames["ThroughputUnit"]].(string)),
-			SourceMetroCode:      ne.String(connectionMap[networkDeviceLinkConnectionSchemaNames["SourceMetroCode"]].(string)),
-			DestinationMetroCode: ne.String(connectionMap[networkDeviceLinkConnectionSchemaNames["DestinationMetroCode"]].(string)),
-			SourceZoneCode:       ne.String(connectionMap[networkDeviceLinkConnectionSchemaNames["SourceZoneCode"]].(string)),
-			DestinationZoneCode:  ne.String(connectionMap[networkDeviceLinkConnectionSchemaNames["DestinationZoneCode"]].(string)),
-		}
-	}
-	return transformed
-}
-
 func expandNetworkDeviceLinkMetroLinks(connections *schema.Set) []ne.DeviceLinkGroupMetroLink {
 	connectionList := connections.List()
 	transformed := make([]ne.DeviceLinkGroupMetroLink, len(connectionList))
@@ -528,25 +423,6 @@ func expandNetworkDeviceLinkMetroLinks(connections *schema.Set) []ne.DeviceLinkG
 			Throughput:     ne.String(connectionMap[networkDeviceLinkMetroSchemaNames["Throughput"]].(string)),
 			ThroughputUnit: ne.String(connectionMap[networkDeviceLinkMetroSchemaNames["ThroughputUnit"]].(string)),
 		}
-	}
-	return transformed
-}
-
-func flattenNetworkDeviceLinkConnections(currentConnections *schema.Set, connections []ne.DeviceLinkGroupLink) interface{} {
-	transformed := make([]interface{}, 0, len(connections))
-	currentConnectionsMap := schemaSetToMap(currentConnections)
-	for i := range connections {
-		transformedConnection := map[string]interface{}{
-			networkDeviceLinkConnectionSchemaNames["Throughput"]:           connections[i].Throughput,
-			networkDeviceLinkConnectionSchemaNames["ThroughputUnit"]:       connections[i].ThroughputUnit,
-			networkDeviceLinkConnectionSchemaNames["SourceMetroCode"]:      connections[i].SourceMetroCode,
-			networkDeviceLinkConnectionSchemaNames["DestinationMetroCode"]: connections[i].DestinationMetroCode,
-		}
-		if v, ok := currentConnectionsMap[networkDeviceLinkConnectionHash(connections[i])]; ok {
-			currentConnectionMap := v.(map[string]interface{})
-			transformedConnection[networkDeviceLinkConnectionSchemaNames["AccountNumber"]] = currentConnectionMap[networkDeviceLinkConnectionSchemaNames["AccountNumber"]]
-		}
-		transformed = append(transformed, transformedConnection)
 	}
 	return transformed
 }
@@ -636,24 +512,6 @@ func networkDeviceLinkDeviceHash(v interface{}) int {
 	return hashcode.String(networkDeviceLinkDeviceKey(v))
 }
 
-func networkDeviceLinkConnectionKey(v interface{}) string {
-	if v, ok := v.(ne.DeviceLinkGroupLink); ok {
-		return fmt.Sprintf("%s-%s-%s-%s",
-			ne.StringValue(v.SourceMetroCode),
-			ne.StringValue(v.DestinationMetroCode),
-			ne.StringValue(v.Throughput),
-			ne.StringValue(v.ThroughputUnit))
-	}
-	if v, ok := v.(map[string]interface{}); ok {
-		return fmt.Sprintf("%s-%s-%s-%s",
-			v[networkDeviceLinkConnectionSchemaNames["SourceMetroCode"]],
-			v[networkDeviceLinkConnectionSchemaNames["DestinationMetroCode"]],
-			v[networkDeviceLinkConnectionSchemaNames["Throughput"]],
-			v[networkDeviceLinkConnectionSchemaNames["ThroughputUnit"]])
-	}
-	return fmt.Sprintf("%v", v)
-}
-
 func networkDeviceLinkMetroLinkKey(v interface{}) string {
 	if v, ok := v.(ne.DeviceLinkGroupMetroLink); ok {
 		return fmt.Sprintf("%s-%s-%s",
@@ -668,10 +526,6 @@ func networkDeviceLinkMetroLinkKey(v interface{}) string {
 			v[networkDeviceLinkConnectionSchemaNames["ThroughputUnit"]])
 	}
 	return fmt.Sprintf("%v", v)
-}
-
-func networkDeviceLinkConnectionHash(v interface{}) int {
-	return hashcode.String(networkDeviceLinkConnectionKey(v))
 }
 
 func networkDeviceLinkMetroLinkHash(v interface{}) int {

--- a/equinix/resource_network_device_link.go
+++ b/equinix/resource_network_device_link.go
@@ -76,7 +76,7 @@ var networkDeviceLinkMetroSchemaNames = map[string]string{
 
 var networkDeviceLinkMetroDescriptions = map[string]string{
 	"AccountNumber":  "Billing account number to be used for connection charges",
-	"metroCode":      "Connection source metro code",
+	"MetroCode":      "Connection source metro code",
 	"Throughput":     "Connection throughput",
 	"ThroughputUnit": "Connection throughput unit",
 }

--- a/equinix/resource_network_device_link.go
+++ b/equinix/resource_network_device_link.go
@@ -59,14 +59,6 @@ var networkDeviceLinkDeviceDescriptions = map[string]string{
 	"IPAddress":   "Assigned IP address from device link subnet",
 }
 
-var networkDeviceLinkConnectionSchemaNames = map[string]string{
-	"AccountNumber":        "account_number",
-	"Throughput":           "throughput",
-	"ThroughputUnit":       "throughput_unit",
-	"SourceMetroCode":      "src_metro_code",
-	"DestinationMetroCode": "dst_metro_code",
-}
-
 var networkDeviceLinkMetroSchemaNames = map[string]string{
 	"AccountNumber":  "account_number",
 	"MetroCode":      "metro_code",
@@ -521,9 +513,9 @@ func networkDeviceLinkMetroLinkKey(v interface{}) string {
 	}
 	if v, ok := v.(map[string]interface{}); ok {
 		return fmt.Sprintf("%s-%s-%s",
-			v[networkDeviceLinkConnectionSchemaNames["MetroCode"]],
-			v[networkDeviceLinkConnectionSchemaNames["Throughput"]],
-			v[networkDeviceLinkConnectionSchemaNames["ThroughputUnit"]])
+			v[networkDeviceLinkMetroSchemaNames["MetroCode"]],
+			v[networkDeviceLinkMetroSchemaNames["Throughput"]],
+			v[networkDeviceLinkMetroSchemaNames["ThroughputUnit"]])
 	}
 	return fmt.Sprintf("%v", v)
 }

--- a/equinix/resource_network_device_link.go
+++ b/equinix/resource_network_device_link.go
@@ -374,7 +374,7 @@ func updateNetworkDeviceLinkResource(link *ne.DeviceLinkGroup, d *schema.Resourc
 	if err := d.Set(networkDeviceLinkSchemaNames["Devices"], flattenNetworkDeviceLinkDevices(d.Get(networkDeviceLinkSchemaNames["Devices"]).(*schema.Set), link.Devices)); err != nil {
 		return fmt.Errorf("error setting Devices: %s", err)
 	}
-	if err := d.Set(networkDeviceLinkSchemaNames["MetroLinks"], flattenNetworkDeviceLinkMetroLinks(d.Get(networkDeviceLinkSchemaNames["Devices"]).(*schema.Set), link.MetroLinks)); err != nil {
+	if err := d.Set(networkDeviceLinkSchemaNames["MetroLinks"], flattenNetworkDeviceLinkMetroLinks(d.Get(networkDeviceLinkSchemaNames["MetroLinks"]).(*schema.Set), link.MetroLinks)); err != nil {
 		return fmt.Errorf("error setting Metro Links: %s", err)
 	}
 	if err := d.Set(networkDeviceLinkSchemaNames["ProjectID"], link.ProjectID); err != nil {

--- a/equinix/resource_network_device_link.go
+++ b/equinix/resource_network_device_link.go
@@ -150,7 +150,7 @@ func createNetworkDeviceLinkResourceSchema() map[string]*schema.Schema {
 				Schema: createNetworkDeviceLinkDeviceResourceSchema(),
 			},
 			Set:         networkDeviceLinkDeviceHash,
-			Description: networkDeviceLinkDescriptions["Device"],
+			Description: networkDeviceLinkDescriptions["Devices"],
 		},
 		networkDeviceLinkSchemaNames["MetroLinks"]: {
 			Type:     schema.TypeSet,

--- a/equinix/resource_network_device_link_test.go
+++ b/equinix/resource_network_device_link_test.go
@@ -84,13 +84,13 @@ func TestNetworkDeviceLink_updateResourceData(t *testing.T) {
 		},
 		MetroLinks: []ne.DeviceLinkGroupMetroLink{
 			{
-				AccountNumber:  ne.String("592205"),
+				AccountNumber:  ne.String(""),
 				MetroCode:      ne.String("MX"),
 				Throughput:     ne.String("10"),
 				ThroughputUnit: ne.String("Mbps"),
 			},
 			{
-				AccountNumber:  ne.String("606828"),
+				AccountNumber:  ne.String(""),
 				MetroCode:      ne.String("LD"),
 				Throughput:     ne.String("10"),
 				ThroughputUnit: ne.String("Mbps"),
@@ -107,11 +107,5 @@ func TestNetworkDeviceLink_updateResourceData(t *testing.T) {
 	assert.Equal(t, ne.StringValue(input.Subnet), d.Get(networkDeviceLinkSchemaNames["Subnet"]), "Subnet matches")
 	assert.Equal(t, ne.StringValue(input.Status), d.Get(networkDeviceLinkSchemaNames["Status"]), "Status matches")
 	assert.Equal(t, input.Devices, expandNetworkDeviceLinkDevices(d.Get(networkDeviceLinkSchemaNames["Devices"]).(*schema.Set)), "Device matches")
-	expandedMetroLinks := expandNetworkDeviceLinkMetroLinks(d.Get(networkDeviceLinkSchemaNames["MetroLinks"]).(*schema.Set))
-	// AccountNumber is write-only (not returned by the API), so it is empty after flatten from empty state
-	expectedMetroLinks := []ne.DeviceLinkGroupMetroLink{
-		{AccountNumber: ne.String(""), MetroCode: input.MetroLinks[0].MetroCode, Throughput: input.MetroLinks[0].Throughput, ThroughputUnit: input.MetroLinks[0].ThroughputUnit},
-		{AccountNumber: ne.String(""), MetroCode: input.MetroLinks[1].MetroCode, Throughput: input.MetroLinks[1].Throughput, ThroughputUnit: input.MetroLinks[1].ThroughputUnit},
-	}
-	assert.ElementsMatch(t, expectedMetroLinks, expandedMetroLinks, "MetroLinks matches")
+	assert.ElementsMatch(t, input.MetroLinks, expandNetworkDeviceLinkMetroLinks(d.Get(networkDeviceLinkSchemaNames["MetroLinks"]).(*schema.Set)), "MetroLinks matches")
 }

--- a/equinix/resource_network_device_link_test.go
+++ b/equinix/resource_network_device_link_test.go
@@ -107,4 +107,11 @@ func TestNetworkDeviceLink_updateResourceData(t *testing.T) {
 	assert.Equal(t, ne.StringValue(input.Subnet), d.Get(networkDeviceLinkSchemaNames["Subnet"]), "Subnet matches")
 	assert.Equal(t, ne.StringValue(input.Status), d.Get(networkDeviceLinkSchemaNames["Status"]), "Status matches")
 	assert.Equal(t, input.Devices, expandNetworkDeviceLinkDevices(d.Get(networkDeviceLinkSchemaNames["Devices"]).(*schema.Set)), "Device matches")
+	expandedMetroLinks := expandNetworkDeviceLinkMetroLinks(d.Get(networkDeviceLinkSchemaNames["MetroLinks"]).(*schema.Set))
+	// AccountNumber is write-only (not returned by the API), so it is empty after flatten from empty state
+	expectedMetroLinks := []ne.DeviceLinkGroupMetroLink{
+		{AccountNumber: ne.String(""), MetroCode: input.MetroLinks[0].MetroCode, Throughput: input.MetroLinks[0].Throughput, ThroughputUnit: input.MetroLinks[0].ThroughputUnit},
+		{AccountNumber: ne.String(""), MetroCode: input.MetroLinks[1].MetroCode, Throughput: input.MetroLinks[1].Throughput, ThroughputUnit: input.MetroLinks[1].ThroughputUnit},
+	}
+	assert.ElementsMatch(t, expectedMetroLinks, expandedMetroLinks, "MetroLinks matches")
 }

--- a/equinix/resource_network_device_link_test.go
+++ b/equinix/resource_network_device_link_test.go
@@ -27,17 +27,6 @@ func TestNetworkDeviceLink_createFromResourceData(t *testing.T) {
 				InterfaceID: ne.Int(10),
 			},
 		},
-		Links: []ne.DeviceLinkGroupLink{
-			{
-				AccountNumber:        ne.String(""),
-				Throughput:           ne.String("1"),
-				ThroughputUnit:       ne.String("Gbps"),
-				SourceMetroCode:      ne.String("LD"),
-				DestinationMetroCode: ne.String("AM"),
-				SourceZoneCode:       ne.String(""),
-				DestinationZoneCode:  ne.String(""),
-			},
-		},
 		MetroLinks: []ne.DeviceLinkGroupMetroLink{
 			{
 				AccountNumber:  ne.String(""),
@@ -61,9 +50,12 @@ func TestNetworkDeviceLink_createFromResourceData(t *testing.T) {
 		networkDeviceLinkSchemaNames["RedundancyType"]: ne.StringValue(expected.RedundancyType),
 	}
 	d := schema.TestResourceDataRaw(t, createNetworkDeviceLinkResourceSchema(), rawData)
-	d.Set(networkDeviceLinkSchemaNames["Devices"], flattenNetworkDeviceLinkDevices(nil, expected.Devices))
-	d.Set(networkDeviceLinkSchemaNames["Links"], flattenNetworkDeviceLinkConnections(nil, expected.Links))
-	d.Set(networkDeviceLinkSchemaNames["MetroLinks"], flattenNetworkDeviceLinkMetroLinks(nil, expected.MetroLinks))
+	if err := d.Set(networkDeviceLinkSchemaNames["Devices"], flattenNetworkDeviceLinkDevices(nil, expected.Devices)); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Set(networkDeviceLinkSchemaNames["MetroLinks"], flattenNetworkDeviceLinkMetroLinks(nil, expected.MetroLinks)); err != nil {
+		t.Fatal(err)
+	}
 	// when
 	result := createNetworkDeviceLink(d)
 	// then
@@ -88,17 +80,6 @@ func TestNetworkDeviceLink_updateResourceData(t *testing.T) {
 				DeviceID:    ne.String("7c737fe8-3a9e-4ab9-afcc-c06d01db326d"),
 				ASN:         ne.Int(0),
 				InterfaceID: ne.Int(10),
-			},
-		},
-		Links: []ne.DeviceLinkGroupLink{
-			{
-				AccountNumber:        ne.String(""),
-				Throughput:           ne.String("1"),
-				ThroughputUnit:       ne.String("Gbps"),
-				SourceMetroCode:      ne.String("LD"),
-				DestinationMetroCode: ne.String("AM"),
-				SourceZoneCode:       ne.String(""),
-				DestinationZoneCode:  ne.String(""),
 			},
 		},
 		MetroLinks: []ne.DeviceLinkGroupMetroLink{
@@ -126,5 +107,4 @@ func TestNetworkDeviceLink_updateResourceData(t *testing.T) {
 	assert.Equal(t, ne.StringValue(input.Subnet), d.Get(networkDeviceLinkSchemaNames["Subnet"]), "Subnet matches")
 	assert.Equal(t, ne.StringValue(input.Status), d.Get(networkDeviceLinkSchemaNames["Status"]), "Status matches")
 	assert.Equal(t, input.Devices, expandNetworkDeviceLinkDevices(d.Get(networkDeviceLinkSchemaNames["Devices"]).(*schema.Set)), "Device matches")
-	assert.Equal(t, input.Links, expandNetworkDeviceLinkConnections(d.Get(networkDeviceLinkSchemaNames["Links"]).(*schema.Set)), "Links matches")
 }

--- a/examples/resources/equinix_network_device_link/example_1.tf
+++ b/examples/resources/equinix_network_device_link/example_1.tf
@@ -14,10 +14,9 @@ resource "equinix_network_device_link" "test" {
     asn          = equinix_network_device.test.secondary_device[0].asn > 0 ? equinix_network_device.test.secondary_device[0].asn : 22333
     interface_id = 7
   }
-  link {
+  metro_link {
     account_number  = equinix_network_device.test.account_number
-    src_metro_code  = equinix_network_device.test.metro_code
-    dst_metro_code  = equinix_network_device.test.secondary_device[0].metro_code
+    metro_code      = equinix_network_device.test.metro_code
     throughput      = "50"
     throughput_unit = "Mbps"
   }

--- a/templates/resources/network_acl_template.md.tmpl
+++ b/templates/resources/network_acl_template.md.tmpl
@@ -23,12 +23,10 @@ The following arguments are supported:
 * `name` - (Required) ACL template name.
 * `project_id` - (Optional) Unique Identifier for the project resource where the acl template is scoped to.If you leave it out, the ACL template will be created under the default project id of your organization.
 * `description` - (Optional) ACL template description, up to 200 characters.
-* `metro_code` - (Deprecated) ACL template location metro code.
 * `inbound_rule` - (Required) One or more rules to specify allowed inbound traffic. Rules are ordered, matching traffic rule stops processing subsequent ones.
 
 The `inbound_rule` block has below fields:
 
-* `subnets` - (Deprecated) Inbound traffic source IP subnets in CIDR format.
 * `subnet` - (Required) Inbound traffic source IP subnet in CIDR format.
 * `protocol` - (Required) Inbound traffic protocol. One of `IP`, `TCP`, `UDP`.
 * `src_port` - (Required) Inbound traffic source ports. Allowed values are a comma separated list of ports, e.g., `20,22,23`, port range, e.g., `1023-1040` or word `any`.
@@ -40,7 +38,6 @@ The `inbound_rule` block has below fields:
 In addition to all arguments above, the following attributes are exported:
 
 * `uuid` - Unique identifier of ACL template resource.
-* `device_id` - (Deprecated) Identifier of a network device where template was applied.
 * `device_acl_status` - Status of ACL template provisioning process, where template was applied. One of `PROVISIONING`, `PROVISIONED`.
 * `device_details` - List of the devices where the ACL template is applied.
 

--- a/templates/resources/network_device_link.md.tmpl
+++ b/templates/resources/network_device_link.md.tmpl
@@ -21,7 +21,6 @@ The following arguments are supported:
 * `name` - (Required) device link name.
 * `subnet` - (Optional) device link subnet in CIDR format. Not required for link between self configured devices.
 * `device` - (Required) definition of one or more devices belonging to the device link. See [Device](#device) section below for more details.
-* `link` - (Deprecated) definition of one or more, inter metro, connections belonging to the device link. See [Link](#link) section below for more details.
 * `metro_link` - (Optional) definition of one or more, inter metro, connections belonging to the device link. See [Metro Link](#metro_link) section below for more details.
 * `redundancy_type` - (Optional) Whether the connection should be created through Fabric's primary or secondary port. Supported values: `PRIMARY` (Default), `SECONDARY`, `HYBRID`
 * `project_id` - (Optional) Unique Identifier for the project resource where the device link is scoped to.If you leave it out, the device link will be created under the default project id of your organization.
@@ -33,18 +32,6 @@ The `device` block supports the following arguments:
 * `id` - (Required) Device identifier.
 * `asn` - (Optional) Device ASN number. Not required for self configured devices.
 * `interface_id` - (Optional) Device network interface identifier to use for device link connection.
-
-### Link
-
-The `link` block supports the following arguments:
-
-* `account_number` - (Required) billing account number to be used for connection charges
-* `throughput` - (Required) connection throughput.
-* `throughput_unit` - (Required) connection throughput unit (Mbps or Gbps).
-* `src_metro_code` - (Required) connection source metro code.
-* `dst_metro_code` - (Required) connection destination metro code.
-* `src_zone_code` - (Deprecated) connection source zone code is not required.
-* `dst_zone_code` - (Deprecated) connection destination zone code is not required.
 
 ### Metro_Link
 


### PR DESCRIPTION
 Remove deprecated attributes from `equinix_network_acl_template` and
 `equinix_network_device_link` resources ahead of the next major release.

`equinix_network_acl_template`:
 - Remove `metro_code` attribute (was: Metro Code is no longer required)
 - Remove `device_id computed` attribute (replaced by `device_details`)
 - Remove `inbound_rule.source_type` computed attribute (was not returned)
 - Remove `inbound_rule.subnets` attribute (replaced by `inbound_rule.subnet`)
 - Simplify `flattenACLTemplateInboundRules` to drop the now-unused `existingRules` argument and `checkExistingSubnets` helper
 - Fix `ImportStatePassthrough` -> `ImportStatePassthroughContext`

`equinix_network_device_link`:
 - Remove `link block` (replaced by `metro_link`)
 - Remove `link.src_zone_code` attribute (was not required)
 - Remove `link.dst_zone_code` attribute (was not required)
 - Remove `associated` expand/flatten/hash functions and schema helpers

 Update `example_1.tf` for `equinix_network_device_link` to use `metro_link`
 Regenerate docs via `make docs`.

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>