### PR TITLE
feat(metal): module for setting project custom data

### DIFF
--- a/docs/resources/metal_project_custom_data.md
+++ b/docs/resources/metal_project_custom_data.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Metal"
+---
+
+~> **Deprecation Notice** Equinix Metal will reach end of life on June 30, 2026. All Metal resources will be removed in version 5.0.0 of this provider. Use version 4.x of this provider for continued use through sunset. See https://docs.equinix.com/metal/ for more information.
+
+# equinix_metal_project_custom_data (Resource)
+
+Updates only the custom metadata for an existing Equinix Metal project.
+
+~> **Note on Destroy**: When this resource is destroyed, the custom data on the project is cleared (reset to an empty object). The project itself is not affected. If the custom data cannot be cleared after multiple retries, the resource will fail to destroy.
+
+## Example Usage
+
+```terraform
+locals {
+  project_id = "<UUID_of_your_project>"
+}
+
+resource "equinix_metal_project_custom_data" "project_metadata" {
+  project_id = local.project_id
+  custom_data = jsonencode({
+    owner   = "platform-team"
+    service = "edge-gateway"
+    env     = "prod"
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The UUID of the project to update.
+* `custom_data` - (Required) JSON object string containing project custom metadata.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The project UUID.

--- a/examples/resources/equinix_metal_project_custom_data/example_1.tf
+++ b/examples/resources/equinix_metal_project_custom_data/example_1.tf
@@ -1,0 +1,12 @@
+locals {
+  project_id = "<UUID_of_your_project>"
+}
+
+resource "equinix_metal_project_custom_data" "project_metadata" {
+  project_id = local.project_id
+  custom_data = jsonencode({
+    owner   = "platform-team"
+    service = "edge-gateway"
+    env     = "prod"
+  })
+}

--- a/internal/provider/services/metal.go
+++ b/internal/provider/services/metal.go
@@ -6,6 +6,7 @@ import (
 	metalorganization "github.com/equinix/terraform-provider-equinix/internal/resources/metal/organization"
 	metalorganizationmember "github.com/equinix/terraform-provider-equinix/internal/resources/metal/organization_member"
 	metalproject "github.com/equinix/terraform-provider-equinix/internal/resources/metal/project"
+	metalprojectcustomdata "github.com/equinix/terraform-provider-equinix/internal/resources/metal/project_custom_data"
 	metalprojectsshkey "github.com/equinix/terraform-provider-equinix/internal/resources/metal/project_ssh_key"
 	metalsshkey "github.com/equinix/terraform-provider-equinix/internal/resources/metal/ssh_key"
 	"github.com/equinix/terraform-provider-equinix/internal/resources/metal/vlan"
@@ -17,6 +18,7 @@ func MetalResources() []func() resource.Resource {
 	return []func() resource.Resource{
 		metalgateway.NewResource,
 		metalproject.NewResource,
+		metalprojectcustomdata.NewResource,
 		metalprojectsshkey.NewResource,
 		metalsshkey.NewResource,
 		metalconnection.NewResource,

--- a/internal/resources/metal/project_custom_data/models.go
+++ b/internal/resources/metal/project_custom_data/models.go
@@ -1,0 +1,28 @@
+package project_custom_data
+
+import (
+	"encoding/json"
+
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type ResourceModel struct {
+	ID         types.String `tfsdk:"id"`
+	ProjectID  types.String `tfsdk:"project_id"`
+	CustomData types.String `tfsdk:"custom_data"`
+}
+
+func (m *ResourceModel) parse(projectID string, project *metalv1.Project) diag.Diagnostics {
+	m.ID = types.StringValue(projectID)
+	m.ProjectID = types.StringValue(projectID)
+
+	// Persist compact canonical JSON to keep state stable.
+	b, err := json.Marshal(project.GetCustomdata())
+	if err != nil {
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to marshal project custom data", err.Error())}
+	}
+	m.CustomData = types.StringValue(string(b))
+	return nil
+}

--- a/internal/resources/metal/project_custom_data/resource.go
+++ b/internal/resources/metal/project_custom_data/resource.go
@@ -1,0 +1,232 @@
+package project_custom_data
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
+	"github.com/equinix/terraform-provider-equinix/internal/framework"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+func NewResource() resource.Resource {
+	return &Resource{
+		BaseResource: framework.NewBaseResource(
+			framework.BaseResourceConfig{
+				Name:   "equinix_metal_project_custom_data",
+				Schema: getResourceSchema(),
+			},
+		),
+	}
+}
+
+type Resource struct {
+	framework.BaseResource
+}
+
+func (r *Resource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
+	var plan ResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := r.Meta.NewMetalClientForFramework(ctx, req.ProviderMeta)
+	projectID := plan.ProjectID.ValueString()
+
+	customData, err := parseCustomData(plan.CustomData.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid custom_data", err.Error())
+		return
+	}
+
+	if err := updateProjectCustomData(ctx, client, projectID, customData); err != nil {
+		resp.Diagnostics.AddError("Failed to update project custom data", err.Error())
+		return
+	}
+
+	project, diags := fetchProject(ctx, client, projectID)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(plan.parse(projectID, project)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
+	var state ResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := r.Meta.NewMetalClientForFramework(ctx, req.ProviderMeta)
+	projectID := state.ProjectID.ValueString()
+	if projectID == "" {
+		projectID = state.ID.ValueString()
+	}
+
+	project, apiResp, err := client.ProjectsApi.FindProjectById(ctx, projectID).Execute()
+	if err != nil {
+		if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Failed to read project",
+			fmt.Sprintf("Could not read project %q: %s", projectID, err.Error()),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(state.parse(projectID, project)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *Resource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
+	var plan ResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := r.Meta.NewMetalClientForFramework(ctx, req.ProviderMeta)
+	projectID := plan.ProjectID.ValueString()
+
+	customData, err := parseCustomData(plan.CustomData.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid custom_data", err.Error())
+		return
+	}
+
+	if err := updateProjectCustomData(ctx, client, projectID, customData); err != nil {
+		resp.Diagnostics.AddError("Failed to update project custom data", err.Error())
+		return
+	}
+
+	project, diags := fetchProject(ctx, client, projectID)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(plan.parse(projectID, project)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
+	var state ResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := r.Meta.NewMetalClientForFramework(ctx, req.ProviderMeta)
+	projectID := state.ProjectID.ValueString()
+	if projectID == "" {
+		projectID = state.ID.ValueString()
+	}
+
+	err := clearProjectCustomData(ctx, client, projectID)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to reset project custom data", err.Error())
+		return
+	}
+}
+
+func parseCustomData(raw string) (map[string]interface{}, error) {
+	customData := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(raw), &customData); err != nil {
+		return nil, fmt.Errorf("custom_data must be valid JSON object: %w", err)
+	}
+	return customData, nil
+}
+
+func updateProjectCustomData(ctx context.Context, client *metalv1.APIClient, projectID string, customData map[string]interface{}) error {
+	updateRequest := metalv1.ProjectUpdateInput{Customdata: customData}
+	_, _, err := client.ProjectsApi.UpdateProject(ctx, projectID).ProjectUpdateInput(updateRequest).Execute()
+	if err != nil {
+		return fmt.Errorf("could not update project %q: %w", projectID, err)
+	}
+	return nil
+}
+
+func clearProjectCustomData(ctx context.Context, client *metalv1.APIClient, projectID string) error {
+	const maxAttempts = 4
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		tflog.Debug(ctx, fmt.Sprintf("Clearing project custom data, attempt %d/%d", attempt, maxAttempts), map[string]any{"project_id": projectID})
+
+		if err := updateProjectCustomData(ctx, client, projectID, map[string]interface{}{}); err != nil {
+			return err
+		}
+
+		project, diags := fetchProject(ctx, client, projectID)
+		if diags.HasError() {
+			return fmt.Errorf("failed to verify project %q custom data reset: %s", projectID, diags[0].Summary())
+		}
+
+		if len(project.GetCustomdata()) == 0 {
+			tflog.Debug(ctx, "Project custom data cleared successfully", map[string]any{"project_id": projectID, "attempt": attempt})
+			return nil
+		}
+
+		if attempt < maxAttempts {
+			tflog.Trace(ctx, "Custom data still present, waiting before retry", map[string]any{"project_id": projectID, "wait_seconds": attempt})
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("custom data reset interrupted (context timeout): %w", ctx.Err())
+			case <-time.After(time.Duration(attempt) * time.Second):
+			}
+		}
+	}
+
+	return fmt.Errorf("project %q custom data still present after %d reset attempts", projectID, maxAttempts)
+}
+
+func fetchProject(ctx context.Context, client *metalv1.APIClient, projectID string) (*metalv1.Project, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	project, apiResp, err := client.ProjectsApi.FindProjectById(ctx, projectID).Execute()
+	if err != nil {
+		if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
+			diags.AddError("Project not found", fmt.Sprintf("Project %q was not found", projectID))
+			return nil, diags
+		}
+		diags.AddError("Error reading project", fmt.Sprintf("Could not read project %q: %s", projectID, err.Error()))
+		return nil, diags
+	}
+	return project, diags
+}

--- a/internal/resources/metal/project_custom_data/resource_schema.go
+++ b/internal/resources/metal/project_custom_data/resource_schema.go
@@ -1,0 +1,29 @@
+package project_custom_data
+
+import (
+	"github.com/equinix/terraform-provider-equinix/internal/deprecations"
+	"github.com/equinix/terraform-provider-equinix/internal/framework"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+func getResourceSchema() *schema.Schema {
+	return &schema.Schema{
+		DeprecationMessage: deprecations.MetalDeprecationMessage,
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttributeDefaultDescription(),
+			"project_id": schema.StringAttribute{
+				Description: "The Equinix Metal project UUID to update",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"custom_data": schema.StringAttribute{
+				Description: "Project custom data as a JSON object string",
+				Required:    true,
+			},
+		},
+	}
+}

--- a/internal/resources/metal/project_custom_data/resource_test.go
+++ b/internal/resources/metal/project_custom_data/resource_test.go
@@ -1,0 +1,113 @@
+package project_custom_data_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/equinix/terraform-provider-equinix/internal/acceptance"
+	"github.com/equinix/terraform-provider-equinix/internal/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccMetalProjectCustomData_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "equinix_metal_project_custom_data.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.TestAccPreCheckMetal(t) },
+		ExternalProviders:        acceptance.TestExternalProviders,
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccMetalProjectCustomDataCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalProjectCustomDataConfig(rInt, `{"owner":"platform","env":"test"}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "custom_data", `{"env":"test","owner":"platform"}`),
+					resource.TestCheckResourceAttrPair(resourceName, "project_id", "equinix_metal_project.test", "id"),
+				),
+			},
+			{
+				Config: testAccMetalProjectCustomDataConfig(rInt, `{"owner":"platform","env":"prod"}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "custom_data", `{"env":"prod","owner":"platform"}`),
+					resource.TestCheckResourceAttrPair(resourceName, "project_id", "equinix_metal_project.test", "id"),
+				),
+			},
+			{
+				Config: testAccMetalProjectCustomDataProjectOnlyConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalProjectCustomDataProjectCleared("equinix_metal_project.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMetalProjectCustomDataProjectCleared(projectResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.TestAccProvider.Meta().(*config.Config).NewMetalClientForTesting()
+
+		rs, ok := s.RootModule().Resources[projectResource]
+		if !ok {
+			return fmt.Errorf("project resource %q not found in state", projectResource)
+		}
+
+		project, _, err := client.ProjectsApi.FindProjectById(context.Background(), rs.Primary.ID).Execute()
+		if err != nil {
+			return fmt.Errorf("could not read project %q: %w", rs.Primary.ID, err)
+		}
+
+		if len(project.GetCustomdata()) != 0 {
+			return fmt.Errorf("project custom data still exists")
+		}
+
+		return nil
+	}
+}
+
+func testAccMetalProjectCustomDataCheckDestroyed(s *terraform.State) error {
+	client := acceptance.TestAccProvider.Meta().(*config.Config).NewMetalClientForTesting()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "equinix_metal_project_custom_data" {
+			continue
+		}
+
+		project, _, err := client.ProjectsApi.FindProjectById(context.Background(), rs.Primary.Attributes["project_id"]).Execute()
+		if err != nil {
+			continue
+		}
+
+		if len(project.GetCustomdata()) != 0 {
+			return fmt.Errorf("project custom data still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccMetalProjectCustomDataConfig(r int, customData string) string {
+	return fmt.Sprintf(`
+resource "equinix_metal_project" "test" {
+    name = "tfacc-project-custom-data-%d"
+}
+
+resource "equinix_metal_project_custom_data" "test" {
+    project_id  = equinix_metal_project.test.id
+    custom_data = <<JSON
+%s
+JSON
+}
+`, r, customData)
+}
+
+func testAccMetalProjectCustomDataProjectOnlyConfig(r int) string {
+	return fmt.Sprintf(`
+resource "equinix_metal_project" "test" {
+    name = "tfacc-project-custom-data-%d"
+}
+`, r)
+}

--- a/templates/resources/metal_project_custom_data.md.tmpl
+++ b/templates/resources/metal_project_custom_data.md.tmpl
@@ -1,0 +1,28 @@
+---
+subcategory: "Metal"
+---
+
+~> **Deprecation Notice** Equinix Metal will reach end of life on June 30, 2026. All Metal resources will be removed in version 5.0.0 of this provider. Use version 4.x of this provider for continued use through sunset. See https://docs.equinix.com/metal/ for more information.
+
+# equinix_metal_project_custom_data (Resource)
+
+Updates only the custom metadata for an existing Equinix Metal project.
+
+~> **Note on Destroy**: When this resource is destroyed, the custom data on the project is cleared (reset to an empty object). The project itself is not affected. If the custom data cannot be cleared after multiple retries, the resource will fail to destroy.
+
+## Example Usage
+
+{{tffile "examples/resources/equinix_metal_project_custom_data/example_1.tf"}}
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The UUID of the project to update.
+* `custom_data` - (Required) JSON object string containing project custom metadata.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The project UUID.


### PR DESCRIPTION
module: equinix_metal_project_custom_data
description: allows the creation, modifications, deletion of a projects custom data

**Creation**
```
OpenTofu will perform the following actions:

  # module.metal[0].equinix_metal_project_custom_data.project_metadata will be created
  + resource "equinix_metal_project_custom_data" "project_metadata" {
      + custom_data = jsonencode(
            {
              + bios_config_url = "REDACTED"
            }
        )
      + id          = (known after apply)
      + project_id  = "REDACTED"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions in workspace "REDACTED"?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.metal[0].equinix_metal_project_custom_data.project_metadata: Creating...
module.metal[0].equinix_metal_project_custom_data.project_metadata: Creation complete after 1s [id=REDACTED]
```

**Modification**
```
OpenTofu will perform the following actions:

  # module.metal[0].equinix_metal_project_custom_data.project_metadata will be updated in-place
  ~ resource "equinix_metal_project_custom_data" "project_metadata" {
      ~ custom_data = jsonencode(
          ~ {
              ~ bios_config_url = "REDACTED" -> "REDACTED"
            }
        )
        id          = "REDACTED"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions in workspace "REDACTED"?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.metal[0].equinix_metal_project_custom_data.project_metadata: Modifying... [id=REDACTED]
module.metal[0].equinix_metal_project_custom_data.project_metadata: Modifications complete after 1s [id=REDACTED]
```


**Deletion**
```
OpenTofu will perform the following actions:

  # module.metal[0].equinix_metal_project_custom_data.project_metadata will be destroyed
  # (because equinix_metal_project_custom_data.project_metadata is not in configuration)
  - resource "equinix_metal_project_custom_data" "project_metadata" {
      - custom_data = jsonencode(
            {
              - bios_config_url = "REDACTEDn"
            }
        ) -> null
      - id          = "REDACTED" -> null
      - project_id  = "REDACTED" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you want to perform these actions in workspace "REDACTED"?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.metal[0].equinix_metal_project_custom_data.project_metadata: Destroying... [id=REDACTED]
module.metal[0].equinix_metal_project_custom_data.project_metadata: Destruction complete after 2s
```
