### PR TITLE
fix: UAT acceptance test cases

### DIFF
--- a/internal/resources/fabric/cloud_router/sweeper.go
+++ b/internal/resources/fabric/cloud_router/sweeper.go
@@ -16,7 +16,7 @@ import (
 func AddTestSweeper() {
 	resource.AddTestSweepers("equinix_fabric_cloud_router", &resource.Sweeper{
 		Name:         "equinix_fabric_cloud_router",
-		Dependencies: []string{},
+		Dependencies: []string{"equinix_fabric_connection"},
 		F:            testSweepCloudRouters,
 	})
 }

--- a/internal/resources/fabric/network/sweeper.go
+++ b/internal/resources/fabric/network/sweeper.go
@@ -17,7 +17,7 @@ import (
 func AddTestSweeper() {
 	resource.AddTestSweepers("equinix_fabric_network", &resource.Sweeper{
 		Name:         "equinix_fabric_network",
-		Dependencies: []string{},
+		Dependencies: []string{"equinix_fabric_connection"},
 		F:            testSweeperNetworks,
 	})
 }

--- a/internal/resources/fabric/routeaggregation/datasource_test.go
+++ b/internal/resources/fabric/routeaggregation/datasource_test.go
@@ -13,7 +13,7 @@ import (
 var datasourceConfig = `
 resource "equinix_fabric_route_aggregation" "new_ra_1" {
   type        = "BGP_IPv4_PREFIX_AGGREGATION"
-  name        = "route_agg_1_PFCR"
+  name        = "RA_datasource_1_PFCR"
   description = "route_agg_1_PFCR_description"
   project = {
     project_id = "33ec651f-cc99-48e0-94d3-47466899cdc7"
@@ -23,7 +23,7 @@ resource "equinix_fabric_route_aggregation" "new_ra_1" {
 resource "equinix_fabric_route_aggregation" "new_ra_2" {
   depends_on = [equinix_fabric_route_aggregation.new_ra_1] # to ensure that 2 is created after 1
   type        = "BGP_IPv4_PREFIX_AGGREGATION"
-  name        = "route_agg_2_PFCR"
+  name        = "RA_datasource_2_PFCR"
   description = "route_agg_2_PFCR_description"
   project = {
     project_id = "33ec651f-cc99-48e0-94d3-47466899cdc7"
@@ -40,14 +40,14 @@ data "equinix_fabric_route_aggregations" "data_ras" {
   filter = {
     property = "/name"
     operator = "LIKE"
-    values   = ["%_PFCR"]
+    values   = ["RA_datasource_%_PFCR"]
   }
   pagination = {
     limit  = 2
     offset = 0
   }
   sort = {
-    property  = "/changeLog/updatedDateTime"
+    property  = "/changeLog/createdDateTime"
     direction = "DESC"
   }
 }
@@ -65,7 +65,7 @@ func TestAccFabricRouteAggregationDataSources_PFCR(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("data.equinix_fabric_route_aggregation.data_ra", tfjsonpath.New("href"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue("data.equinix_fabric_route_aggregation.data_ra", tfjsonpath.New("uuid"), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue("data.equinix_fabric_route_aggregation.data_ra", tfjsonpath.New("name"), knownvalue.StringExact("route_agg_1_PFCR")),
+					statecheck.ExpectKnownValue("data.equinix_fabric_route_aggregation.data_ra", tfjsonpath.New("name"), knownvalue.StringExact("RA_datasource_1_PFCR")),
 					statecheck.ExpectKnownValue("data.equinix_fabric_route_aggregation.data_ra", tfjsonpath.New("description"), knownvalue.StringExact("route_agg_1_PFCR_description")),
 					statecheck.ExpectKnownValue("data.equinix_fabric_route_aggregation.data_ra", tfjsonpath.New("type"), knownvalue.StringExact("BGP_IPv4_PREFIX_AGGREGATION")),
 					statecheck.ExpectKnownValue("data.equinix_fabric_route_aggregation.data_ra", tfjsonpath.New("change_log"),
@@ -85,7 +85,7 @@ func TestAccFabricRouteAggregationDataSources_PFCR(t *testing.T) {
 						knownvalue.ListPartial(map[int]knownvalue.Check{
 							0: knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":              knownvalue.NotNull(),
-								"name":              knownvalue.StringExact("route_agg_2_PFCR"),
+								"name":              knownvalue.StringExact("RA_datasource_2_PFCR"),
 								"description":       knownvalue.StringExact("route_agg_2_PFCR_description"),
 								"href":              knownvalue.NotNull(),
 								"connections_count": knownvalue.Int32Exact(0),
@@ -100,7 +100,7 @@ func TestAccFabricRouteAggregationDataSources_PFCR(t *testing.T) {
 							}),
 							1: knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":              knownvalue.NotNull(),
-								"name":              knownvalue.StringExact("route_agg_1_PFCR"),
+								"name":              knownvalue.StringExact("RA_datasource_1_PFCR"),
 								"description":       knownvalue.StringExact("route_agg_1_PFCR_description"),
 								"href":              knownvalue.NotNull(),
 								"connections_count": knownvalue.Int32Exact(0),

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -27,10 +27,6 @@ func IsSweepableTestResource(namePrefix string) bool {
 
 func IsSweepableFabricTestResource(resourceName string) bool {
 	for _, suffix := range FabricTestResourceSuffixes {
-		if strings.Contains(resourceName, "DO_NOT_DELETE") {
-			return false
-		}
-
 		if strings.HasSuffix(resourceName, suffix) {
 			return true
 		}

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -27,6 +27,10 @@ func IsSweepableTestResource(namePrefix string) bool {
 
 func IsSweepableFabricTestResource(resourceName string) bool {
 	for _, suffix := range FabricTestResourceSuffixes {
+		if strings.Contains(resourceName, "DO_NOT_DELETE") {
+			return false
+		}
+
 		if strings.HasSuffix(resourceName, suffix) {
 			return true
 		}


### PR DESCRIPTION
fix: add connections deps to resource sweepers which depends on connections
fix: make filter more specific to RA datasource to avoid retrieving RAs from other test
fix: skip trying to sweep `DO_NOT_DELETE` Fabric resources