### PR TITLE
chore: remove selfProfile from input of SP

### DIFF
--- a/docs/resources/fabric_service_profile.md
+++ b/docs/resources/fabric_service_profile.md
@@ -64,7 +64,6 @@ resource "equinix_fabric_service_profile" "new_service_profile" {
 - `notifications` (Block List) Preferences for notifications on connection configuration or status changes (see [below for nested schema](#nestedblock--notifications))
 - `ports` (Block List) Ports (see [below for nested schema](#nestedblock--ports))
 - `project` (Block Set, Max: 1) Project information (see [below for nested schema](#nestedblock--project))
-- `self_profile` (Boolean) Self Profile indicating if the profile is created for customer's self use
 - `state` (String) Service profile state - ACTIVE, PENDING_APPROVAL, DELETED, REJECTED
 - `tags` (List of String) Tags attached to the connection
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
@@ -78,6 +77,7 @@ resource "equinix_fabric_service_profile" "new_service_profile" {
 - `change_log` (Set of Object) Captures connection lifecycle change information (see [below for nested schema](#nestedatt--change_log))
 - `href` (String) Service Profile URI response attribute
 - `id` (String) The ID of this resource.
+- `self_profile` (Boolean) Self Profile indicating if the profile is created for customer's self use
 - `uuid` (String) Equinix assigned service profile identifier
 
 <a id="nestedblock--access_point_type_configs"></a>

--- a/equinix/resource_fabric_service_profile.go
+++ b/equinix/resource_fabric_service_profile.go
@@ -129,7 +129,7 @@ func fabricServiceProfileSchema() map[string]*schema.Schema {
 		},
 		"self_profile": {
 			Type:        schema.TypeBool,
-			Optional:    true,
+			Computed:    true,
 			Description: "Self Profile indicating if the profile is created for customer's self use",
 		},
 		"state": {
@@ -642,10 +642,6 @@ func getServiceProfileRequestPayload(d *schema.ResourceData) fabricv4.ServicePro
 	if schemaMetros, ok := d.GetOk("metros"); ok {
 		spMetros := metrosTerraformToGo(schemaMetros.([]any))
 		createRequest.SetMetros(spMetros)
-	}
-
-	if selfProfile, ok := d.GetOk("self_profile"); ok {
-		createRequest.SetSelfProfile(selfProfile.(bool))
 	}
 
 	return createRequest


### PR DESCRIPTION
Discussion here:https://equinix.slack.com/archives/C071GPG8K1V/p1782800584241019

Lynx team has confirmed that this is not intended to be part of the request schema.

The current API does not respect the provided `selfProfile`, _ie_ sending `selfProfile=false` will still result in `selfProfile=true` in the response, and Lynx team will remove this in the API spec