### PR TITLE
fix: sweep only test

### DIFF
--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -136,6 +136,7 @@ jobs:
           SWEEP: "all" #Flag required to define the regions that the sweeper is to be ran in
           SWEEP_ALLOW_FAILURES: "true" #Enable to allow Sweeper Tests to continue after failures
           SWEEP_DIR: "./equinix"
+          SWEEP_TARGET: "PFNV"
         run: |
           # Added sweep-run to filter Fabric PNFV test
           go test -json $(go list ./... | grep 'internal/sweep\|equinix/equinix') -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run=$(grep -or 'AddTestSweepers("[^"]*"' | grep "_fabric_" | cut -d '"' -f2 | paste -s -d, -)
@@ -210,6 +211,7 @@ jobs:
           EQUINIX_API_CLIENTSECRET: ${{ secrets.EQUINIX_API_CLIENTSECRET_PFCR }}
           SWEEP: "all" #Flag required to define the regions that the sweeper is to be ran in
           SWEEP_ALLOW_FAILURES: "true" #Enable to allow Sweeper Tests to continue after failures
+          SWEEP_TARGET: "PFCR"
         run: |
           # Added sweep-run to filter Fabric PFCR test
           go test $(go list ./... | grep 'internal/sweep\|equinix/equinix') -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run=$(grep -or 'AddTestSweepers("[^"]*"' | grep "_fabric_" | cut -d '"' -f2 | paste -s -d, -)
@@ -292,6 +294,8 @@ jobs:
           EQUINIX_TOKEN_EXCHANGE_SCOPE: ${{ secrets.EQUINIX_STS_AUTH_SCOPE_PFCR }}
           ${{ matrix.sts_config.env_var_name }}: ${{ steps.get_id_token.outputs.id_token }}
           ${{ matrix.sts_config.set_custom_env_var && 'EQUINIX_TOKEN_EXCHANGE_SUBJECT_TOKEN_ENV_VAR' || 'SKIP' }}: ${{ matrix.sts_config.token_exchange_subject_token_env_var || '' }}
+          SWEEP_TARGET: "STS"
+
         run: |
           go test ./... --run "(TestAccFabricCreatePort2SPConnection_PFCR|TestAccCloudRouterCreateOnlyRequiredParameters_PFCR)" -v -coverprofile coverage_pfcr.txt -covermode=atomic -count 1
 

--- a/.github/workflows/fabric_acctest.yml
+++ b/.github/workflows/fabric_acctest.yml
@@ -136,7 +136,7 @@ jobs:
           SWEEP: "all" #Flag required to define the regions that the sweeper is to be ran in
           SWEEP_ALLOW_FAILURES: "true" #Enable to allow Sweeper Tests to continue after failures
           SWEEP_DIR: "./equinix"
-          SWEEP_TARGET: "PFNV"
+          SWEEP_TARGET: "PNFV"
         run: |
           # Added sweep-run to filter Fabric PNFV test
           go test -json $(go list ./... | grep 'internal/sweep\|equinix/equinix') -v -timeout 180m -sweep=${SWEEP} -sweep-allow-failures=${SWEEP_ALLOW_FAILURES} -sweep-run=$(grep -or 'AddTestSweepers("[^"]*"' | grep "_fabric_" | cut -d '"' -f2 | paste -s -d, -)

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -2,6 +2,7 @@ package sweep
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +27,10 @@ func IsSweepableTestResource(namePrefix string) bool {
 }
 
 func IsSweepableFabricTestResource(resourceName string) bool {
+	if v := os.Getenv("SWEEP_TARGET"); v != "" {
+		return strings.HasSuffix("_"+resourceName, v)
+	}
+
 	for _, suffix := range FabricTestResourceSuffixes {
 		if strings.HasSuffix(resourceName, suffix) {
 			return true


### PR DESCRIPTION
With our current pipeline, it is possible (likely even), that a test suite ends earlier than the other, which causes it to sweep all of the resources, which causes another test suite to fail