### PR TITLE
chore(ci): Force Renovate to use Conventional Commit tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    ":semanticCommits",
   ],
   "postUpdateOptions": [
     "gomodTidy"


### PR DESCRIPTION
A [Renovate change earlier this year](https://github.com/renovatebot/renovate/pull/42419 ) caused Renovate to explicitly ignore merge commits when analyzing commit logs to automatically enable Conventional Commit tags.

This is the opposite of the behavior we need, since we enforce tags in PR titles, not in the individual commits in a PR.  Rather than try to get this addressed upstream, we can just force Renovate to use Conventional Commits and not worry about future upstream changes to that logic.